### PR TITLE
doc: add plan for different-named indexed dimension broadcasting

### DIFF
--- a/doc/indexed-dimension-broadcasting-plan.md
+++ b/doc/indexed-dimension-broadcasting-plan.md
@@ -4,11 +4,16 @@
 
 This document outlines the implementation plan for supporting different-named indexed dimension broadcasting in the Simlin engine compiler. This feature allows operations like `sales[Products] + costs[Regions]` where Products and Regions are different indexed dimensions with the same size.
 
+**Key Principles:**
+1. **N-dimensional generalization**: All algorithms work for any number of dimensions, no special-casing for 1D/2D
+2. **Test-Driven Development**: Write/enable tests first, then implement to make them pass
+3. **No compatibility shims**: Replace old code paths entirely, delete superseded code
+
 ## Problem Statement
 
-Currently, the compiler only allows dimension matching by name. Two test categories are failing:
+Currently, the compiler only allows dimension matching by name. The failing tests demonstrate two patterns that should work:
 
-### Category 1: Same-Output-Dimension Broadcasting (Simpler)
+### Pattern 1: Same-Rank Positional Matching
 ```
 indexed_dimension("Products", 3)
 indexed_dimension("Regions", 3)
@@ -17,283 +22,238 @@ array_aux("costs[Regions]", "Regions * 10")     // [10, 20, 30]
 array_aux("combined[Products]", "sales + costs") // Should be [11, 22, 33]
 ```
 
-Here, `costs[Regions]` needs to match `Products` via positional/size-based matching because both are indexed dimensions of size 3.
+Here, `costs[Regions]` needs to match `Products` via size-based matching because both are indexed dimensions of size 3.
 
-### Category 2: 2D Broadcasting (Complex)
+### Pattern 2: Cross-Dimension Broadcasting (N-dimensional)
 ```
+// 2D example
 indexed_dimension("First", 2)
 indexed_dimension("Second", 2)
 array_aux("a[First]", "First * 10")   // [10, 20]
 array_aux("b[Second]", "Second")      // [1, 2]
 array_aux("combined[First, Second]", "a + b")
-// Should be: [11, 12, 21, 22] (row-major)
-// combined[i,j] = a[i] + b[j]
+// combined[i,j] = a[i] + b[j] → [11, 12, 21, 22]
+
+// 3D example
+indexed_dimension("X", 2)
+indexed_dimension("Y", 3)
+indexed_dimension("Z", 4)
+array_aux("plane[X, Y]", "X * 10 + Y")     // 2x3 array
+array_aux("line[Z]", "Z")                   // length-4 array
+array_aux("cube[X, Y, Z]", "plane + line")  // 2x3x4 array
+// cube[i,j,k] = plane[i,j] + line[k]
 ```
 
-This requires true broadcasting: `a[First]` repeats over the Second dimension, and `b[Second]` repeats over the First dimension.
+The algorithm must work for ANY number of dimensions, not just 1D/2D.
 
 ## Current Architecture Analysis
 
-### Key Code Paths
+### Problem: Scattered Dimension Matching Logic
 
-There are **four main code paths** where dimension matching occurs:
+There are **four separate code paths** where dimension matching occurs, each with slightly different logic:
 
-1. **`find_dimension_reordering`** (compiler.rs:4559)
-   - Purpose: Match source dimensions to target dimensions for reordering
-   - Current behavior: Exact name matching only
-   - Status: Needs positional fallback for indexed dimensions
+1. **`find_dimension_reordering`** (compiler.rs:4559) - Name-only matching
+2. **`get_implicit_subscripts`** (compiler.rs:716) - Has size-based fallback
+3. **Subscript handling in `lower_from_expr3`** (compiler.rs:1649-1800) - Partial size matching
+4. **Bare Var handling** (compiler.rs:1480-1560) - Uses name-only `find_dimension_reordering`
 
-2. **`get_implicit_subscripts`** (compiler.rs:716)
-   - Purpose: Determine which active subscripts to use for bare array references
-   - Current behavior: Has size-based fallback (lines 783-813)
-   - Status: Logic exists but not applied consistently elsewhere
+**This scattered logic is the root cause of the bug.** The fix requires consolidating into ONE unified approach.
 
-3. **Subscript handling in `lower_from_expr3`** (compiler.rs:1649-1800)
-   - Purpose: Resolve array subscripts to concrete offsets in A2A context
-   - Current behavior: Name-matching with incomplete positional fallback
-   - Status: Needs coordinated updates
+### Key Semantic Rules
 
-4. **Bare Var handling** (compiler.rs:1480-1560)
-   - Purpose: Handle unsubscripted array variable references in A2A context
-   - Current behavior: Uses `find_dimension_reordering` which is name-only
-   - Status: Needs positional fallback
-
-### Current Size-Based Matching Logic (Reference)
-
-The size-based fallback in `get_implicit_subscripts` (lines 783-813) provides a reference implementation:
-
-```rust
-// SECOND PASS: Only if no name match exists, try size-based matching
-// for indexed dimensions. Find the first unused indexed dimension with
-// the same size.
-//
-// IMPORTANT: Size-based fallback only applies when BOTH dimensions are
-// indexed. Named dimensions must match by name (or subdimension relationship)
-// because their elements have semantic meaning.
-let size_match_idx = if let Dimension::Indexed(_, dim_size) = dim {
-    active_dims.iter().enumerate().find_map(|(i, candidate)| {
-        if !used[i]
-            && let Dimension::Indexed(_, candidate_size) = candidate
-            && dim_size == candidate_size
-        {
-            return Some(i);
-        }
-        None
-    })
-} else {
-    None
-};
-```
-
-Key principles:
-- **Indexed dimensions only**: Named dimensions must match by name
-- **Size equality required**: Dimensions must have the same size
-- **First unused match**: Preserves positional semantics
+These rules must be preserved:
+1. **Named dimensions**: Match by name ONLY (semantic meaning matters)
+2. **Indexed dimensions**: Match by name first, then by size as fallback
+3. **Broadcasting**: When input has fewer dimensions than output, unmatched output dimensions use stride 0
 
 ## Implementation Plan
 
-### Phase 1: Create Unified Dimension Matching Helper
+### Phase 1: Test Infrastructure (TDD)
 
-Create a new helper function that encapsulates the matching logic used in `get_implicit_subscripts` so it can be reused consistently across all code paths.
+**Goal:** Define expected behavior through tests BEFORE implementation.
 
-**New function: `find_dimension_matching`**
+#### 1.1 Enable existing ignored tests
+Remove `#[ignore]` from the tests in `indexed_dimension_broadcasting_tests`:
+- `different_indexed_dims_same_size_broadcast`
+- `different_indexed_dims_with_wildcard`
+- `indexed_dims_2d_positional_matching`
+- `add_1d_different_dim_arrays_in_2d_context`
+- `name_match_before_size_match_for_indexed_dims`
+- `name_match_same_size_dims`
 
+#### 1.2 Add N-dimensional tests (3D, 4D)
 ```rust
-/// Result of dimension matching for a single source dimension.
-enum DimensionMatch {
-    /// Found an exact name match at the given index
-    NameMatch(usize),
-    /// Found a positional match (indexed dimensions with same size)
-    PositionalMatch(usize),
-    /// No match found
-    NoMatch,
+#[test]
+fn broadcast_to_3d() {
+    // plane[X,Y] + line[Z] → cube[X,Y,Z]
+    let project = TestProject::new("broadcast_3d")
+        .indexed_dimension("X", 2)
+        .indexed_dimension("Y", 3)
+        .indexed_dimension("Z", 4)
+        .array_aux("plane[X, Y]", "X * 10 + Y")  // 2x3
+        .array_aux("line[Z]", "Z * 100")         // 4
+        .array_aux("cube[X, Y, Z]", "plane + line");
+    // cube[x,y,z] = plane[x,y] + line[z]
+    // Expected: 24 values in row-major order
+    project.assert_compiles();
+    project.assert_sim_builds();
+    // Verify specific values...
 }
 
-/// Find a matching active dimension for the given source dimension.
+#[test]
+fn broadcast_scalar_to_4d() {
+    // scalar + 4D array
+    let project = TestProject::new("broadcast_4d")
+        .indexed_dimension("A", 2)
+        .indexed_dimension("B", 2)
+        .indexed_dimension("C", 2)
+        .indexed_dimension("D", 2)
+        .scalar_const("offset", 100.0)
+        .array_aux("arr[A, B, C, D]", "A + B*2 + C*4 + D*8")
+        .array_aux("result[A, B, C, D]", "arr + offset");
+    project.assert_compiles();
+    // ...
+}
+
+#[test]
+fn broadcast_multiple_inputs_3d() {
+    // a[X] + b[Y] + c[Z] → result[X,Y,Z]
+    // Three 1D arrays broadcasting to 3D
+    let project = TestProject::new("triple_broadcast")
+        .indexed_dimension("X", 2)
+        .indexed_dimension("Y", 3)
+        .indexed_dimension("Z", 4)
+        .array_aux("a[X]", "X * 1000")
+        .array_aux("b[Y]", "Y * 100")
+        .array_aux("c[Z]", "Z")
+        .array_aux("result[X, Y, Z]", "a + b + c");
+    // result[x,y,z] = a[x] + b[y] + c[z]
+    project.assert_compiles();
+    // ...
+}
+```
+
+#### 1.3 Run tests to confirm they fail
+```bash
+cargo test -p simlin-engine indexed_dimension_broadcasting
+```
+Document the specific error messages to understand what needs fixing.
+
+### Phase 2: Core Algorithm - Unified Dimension Matching
+
+**Goal:** Create ONE function that handles ALL dimension matching, replacing scattered logic.
+
+#### 2.1 The N-Dimensional Matching Algorithm
+
+```rust
+/// Result of matching source dimensions to target dimensions.
 ///
-/// Matching priority:
-/// 1. Exact name match (highest priority)
-/// 2. Positional match for indexed dimensions of same size
+/// For each target dimension, provides either:
+/// - Some(source_idx): which source dimension maps here
+/// - None: no source dimension (broadcast with stride 0)
+pub struct DimensionMapping {
+    /// mapping[target_idx] = Some(source_idx) or None
+    pub mapping: Vec<Option<usize>>,
+    /// For each source dimension, which target dimension it matched
+    pub source_to_target: Vec<usize>,
+}
+
+/// Match source dimensions to target dimensions.
 ///
-/// Named dimensions ONLY match by name - never by size.
-fn find_dimension_match(
+/// Algorithm (dimension-agnostic, works for any N):
+/// 1. For each source dimension, find a matching target dimension
+///    - Named dims: match by name only
+///    - Indexed dims: match by name first, then by size
+/// 2. Verify all source dimensions found a match
+/// 3. Build the reverse mapping (target → source)
+///
+/// Returns None if any source dimension cannot be matched.
+pub fn match_dimensions(
+    source_dims: &[Dimension],
+    target_dims: &[Dimension],
+) -> Option<DimensionMapping> {
+    let mut target_used = vec![false; target_dims.len()];
+    let mut source_to_target = Vec::with_capacity(source_dims.len());
+
+    // For each source dimension, find its target
+    for source_dim in source_dims {
+        let target_idx = find_target_for_source(source_dim, target_dims, &target_used)?;
+        target_used[target_idx] = true;
+        source_to_target.push(target_idx);
+    }
+
+    // Build reverse mapping
+    let mut mapping = vec![None; target_dims.len()];
+    for (source_idx, &target_idx) in source_to_target.iter().enumerate() {
+        mapping[target_idx] = Some(source_idx);
+    }
+
+    Some(DimensionMapping { mapping, source_to_target })
+}
+
+/// Find target dimension for a source dimension.
+fn find_target_for_source(
     source_dim: &Dimension,
-    active_dims: &[Dimension],
+    target_dims: &[Dimension],
     used: &[bool],
-) -> DimensionMatch {
-    // First pass: exact name match
-    for (i, candidate) in active_dims.iter().enumerate() {
-        if !used[i] && candidate.name() == source_dim.name() {
-            return DimensionMatch::NameMatch(i);
+) -> Option<usize> {
+    // First pass: exact name match (works for both named and indexed)
+    for (i, target) in target_dims.iter().enumerate() {
+        if !used[i] && target.name() == source_dim.name() {
+            return Some(i);
         }
     }
 
-    // Second pass: positional match for indexed dimensions only
-    if let Dimension::Indexed(_, dim_size) = source_dim {
-        for (i, candidate) in active_dims.iter().enumerate() {
+    // Second pass: size-based match (indexed dimensions only)
+    if let Dimension::Indexed(_, source_size) = source_dim {
+        for (i, target) in target_dims.iter().enumerate() {
             if !used[i] {
-                if let Dimension::Indexed(_, candidate_size) = candidate {
-                    if dim_size == candidate_size {
-                        return DimensionMatch::PositionalMatch(i);
+                if let Dimension::Indexed(_, target_size) = target {
+                    if source_size == target_size {
+                        return Some(i);
                     }
                 }
             }
         }
     }
 
-    DimensionMatch::NoMatch
+    None
 }
 ```
 
-### Phase 2: Update `find_dimension_reordering`
-
-Extend to support positional matching as fallback for indexed dimensions.
-
-**Current signature:**
-```rust
-pub fn find_dimension_reordering(
-    source_dims: &[String],
-    target_dims: &[String],
-) -> Option<Vec<usize>>
-```
-
-**New signature:**
-```rust
-pub fn find_dimension_reordering_with_dims(
-    source_dims: &[Dimension],
-    target_dims: &[Dimension],
-) -> Option<Vec<usize>>
-```
-
-This allows the function to check dimension types and apply size-based matching for indexed dimensions.
-
-### Phase 3: Update Bare Var Handling
-
-Modify the code at lines 1480-1560 to use the new matching logic.
-
-The key change is replacing:
-```rust
-if let Some(reordering) = find_dimension_reordering(&source_dim_names, &target_dim_names)
-```
-
-With:
-```rust
-if let Some(reordering) = find_dimension_reordering_with_dims(source_dims, target_dims)
-```
-
-### Phase 4: Update Subscript Handling in A2A Context
-
-The most complex changes are in the subscript handling (lines 1649-1800).
-
-**Current logic flow:**
-1. Build `active_dim_map` from dimension name → (index, subscript)
-2. For each view dimension, try name-based matching first
-3. Fall back to positional matching only if name matching fails and counts match
-
-**Required changes:**
-1. Add size-based matching as a middle tier:
-   - If name matching fails
-   - AND source dim is indexed
-   - AND there's an unused active dim with same size (also indexed)
-   - Then use that active dim's subscript
-
-**Key modification around line 1717:**
-```rust
-let (active_idx, subscript) = if use_name_matching[view_idx] {
-    // Name-based matching (existing code)
-    ...
-} else {
-    // Enhanced positional matching
-    // Check if we can use size-based matching for indexed dimensions
-    let view_dim_name = &view.dim_names[view_idx];
-    let view_dim_size = view.dims[view_idx];
-
-    // Try to find matching indexed dimension by size
-    let size_match = if is_indexed_dimension(view_dim_name, &self.dimensions) {
-        active_dims.iter().enumerate()
-            .filter(|(i, _)| !used_active[*i])
-            .find(|(_, dim)| {
-                matches!(dim, Dimension::Indexed(_, size) if *size as usize == view_dim_size)
-            })
-            .map(|(i, _)| (i, &active_subscripts[i]))
-    } else {
-        None
-    };
-
-    if let Some((idx, sub)) = size_match {
-        used_active[idx] = true;
-        (idx, sub)
-    } else {
-        // Fall back to strict positional matching
-        (view_idx, &active_subscripts[view_idx])
-    }
-};
-```
-
-### Phase 5: Handle 2D Broadcasting (Category 2)
-
-This is the most complex case and requires additional infrastructure.
-
-**Problem:** When we have:
-- Output: `combined[First, Second]`
-- Input: `a[First]` (1D), `b[Second]` (1D)
-- Operation: `a + b`
-
-We need to recognize that:
-- `a[First]` should broadcast to `[First, Second]` by repeating over Second
-- `b[Second]` should broadcast to `[First, Second]` by repeating over First
-
-**Approach:** The key insight is that broadcasting is already partially handled by the dimension matching logic. When we have fewer source dimensions than target dimensions:
-
-1. **Dimension Identification**: For each source dimension, find which output dimension it matches (by name for named dims, by size/position for indexed dims)
-
-2. **Stride Adjustment**: Create a view where:
-   - Matched dimension: use normal stride
-   - Unmatched dimensions: use stride of 0 (value repeats)
-
-**Example for `a[First]` in `combined[First, Second]`:**
-- Source view: dims=[2], strides=[1], offset=0
-- After broadcasting: dims=[2, 2], strides=[1, 0], offset=0
-  - The stride of 0 for Second means a[i] is used for all j values
-
-**Implementation:**
-
-Add a `broadcast_view_to_target` function:
+#### 2.2 Broadcasting Function (N-dimensional)
 
 ```rust
-/// Broadcast a view to match target dimensions.
+/// Broadcast a source view to match target dimensions.
 ///
 /// For each target dimension:
 /// - If source has a matching dimension: use its stride
-/// - If source lacks this dimension: use stride 0 (broadcast/repeat)
+/// - If no match: use stride 0 (broadcast/repeat)
 ///
-/// Returns None if dimensions are incompatible.
-fn broadcast_view_to_target(
+/// This is dimension-agnostic: works for any N.
+pub fn broadcast_view(
     source_view: &ArrayView,
     source_dims: &[Dimension],
     target_dims: &[Dimension],
 ) -> Option<ArrayView> {
+    let mapping = match_dimensions(source_dims, target_dims)?;
+
     let mut new_dims = Vec::with_capacity(target_dims.len());
     let mut new_strides = Vec::with_capacity(target_dims.len());
     let mut new_dim_names = Vec::with_capacity(target_dims.len());
 
-    for target_dim in target_dims {
-        // Find matching source dimension
-        let source_match = find_source_dimension_for_target(
-            target_dim, source_dims, source_view
-        );
+    for (target_idx, target_dim) in target_dims.iter().enumerate() {
+        new_dims.push(target_dim.len());
+        new_dim_names.push(target_dim.name().to_string());
 
-        match source_match {
-            Some((source_idx, stride)) => {
-                new_dims.push(target_dim.len());
-                new_strides.push(stride);
-                new_dim_names.push(target_dim.name().to_string());
+        match mapping.mapping[target_idx] {
+            Some(source_idx) => {
+                // Source dimension maps here - use its stride
+                new_strides.push(source_view.strides[source_idx]);
             }
             None => {
-                // No match - broadcast (use stride 0)
-                new_dims.push(target_dim.len());
+                // No source dimension - broadcast (stride 0)
                 new_strides.push(0);
-                new_dim_names.push(target_dim.name().to_string());
             }
         }
     }
@@ -308,87 +268,148 @@ fn broadcast_view_to_target(
 }
 ```
 
-### Phase 6: Integration into Binary Operations
+### Phase 3: Replace Scattered Matching Logic
 
-Modify the Op2 handling in `lower_from_expr3` (around line 1973) to apply broadcasting when operand dimensions don't match output dimensions.
+**Goal:** Delete old code paths and replace with unified functions.
+
+#### 3.1 Delete `find_dimension_reordering` (or reimplement using `match_dimensions`)
+
+The old function only supported name matching. Either:
+- Delete it entirely and use `match_dimensions` everywhere
+- Reimplement it as a thin wrapper around `match_dimensions`
+
+**Recommended:** Delete and replace all call sites.
+
+#### 3.2 Simplify `get_implicit_subscripts`
+
+Replace the scattered matching logic (lines 765-820) with:
+```rust
+fn get_implicit_subscripts(&self, dims: &[Dimension], ident: &str) -> Result<Vec<&str>> {
+    let active_dims = self.active_dimension.as_ref()
+        .ok_or_else(|| sim_err!(ArrayReferenceNeedsExplicitSubscripts, ident))?;
+    let active_subscripts = self.active_subscript.as_ref().unwrap();
+
+    let mapping = match_dimensions(dims, active_dims)
+        .ok_or_else(|| sim_err!(MismatchedDimensions, ident))?;
+
+    // Build subscripts in source dimension order
+    Ok(mapping.source_to_target.iter()
+        .map(|&target_idx| active_subscripts[target_idx].as_str())
+        .collect())
+}
+```
+
+#### 3.3 Simplify Subscript handling in `lower_from_expr3`
+
+The complex logic at lines 1649-1800 should be replaced with calls to `match_dimensions` and `broadcast_view`.
+
+#### 3.4 Simplify bare Var handling
+
+Replace the reordering logic at lines 1480-1560 with the unified approach.
+
+### Phase 4: Integration and Cleanup
+
+#### 4.1 Update Op2 handling for broadcasting
+
+When processing binary operations, check if either operand needs broadcasting:
 
 ```rust
-Expr3::Op2(op, left, right, array_bounds, loc) => {
-    let mut l_expr = self.lower_from_expr3(left)?;
-    let mut r_expr = self.lower_from_expr3(right)?;
+// Pseudocode
+fn lower_op2(&self, op, left, right, output_bounds) -> Result<Expr> {
+    let l_expr = self.lower_from_expr3(left)?;
+    let r_expr = self.lower_from_expr3(right)?;
 
-    if let Some(bounds) = array_bounds {
-        let output_dims = bounds.dims();
-        let output_dim_names = bounds.dim_names();
+    if let Some(output_dims) = self.get_output_dimensions(output_bounds) {
+        let l_dims = self.get_expr_dimensions(&l_expr);
+        let r_dims = self.get_expr_dimensions(&r_expr);
 
-        // Check if broadcasting is needed
-        if let Some(output_names) = output_dim_names {
-            // Get dimensions of each operand
-            let l_dims = get_expr_dims(&l_expr);
-            let r_dims = get_expr_dims(&r_expr);
-
-            // Apply broadcasting if needed
-            if l_dims.map(|d| d.len()).unwrap_or(0) < output_dims.len() {
-                l_expr = apply_broadcast(l_expr, l_dims, output_names)?;
-            }
-            if r_dims.map(|d| d.len()).unwrap_or(0) < output_dims.len() {
-                r_expr = apply_broadcast(r_expr, r_dims, output_names)?;
-            }
-        }
+        // Apply broadcasting if dimensions don't match output
+        let l_expr = self.maybe_broadcast(l_expr, l_dims, &output_dims)?;
+        let r_expr = self.maybe_broadcast(r_expr, r_dims, &output_dims)?;
     }
 
-    Ok(Expr::Op2(lower_op(*op), Box::new(l_expr), Box::new(r_expr), *loc))
+    Ok(Expr::Op2(op, Box::new(l_expr), Box::new(r_expr), loc))
 }
+```
+
+#### 4.2 Delete dead code
+
+After replacing all call sites:
+- Delete old `find_dimension_reordering` if not reused
+- Delete any fallback paths that were superseded
+- Delete helper functions that are no longer called
+- Run `cargo clippy` to find unused code
+
+#### 4.3 Final test verification
+
+```bash
+# All tests should pass
+cargo test -p simlin-engine
+
+# Verify no warnings about unused code
+cargo clippy -p simlin-engine
 ```
 
 ## Testing Strategy
 
-### Test Order
+### TDD Approach
 
-1. **Phase 1-4 tests** (same-dimension-count broadcasting):
-   - `different_indexed_dims_same_size_broadcast`
-   - `different_indexed_dims_with_wildcard`
-   - `indexed_dims_2d_positional_matching`
+1. **Enable all ignored tests FIRST** - they define expected behavior
+2. **Add N-dimensional tests** - verify generalization works
+3. **Run tests** - they should fail initially
+4. **Implement** - until all tests pass
+5. **Cleanup** - remove dead code, verify no regressions
 
-2. **Phase 5-6 tests** (cross-dimension broadcasting):
-   - `add_1d_different_dim_arrays_in_2d_context`
-   - `name_match_before_size_match_for_indexed_dims`
-   - `name_match_same_size_dims`
+### Test Categories
 
-### Regression Prevention
+| Category | Example | Tests |
+|----------|---------|-------|
+| Same-rank positional | `a[DimA] + b[DimB]` → `result[DimA]` | `different_indexed_dims_same_size_broadcast`, `different_indexed_dims_with_wildcard` |
+| Cross-dimension 2D | `a[X] + b[Y]` → `result[X,Y]` | `add_1d_different_dim_arrays_in_2d_context`, `name_match_*` |
+| Cross-dimension 3D | `plane[X,Y] + line[Z]` → `cube[X,Y,Z]` | `broadcast_to_3d` (new) |
+| Cross-dimension 4D | `scalar + arr[A,B,C,D]` | `broadcast_scalar_to_4d` (new) |
+| Multiple broadcasts | `a[X] + b[Y] + c[Z]` → 3D | `broadcast_multiple_inputs_3d` (new) |
 
-- All existing tests must continue to pass
-- Named dimensions must NOT use size-based matching
-- Only indexed dimensions with matching sizes can be positionally matched
+### Regression Tests
+
+All existing passing tests must continue to pass:
+- Named dimension matching (by name only)
+- Subdimension relationships
+- Existing array operations
+
+## Key Design Decisions
+
+### 1. Named vs Indexed Semantics
+- **Named dimensions** (Cities, Products): Match by name ONLY. `Cities[Boston,Seattle]` ≠ `Products[Widget,Gadget]` even if both size 2.
+- **Indexed dimensions** (Dim(5)): Match by name first, then by size. This enables `a[DimA(3)] + b[DimB(3)]`.
+
+### 2. Matching Algorithm
+- **Greedy**: First match wins. When multiple same-size indexed dims exist, first unused one matches.
+- **All-or-nothing**: If any source dimension can't match, the operation fails.
+
+### 3. Broadcasting via Stride 0
+- Unmatched target dimensions get stride 0 in the view
+- This means the value repeats (broadcasts) over that dimension
+- No data copying required - pure view manipulation
+
+### 4. No Compatibility Shims
+- Old `find_dimension_reordering` will be deleted or reimplemented
+- All four code paths will be unified into ONE approach
+- No fallback to old behavior
 
 ## Risks and Mitigation
 
-### Risk 1: Breaking existing dimension matching
-**Mitigation:** Size-based matching is ONLY applied to indexed dimensions. Named dimensions always require exact name or subdimension matching.
+| Risk | Mitigation |
+|------|------------|
+| Breaking named dimension semantics | Size-based matching ONLY for indexed dimensions |
+| Ambiguous multi-match | Greedy algorithm with first-unused selection |
+| N-dimensional edge cases | Comprehensive test suite including 3D, 4D cases |
+| Performance regression | Algorithm is O(n²) on dimension count, which is always small (<10) |
 
-### Risk 2: Ambiguous matching
-**Mitigation:** When multiple indexed dimensions have the same size, use the first unused one (preserving positional semantics). This matches Stella/Vensim behavior.
+## Summary
 
-### Risk 3: Complexity in VM
-**Mitigation:** The bytecode VM already has infrastructure for stride-based iteration. Broadcasting with stride 0 is a natural extension.
+The implementation consolidates scattered dimension matching logic into TWO key functions:
+1. `match_dimensions()` - unified N-dimensional matching algorithm
+2. `broadcast_view()` - creates views with stride 0 for broadcasting
 
-## Implementation Order
-
-1. Create the unified `find_dimension_match` helper
-2. Update `find_dimension_reordering` to support dimension types
-3. Update bare Var handling (Phase 3)
-4. Update Subscript handling (Phase 4)
-5. Implement `broadcast_view_to_target` (Phase 5)
-6. Integrate broadcasting into Op2 (Phase 6)
-7. Enable ignored tests and verify
-
-## Estimated Complexity
-
-- Phase 1: Low (new helper function)
-- Phase 2: Low (extend existing function)
-- Phase 3: Low (use new helper)
-- Phase 4: Medium (careful integration with existing logic)
-- Phase 5: Medium (new broadcasting logic)
-- Phase 6: Medium (integration with expression lowering)
-
-Total: ~400-600 lines of new/modified code across compiler.rs.
+These replace the four separate code paths with ONE consistent approach, enabling both same-rank positional matching and cross-dimension broadcasting for any number of dimensions.


### PR DESCRIPTION
This plan outlines the implementation approach for allowing operations
between arrays with different indexed dimension names but the same size.
For example: sales[Products] + costs[Regions] where both dimensions have
size 3.

The key insight is that there are four separate code paths in the compiler
where dimension matching occurs, and all need coordinated updates:

1. find_dimension_reordering - currently name-only matching
2. get_implicit_subscripts - already has size-based fallback
3. Subscript handling in lower_from_expr3 - A2A iteration logic
4. Bare Var handling - uses find_dimension_reordering

Named dimensions must always match by name (semantic meaning), but indexed
dimensions can use positional matching when they have the same size.

The plan covers two categories of tests:
- Same-dimension-count broadcasting (simpler)
- 2D broadcasting from 1D arrays (requires stride-0 repetition)

Implementation is broken into 6 phases with estimated ~400-600 lines of
changes to compiler.rs.