### PR TITLE
engine: realign flow-to-stock link timing

### DIFF
--- a/src/simlin-compat/tests/simulate_ltm.rs
+++ b/src/simlin-compat/tests/simulate_ltm.rs
@@ -271,7 +271,6 @@ fn simulate_ltm_path(model_path: &str) {
 }
 
 #[test]
-#[ignore]
 fn simulates_population_ltm() {
     simulate_ltm_path("../../test/logistic_growth_ltm/logistic_growth.stmx");
 }

--- a/src/simlin-engine/src/ltm_augment.rs
+++ b/src/simlin-engine/src/ltm_augment.rs
@@ -325,7 +325,11 @@ fn generate_flow_to_stock_equation(flow: &str, stock: &str, stock_var: &Variable
     let sign = if is_inflow { "" } else { "-" };
 
     // Using SAFEDIV to handle division by zero
-    let numerator = format!("{sign}({flow} - PREVIOUS({flow}))");
+    let numerator = format!(
+        "{sign}(PREVIOUS({flow}) - PREVIOUS(PREVIOUS({flow})))",
+        sign = sign,
+        flow = flow
+    );
     let denominator = format!(
         "(({stock} - PREVIOUS({stock})) - (PREVIOUS({stock}) - PREVIOUS(PREVIOUS({stock}))))"
     );


### PR DESCRIPTION
## Summary
- re-enable the logistic growth LTM regression test to observe current output
- adjust the flow-to-stock link score formula to use the previous-step delta so that link polarity matches the LTM reference when flows change sign

## Testing
- cargo test simulates_population_ltm --package simlin-compat -- --nocapture *(fails: exposes current LTM discrepancies)*

------
https://chatgpt.com/codex/tasks/task_e_68f4fcc2d7bc8328a53a7f6434884e65