### PR TITLE
Update documentation for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ Simlin is an [open source](LICENSE) tool for creating and editing [System Dynami
 
 ## Local development
 
+### Prerequisites
+
+- **GCLOUD:** Make sure that you have installed the Google Cloud CLI and its firestore emulator. You can follow this [guide](https://cloud.google.com/sdk/docs/install-sdk#deb).
+- **wasm-bindgen**. In addition, install the latest version of wasm-bindgen:
+  ```bash
+  $ cargo uninstall wasm-bindgen-cli
+  $ cargo install wasm-bindgen-cli
+  $ wasm-bindgen --version
+  wasm-bindgen 0.2.92
+  ```
+
+### Running the development version
+
 ```bash
 # dependencies; ignore warnings
 $ yarn install
@@ -39,7 +52,6 @@ $ yarn start:firestore
 $ yarn start:backend
 # in third and final tab:
 $ yarn start:frontend
-
 ```
 
 Now to the browser!


### PR DESCRIPTION
For local development, gcloud and wasm-bindgen-cli must be installed first.
