### PR TITLE
engine: complete unit inference and checking implementation

### DIFF
--- a/src/simlin-engine/src/unit_checking_test.rs
+++ b/src/simlin-engine/src/unit_checking_test.rs
@@ -632,6 +632,27 @@ mod tests {
     }
 
     #[test]
+    fn test_arrayed_expression_conflicting_inferred_units() {
+        // Test that inference catches when different array elements have different units
+        // without any declared units on the array itself
+        TestProject::new("arrayed_conflict_test")
+            .with_time_units("days")
+            .unit("widgets", None)
+            .unit("gadgets", None)
+            .named_dimension("Type", &["A", "B"])
+            .aux_with_units("widget_rate", "10", Some("widgets"))
+            .aux_with_units("gadget_rate", "20", Some("gadgets"))
+            // Different elements have different units - should fail
+            .array_with_ranges_direct(
+                "rates",
+                vec!["Type".to_string()],
+                vec![("A", "widget_rate"), ("B", "gadget_rate")],
+                None, // No declared units - relies on inference
+            )
+            .assert_unit_error();
+    }
+
+    #[test]
     fn test_arrayed_expression_unit_mismatch() {
         // Test that unit checking catches mismatches in arrayed expressions
         // The declared units are "widgets" but the expression computes "widgets/days"

--- a/src/simlin-engine/src/units.rs
+++ b/src/simlin-engine/src/units.rs
@@ -32,6 +32,14 @@ impl Units {
             (Units::Explicit(lhs), Units::Explicit(rhs)) => *lhs == *rhs,
         }
     }
+
+    /// Convert to a UnitMap, treating Constant as dimensionless (empty map)
+    pub fn to_unit_map(&self) -> UnitMap {
+        match self {
+            Units::Explicit(units) => units.clone(),
+            Units::Constant => UnitMap::new(),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, Eq, PartialEq)]


### PR DESCRIPTION
## Summary

This PR addresses several stubbed-out or incomplete parts of the unit inference and checking system that were left as TODOs or workarounds.

## Changes

**Unit Inference (`units_infer.rs`):**
- Fixed higher-order exponent handling. Previously, `@x^2 = meters` would incorrectly substitute `@x = seconds` as `seconds` instead of `seconds^2`. Now `single_fv()` rejects metavariables with |exponent| > 1 (since solving requires fractional exponents we can't represent), and `substitute()` properly scales units by exponent magnitude.
- Implemented arrayed expression constraint generation. Previously returned `Units::Constant`, ignoring all arrayed expressions.

**Unit Checking (`units_check.rs`):**
- Implemented `ApplyToAll` and `Arrayed` expression checking (previously empty match arms)
- Fixed if/else branch mismatch to return a proper error instead of printing to stderr
- Implemented SafeDiv fallback validation (the optional third argument must match `a/b` units)
- Clarified module validation with documentation (handled through inference constraints)

## Design Notes

For arrayed expressions, all elements must have the same units. The implementation processes each element and uses any explicit units found, propagating errors immediately if encountered.

The exponent fix is conservative: rather than attempting fractional exponent math, constraints with |exp| > 1 are left unresolved. This matches the behavior of under-constrained models where some variables lack unit declarations.

## Test Plan

- Added 12 new tests covering all fixed functionality
- All 559 existing tests continue to pass