### PR TITLE
engine: fix dimension matching to prefer name over size

### DIFF
--- a/src/simlin-engine/src/compiler.rs
+++ b/src/simlin-engine/src/compiler.rs
@@ -783,6 +783,15 @@ impl Context<'_> {
             // SECOND PASS: Only if no name match exists, try size-based matching
             // for indexed dimensions. Find the first unused indexed dimension with
             // the same size.
+            //
+            // IMPORTANT: Size-based fallback only applies when BOTH dimensions are
+            // indexed. Named dimensions must match by name (or subdimension relationship)
+            // because their elements have semantic meaning. For example, Cities=[Boston,
+            // Seattle] and Products=[Widgets,Gadgets] shouldn't match just because both
+            // have size 2 - that would be semantically incorrect.
+            //
+            // NOTE: This algorithm mirrors the dimension matching in vm.rs LoadIterViewTop.
+            // If you modify this logic, update the VM implementation as well.
             let size_match_idx = if let Dimension::Indexed(_, dim_size) = dim {
                 active_dims.iter().enumerate().find_map(|(i, candidate)| {
                     if !used[i]

--- a/src/simlin-engine/src/vm.rs
+++ b/src/simlin-engine/src/vm.rs
@@ -945,7 +945,16 @@ impl Vm {
                                 }
                             }
 
-                            // Pass 2: Size-based fallback for unmatched indexed dimensions
+                            // Pass 2: Size-based fallback for unmatched indexed dimensions.
+                            //
+                            // IMPORTANT: Size-based fallback only applies when BOTH dimensions
+                            // are indexed. Named dimensions must match by name because their
+                            // elements have semantic meaning. For example, Cities=[Boston,Seattle]
+                            // and Products=[Widgets,Gadgets] shouldn't match just because both
+                            // have size 2.
+                            //
+                            // NOTE: This algorithm mirrors compiler.rs get_implicit_subscripts.
+                            // If you modify this logic, update the compiler implementation too.
                             for (src_dim_pos, src_dim_id) in source_view.dim_ids.iter().enumerate()
                             {
                                 if source_to_iter[src_dim_pos].is_some() {


### PR DESCRIPTION
The get_implicit_subscripts function now uses a two-pass algorithm:
first looking for exact name matches across all unused active dimensions,
then falling back to size-based matching only if no name match exists.

This fixes a bug where size-based matching would incorrectly bind
subscripts when multiple indexed dimensions had the same size. For
example, with active_dims = [IdxA(3), IdxB(3)] and a variable with
dims = [IdxB], the old linear scan would hit IdxA first, see matching
size, and incorrectly use its subscript instead of finding the correct
IdxB match later in the list.

Also added tests for 1D array broadcasting in 2D contexts, including
tests marked as ignored for cross-dimension broadcasting which requires
additional compiler work.