### PR TITLE
engine: add expr2 -> expr3 lowering with wildcard resolution

### DIFF
--- a/src/simlin-engine/src/ast/expr2.rs
+++ b/src/simlin-engine/src/ast/expr2.rs
@@ -95,6 +95,17 @@ impl IndexExpr2 {
         Ok(expr)
     }
 
+    /// Get the source location of this index expression.
+    pub fn get_loc(&self) -> Loc {
+        match self {
+            IndexExpr2::Wildcard(loc) => *loc,
+            IndexExpr2::StarRange(_, loc) => *loc,
+            IndexExpr2::Range(_, _, loc) => *loc,
+            IndexExpr2::DimPosition(_, loc) => *loc,
+            IndexExpr2::Expr(e) => e.get_loc(),
+        }
+    }
+
     pub(crate) fn get_var_loc(&self, ident: &str) -> Option<Loc> {
         match self {
             IndexExpr2::Wildcard(_) => None,


### PR DESCRIPTION
Implements pass 0 transformations for the expr2 → expr3 lowering:

1. Wildcard resolution: Converts bare wildcards (`*`) to explicit
   star ranges (`*:dim`) based on the variable's dimensions at each
   subscript position. This ensures that after lowering, all array
   subscripts have explicit dimension information.

2. Bare array expansion: When a bare array variable (e.g., `revenue`)
   is encountered, implicit subscripts are added to convert it to
   a fully subscripted form (e.g., `revenue[*:Location, *:Product]`).

3. Error handling: Using a wildcard on a scalar/unknown variable now
   produces a `CantSubscriptScalar` error with proper location info.

Key design decisions:
- IndexExpr3 no longer has a Wildcard variant; all wildcards are
  resolved to StarRange during lowering. This enforces at the type
  level that wildcard resolution has happened.
- Explicit user-provided star ranges (e.g., `arr[*:SubDim]`) are
  passed through unchanged to preserve the user's intent.
- ArrayBounds are preserved from Expr2 since the conversion from
  `*` to `*:dim` (where dim is the variable's own dimension) does
  not change the array dimensions.