### PR TITLE
diagram: fix type errors from React 19 and recharts v3 upgrade

### DIFF
--- a/src/diagram/drawing/Canvas.tsx
+++ b/src/diagram/drawing/Canvas.tsx
@@ -165,7 +165,7 @@ export const Canvas = styled(
   class InnerCanvas extends React.PureComponent<CanvasProps & { className?: string }, CanvasState> {
     state: CanvasState;
 
-    readonly svgRef: React.RefObject<HTMLDivElement>;
+    readonly svgRef: React.RefObject<HTMLDivElement | null>;
 
     // XXX: these should all be private, but that doesn't work with styled
     svgObserver: ResizeObserver | undefined;


### PR DESCRIPTION
## Summary
- Fix Canvas.tsx ref type for React 19 compatibility (createRef now returns RefObject<T | null>)
- Fix LookupEditor.tsx to use recharts v3's public hooks API instead of the removed getYScaleByAxisId method

## Details
The React 18 to 19 upgrade changed `createRef()` to return `RefObject<T | null>` by default.

The recharts v2 to v3 upgrade removed the `getYScaleByAxisId()` method from the LineChart ref (which now forwards to SVGSVGElement). The LookupEditor used this to convert pixel coordinates to data values when users drag points on the lookup table chart.

The fix introduces a `ChartLayoutExtractor` wrapper component that uses recharts v3's public hooks (`useOffset`, `useChartHeight`) to extract the actual chart layout dimensions at runtime. This enables robust pixel-to-data coordinate conversion that adapts to responsive container resizing and future recharts updates.

## Test plan
- [x] `yarn build` passes
- [x] All pre-commit checks pass
- [x] Manual testing of lookup editor drag functionality