### PR TITLE
Publically -> Publicly

### DIFF
--- a/src/app/NewProject.tsx
+++ b/src/app/NewProject.tsx
@@ -242,7 +242,7 @@ export const NewProject = styled(
                   <Grid item xs={12}>
                     <Typography>
                       <Checkbox checked={this.state.isPublic} onChange={this.handlePublicChecked} />
-                      Publically accessible
+                      Publicly accessible
                     </Typography>
                   </Grid>
                 </Grid>


### PR DESCRIPTION
https://en.wiktionary.org/wiki/publically

"This spelling is omitted from many dictionaries. The suffix -ally is normally used in this context (added onto words that end in -ic), but public is an exception, and publicly is generally considered more correct."