### PR TITLE
Make Canvas component work like native map apps

### DIFF
--- a/src/diagram/drawing/Canvas.tsx
+++ b/src/diagram/drawing/Canvas.tsx
@@ -174,7 +174,8 @@ export const Canvas = styled(
     computeBounds = false;
 
     // Multi-touch tracking for pinch gestures
-    activePointers: Map<number, TrackedPointer> = new Map();
+    // Note: use globalThis.Map to get native Map (not Immutable.Map from imports)
+    activePointers = new (globalThis.Map)<number, TrackedPointer>();
 
     // Momentum/inertia animation
     velocityTracker: VelocityTracker = { positions: [] };
@@ -934,6 +935,10 @@ export const Canvas = styled(
       // Clear velocity tracking and pointer data
       this.velocityTracker.positions = [];
       this.activePointers.clear();
+      // Clear single-pointer gesture state
+      this.pointerId = undefined;
+      this.mouseDownPoint = undefined;
+      this.selectionCenterOffset = undefined;
     }
 
     // Flutter-style friction simulation: calculates position at time t
@@ -1445,6 +1450,8 @@ export const Canvas = styled(
           pinchModelPoint,
           isMovingCanvas: false,
           isDragSelecting: false,
+          // Clear any canvas offset to prevent momentum from starting when exiting pinch
+          movingCanvasOffset: undefined,
         });
         return;
       }


### PR DESCRIPTION
Implement Google Maps/Apple Maps style interactions for the Canvas component to provide a native feel on Mac and iOS devices:

- Wheel event handling: Two-finger trackpad scroll for panning, and pinch-to-zoom via ctrlKey wheel events (how browsers report trackpad pinch gestures)

- Multi-touch pinch gesture: Track multiple pointers using the Pointer Events API to detect and handle pinch-to-zoom on touch devices. Zoom is centered on the pinch midpoint for intuitive behavior.

- Momentum scrolling: Implement Flutter's FrictionSimulation physics for natural deceleration after pan gestures. Uses friction coefficient of 0.135 matching iOS scroll physics, with velocity tracking over the last 100ms of touch movement.

- CSS touch-action: none: Prevent browser default touch gestures from interfering with custom pan/zoom handling.

The zoom-at-point math ensures the point under the cursor/pinch center remains stable during zoom operations, matching user expectations from map applications.