### PR TITLE
Implement public projects

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -228,7 +228,16 @@ const InnerApp = styled(
 
     editor = (props: RouteComponentProps<EditorMatchParams>) => {
       const { username, projectName } = props.params;
-      return <HostedWebEditor username={username} projectName={projectName} baseURL={this.getBaseURL()} />;
+      const user = this.state.user;
+      const readOnlyMode = !user || user.id !== username;
+      return (
+        <HostedWebEditor
+          username={username}
+          projectName={projectName}
+          baseURL={this.getBaseURL()}
+          readOnlyMode={readOnlyMode}
+        />
+      );
     };
 
     home = (_props: RouteComponentProps) => {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -267,12 +267,14 @@ const InnerApp = styled(
         );
       }
 
-      if (!this.state.user) {
-        return <Login disabled={this.state.authUnknown} auth={this.state.auth} />;
-      }
+      if (!/\/.*\/.*/.test(window.location.pathname)) {
+        if (!this.state.user) {
+          return <Login disabled={this.state.authUnknown} auth={this.state.auth} />;
+        }
 
-      if (this.state.isNewUser) {
-        return <NewUser user={defined(this.state.user)} onUsernameChanged={this.handleUsernameChanged} />;
+        if (this.state.isNewUser) {
+          return <NewUser user={defined(this.state.user)} onUsernameChanged={this.handleUsernameChanged} />;
+        }
       }
 
       return (

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -13,7 +13,7 @@ import {
   User as FirebaseUser,
 } from 'firebase/auth';
 
-import { useLocation, Route, RouteComponentProps, Switch } from 'wouter';
+import { useLocation, Route, RouteComponentProps, Switch, Redirect } from 'wouter';
 import { styled } from '@mui/material/styles';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
@@ -230,6 +230,7 @@ const InnerApp = styled(
       const { username, projectName } = props.params;
       const user = this.state.user;
       const readOnlyMode = !user || user.id !== username;
+
       return (
         <HostedWebEditor
           username={username}

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -277,7 +277,11 @@ const InnerApp = styled(
         );
       }
 
-      // if a user is navigating to a model,
+      const urlParams = new URLSearchParams(window.location.search);
+      const projectParam = urlParams.get('project');
+      if (projectParam) return <Redirect to={projectParam} />;
+
+      // if a user is navigating to a project,
       // skip the high level auth check, to enable public models
       if (!/\/.*\/.*/.test(window.location.pathname)) {
         if (!this.state.user) {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -276,6 +276,8 @@ const InnerApp = styled(
         );
       }
 
+      // if a user is navigating to a model,
+      // skip the high level auth check, to enable public models
       if (!/\/.*\/.*/.test(window.location.pathname)) {
         if (!this.state.user) {
           return <Login disabled={this.state.authUnknown} auth={this.state.auth} />;

--- a/src/diagram/Editor.tsx
+++ b/src/diagram/Editor.tsx
@@ -168,6 +168,7 @@ interface EditorProps {
   name: string; // used when saving
   embedded?: boolean;
   onSave: (project: Readonly<Uint8Array>, currVersion: number) => Promise<number | undefined>;
+  readOnlyMode?: boolean;
 }
 
 export const Editor = styled(
@@ -208,6 +209,15 @@ export const Editor = styled(
         await this.openEngine(props.initialProjectBinary, activeProject);
         this.scheduleSimRun();
       });
+    }
+
+    componentDidMount() {
+      if (this.props.readOnlyMode)
+        this.setState({
+          modelErrors: this.state.modelErrors.push(
+            new Error("This is a read-only version. Any changes you make won't be saved."),
+          ),
+        });
     }
 
     project(): Project | undefined {

--- a/src/diagram/HostedWebEditor.tsx
+++ b/src/diagram/HostedWebEditor.tsx
@@ -25,6 +25,7 @@ interface HostedWebEditorProps {
   projectName: string;
   embedded?: boolean;
   baseURL?: string;
+  readOnlyMode?: boolean;
 }
 
 interface HostedWebEditorState {
@@ -63,6 +64,8 @@ export const HostedWebEditor = styled(
     }
 
     handleSave = async (project: Readonly<Uint8Array>, currVersion: number): Promise<number | undefined> => {
+      if (this.props.readOnlyMode) return;
+
       const bodyContents = {
         currVersion,
         projectPB: fromUint8Array(project as Uint8Array),

--- a/src/diagram/HostedWebEditor.tsx
+++ b/src/diagram/HostedWebEditor.tsx
@@ -60,7 +60,7 @@ export const HostedWebEditor = styled(
     }
 
     getBaseURL(): string {
-      return this.props.baseURL !== undefined ? this.props.baseURL : baseURL;
+      return this.props.baseURL ?? baseURL;
     }
 
     handleSave = async (project: Readonly<Uint8Array>, currVersion: number): Promise<number | undefined> => {
@@ -141,6 +141,7 @@ export const HostedWebEditor = styled(
             name={this.props.projectName}
             embedded={this.props.embedded}
             onSave={this.handleSave}
+            readOnlyMode={this.props.readOnlyMode}
           />
         </div>
       );

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -168,12 +168,11 @@ export const apiRouter = (app: Application): Router => {
         return;
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const project: any = projectModel.toObject();
-      project.file = file.getJsonContents();
-      project.pb = file.getProjectContents_asB64();
+      const project = projectModel.toObject();
+      const jsonFile = file.getJsonContents();
+      const pb = file.getProjectContents_asB64();
 
-      res.status(200).json(project);
+      res.status(200).json({ ...project, file: jsonFile, pb });
     },
   );
 

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -21,7 +21,7 @@ import { apiRouter } from './api';
 import { defined } from '@system-dynamics/core/common';
 import { Application } from './application';
 import { authn } from './authn';
-import { authz, userAuthz } from './authz';
+import authz from './authz';
 import { createDatabase } from './models/db';
 import { redirectToHttps } from './redirect-to-https';
 import { requestLogger } from './request-logger';
@@ -224,12 +224,12 @@ class App {
 
     this.app.get(
       '/:username/:projectName',
-      async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      async (req: Request, res: Response, next: NextFunction) => {
         const project = await this.app.db.project.findOne(`${req.params.username}/${req.params.projectName}`);
         if (project?.getIsPublic()) next();
-        else userAuthz(req, res, next);
+        else authz(req, res, next, (res) => res.redirect('/'));
       },
-      async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+      async (req: Request, res: Response, next: NextFunction) => {
         const email = req.session.passport.user.email as string;
         const user = req.user as any as UserPb | undefined;
 
@@ -270,8 +270,7 @@ class App {
         res.set('Cache-Control', 'no-store');
         res.set('Max-Age', '0');
 
-        // eslint-disable-next-line @typescript-eslint/await-thenable
-        await next();
+        next();
       },
       staticHandler,
     );

--- a/src/server/authz.ts
+++ b/src/server/authz.ts
@@ -8,11 +8,7 @@ function jsonError(res: Response): void {
   res.status(401).json({ error: 'unauthorized' });
 }
 
-function redirectError(res: Response): void {
-  res.redirect('/');
-}
-
-const doAuthz = (req: Request, res: Response, next: NextFunction, onFail: (res: Response) => void): void => {
+export default (req: Request, res: Response, next: NextFunction, onFail?: (res: Response) => void): void => {
   // allow unauthorized access to projects for embedding in blogs
   const failEarly = !(req.method === 'GET' && req.path.startsWith('/projects/'));
 
@@ -21,7 +17,7 @@ const doAuthz = (req: Request, res: Response, next: NextFunction, onFail: (res: 
     req.session = {};
 
     if (failEarly) {
-      onFail(res);
+      (onFail ?? jsonError)(res);
       return;
     }
   } else if (!req.session.passport.user) {
@@ -29,18 +25,10 @@ const doAuthz = (req: Request, res: Response, next: NextFunction, onFail: (res: 
     req.session = {};
 
     if (failEarly) {
-      onFail(res);
+      (onFail ?? jsonError)(res);
       return;
     }
   }
 
   next();
-};
-
-export const authz = (req: Request, res: Response, next: NextFunction): void => {
-  doAuthz(req, res, next, jsonError);
-};
-
-export const userAuthz = (req: Request, res: Response, next: NextFunction): void => {
-  doAuthz(req, res, next, redirectError);
 };

--- a/src/server/build
+++ b/src/server/build
@@ -1,0 +1,1 @@
+../app/build


### PR DESCRIPTION
Hello!

This PR implements the public projects feature, where, if a project is made public, everyone (with or without login) can open it and play with it.

The current state of the PR is *draft*: there are no tests, and, although functionally it sort of works, it uses some hacks (like ignoring auth errors). As of opening the PR, it shows the minimum viable changes to have a barely-working version of the feature.

## Design decision

* What can people do on public models? Should they be able to edit them (of course only locally, with no changes saved)? Or only seeing results — and, in the near future when we have multi-run working, running the model?

### Additional note

I noticed that the architecture around routing/authentication on the client side could be simplified, probably by letting each page take care of its own authentication logic.

Closes #84 