### PR TITLE
engine: improve indexed dimension support in VM and compiler

### DIFF
--- a/src/simlin-engine/src/test_common.rs
+++ b/src/simlin-engine/src/test_common.rs
@@ -509,6 +509,18 @@ impl TestProject {
         }
     }
 
+    /// Get interpreter results for a variable (allows checking for NaN values)
+    pub fn interpreter_result(&self, var_name: &str) -> Vec<f64> {
+        let results = self
+            .run_interpreter()
+            .expect("Interpreter should run successfully");
+
+        results
+            .get(var_name)
+            .unwrap_or_else(|| panic!("Variable {var_name} not found in results"))
+            .clone()
+    }
+
     /// Test that simulation creation succeeds
     pub fn assert_sim_builds(&self) {
         self.build_sim()


### PR DESCRIPTION
This commit adds several improvements to indexed dimension handling:

1. VM bounds checking (vm.rs): LoadIterViewTop now returns NaN for
   out-of-bounds access when iterating over a larger array than the source.
   This enables safe handling of size-mismatched array operations.

2. VM positional fallback for indexed dimensions: When dim_id matching
   fails during iteration, the VM now checks if both dimensions are
   indexed with the same size. If so, it uses positional matching instead
   of requiring exact dim_id match. This enables operations like
   a[DimA] + b[DimB] where DimA and DimB are different indexed dimensions
   of the same size.

3. Star-range desugaring for indexed dimensions (compiler.rs): The
   compiler now handles *:IndexedSubDim by desugaring it to [1:SIZE(IndexedSubDim)].
   For example, arr[*:SubIdx] where SubIdx is indexed(3) becomes arr[1:3].

4. Compiler positional matching (compiler.rs): get_implicit_subscripts
   now supports positional matching for indexed dimensions of the same
   size, enabling bare array references across different indexed dimensions.

5. New tests (array_tests.rs): Added comprehensive tests for star-range
   indexed subdimension desugaring and SUM with ranges.

Note: Some tests for different-named indexed dimension broadcasting
(e.g., a[DimA] + b[DimB]) are marked as #[ignore] because they require
additional compiler-level changes to find_dimension_reordering and other
dimension matching code paths. The VM-level positional matching is in
place, but the compiler's dimension compatibility checking needs updates
at multiple levels.