### PR TITLE
Document safety for JSON FFI functions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1191,6 +1191,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "prost",
+ "serde",
  "serde_json",
  "simlin-compat",
  "simlin-engine",

--- a/src/libsimlin/Cargo.toml
+++ b/src/libsimlin/Cargo.toml
@@ -15,6 +15,7 @@ simlin-engine = { version = "0.1", path = "../simlin-engine" }
 simlin-compat = { version = "0.1", path = "../simlin-compat", features = ["vensim"] }
 prost = "0.14"
 serde_json = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 
 [dev-dependencies]

--- a/src/libsimlin/simlin.h
+++ b/src/libsimlin/simlin.h
@@ -492,6 +492,19 @@ void simlin_project_serialize(SimlinProject *project,
                               uintptr_t *out_len,
                               SimlinError ** out_error);
 
+// Serializes a project to JSON format.
+//
+// The resulting buffer contains UTF-8 JSON matching the native Simlin JSON
+// schema. Only the native format is supported.
+//
+// The caller takes ownership of `out_buffer` and must free it with
+// `simlin_free`.
+void simlin_project_serialize_json(SimlinProject *project,
+                                   SimlinJsonFormat format,
+                                   uint8_t **out_buffer,
+                                   uintptr_t *out_len,
+                                   SimlinError **out_error);
+
 // Applies a patch to the project datamodel.
 //
 // The patch is encoded as a `project_io.Patch` protobuf message. The caller can
@@ -518,6 +531,19 @@ void simlin_project_apply_patch(SimlinProject *project,
                                 bool allow_errors,
                                 SimlinError **out_collected_errors,
                                 SimlinError ** out_error);
+
+// Applies a patch described by the native JSON format to the project.
+//
+// Only the native JSON format is accepted. The payload must be UTF-8 encoded.
+// Semantics match `simlin_project_apply_patch`.
+void simlin_project_apply_patch_json(SimlinProject *project,
+                                     const uint8_t *patch_data,
+                                     uintptr_t patch_len,
+                                     SimlinJsonFormat format,
+                                     bool dry_run,
+                                     bool allow_errors,
+                                     SimlinError **out_collected_errors,
+                                     SimlinError **out_error);
 
 // Get all errors in a project including static analysis and compilation errors
 //

--- a/src/pysimlin/simlin/_ffi_build.py
+++ b/src/pysimlin/simlin/_ffi_build.py
@@ -155,7 +155,9 @@ SimlinProject *simlin_import_xmile(const uint8_t *data, uintptr_t len, OutError 
 SimlinProject *simlin_import_mdl(const uint8_t *data, uintptr_t len, OutError out_error);
 void simlin_export_xmile(SimlinProject *project, uint8_t **out_buffer, uintptr_t *out_len, OutError out_error);
 void simlin_project_serialize(SimlinProject *project, uint8_t **out_buffer, uintptr_t *out_len, OutError out_error);
+void simlin_project_serialize_json(SimlinProject *project, SimlinJsonFormat format, uint8_t **out_buffer, uintptr_t *out_len, OutError out_error);
 void simlin_project_apply_patch(SimlinProject *project, const uint8_t *patch_data, uintptr_t patch_len, bool dry_run, bool allow_errors, SimlinError **out_collected_errors, OutError out_error);
+void simlin_project_apply_patch_json(SimlinProject *project, const uint8_t *patch_data, uintptr_t patch_len, SimlinJsonFormat format, bool dry_run, bool allow_errors, SimlinError **out_collected_errors, OutError out_error);
 SimlinError *simlin_project_get_errors(SimlinProject *project, OutError out_error);
 """
 


### PR DESCRIPTION
## Summary
- document the safety requirements for the JSON serialization and patch FFI entry points

## Testing
- cargo build -p simlin
- cargo clippy -p simlin

------
https://chatgpt.com/codex/tasks/task_e_68eb2a25e7148328836fb1f70500837e