### PR TITLE
libsimlin: add error categorization and simulatability check

### DIFF
--- a/src/libsimlin/cbindgen.toml
+++ b/src/libsimlin/cbindgen.toml
@@ -18,13 +18,15 @@ include = []
 
 [export]
 # Explicitly include the types we want
-include = ["SimlinErrorCode", "SimlinLoopPolarity", "SimlinLoop", "SimlinLoops", "SimlinProject", "SimlinModel", "SimlinSim", "SimlinError", "SimlinErrorDetail", "SimlinJsonFormat"]
+include = ["SimlinErrorCode", "SimlinErrorKind", "SimlinUnitErrorKind", "SimlinLoopPolarity", "SimlinLoop", "SimlinLoops", "SimlinProject", "SimlinModel", "SimlinSim", "SimlinError", "SimlinErrorDetail", "SimlinJsonFormat"]
 exclude = []
 item_types = ["enums", "structs", "unions", "typedefs", "opaque", "functions"]
 
 [export.rename]
 # Keep type names unchanged
 "SimlinErrorCode" = "SimlinErrorCode"
+"SimlinErrorKind" = "SimlinErrorKind"
+"SimlinUnitErrorKind" = "SimlinUnitErrorKind"
 "SimlinLoopPolarity" = "SimlinLoopPolarity"
 "SimlinLoop" = "SimlinLoop"
 "SimlinLoops" = "SimlinLoops"

--- a/src/libsimlin/src/ffi_error.rs
+++ b/src/libsimlin/src/ffi_error.rs
@@ -1,4 +1,4 @@
-use crate::SimlinErrorCode;
+use crate::{SimlinErrorCode, SimlinErrorKind, SimlinUnitErrorKind};
 use std::ffi::CString;
 use std::os::raw::c_char;
 use std::ptr;
@@ -24,6 +24,8 @@ pub struct ErrorDetail {
     pub variable_name: Option<String>,
     pub start_offset: u16,
     pub end_offset: u16,
+    pub kind: SimlinErrorKind,
+    pub unit_error_kind: SimlinUnitErrorKind,
 }
 
 impl ErrorDetail {
@@ -35,6 +37,8 @@ impl ErrorDetail {
             variable_name: None,
             start_offset: 0,
             end_offset: 0,
+            kind: SimlinErrorKind::default(),
+            unit_error_kind: SimlinUnitErrorKind::default(),
         }
     }
 }
@@ -47,6 +51,8 @@ struct OwnedDetail {
     variable_name: Option<CString>,
     start_offset: u16,
     end_offset: u16,
+    kind: SimlinErrorKind,
+    unit_error_kind: SimlinUnitErrorKind,
 }
 
 impl OwnedDetail {
@@ -58,6 +64,8 @@ impl OwnedDetail {
             variable_name: detail.variable_name.map(sanitize_for_c),
             start_offset: detail.start_offset,
             end_offset: detail.end_offset,
+            kind: detail.kind,
+            unit_error_kind: detail.unit_error_kind,
         }
     }
 
@@ -78,6 +86,8 @@ impl OwnedDetail {
                 .map_or(ptr::null(), |v| v.as_ptr() as *const c_char),
             start_offset: self.start_offset,
             end_offset: self.end_offset,
+            kind: self.kind,
+            unit_error_kind: self.unit_error_kind,
         }
     }
 }


### PR DESCRIPTION
## Summary

- Adds `SimlinErrorKind` enum to categorize errors by origin (Project, Model, Variable, Units, Simulation)
- Adds `SimlinUnitErrorKind` enum to distinguish unit error types (Definition, Consistency, Inference)
- Extends `SimlinErrorDetail` struct with `kind` and `unit_error_kind` fields
- Adds `simlin_project_is_simulatable` function for quick UI checks on whether simulation can run
- Fixes error formatting to properly detect and categorize unit errors based on error codes

## Test plan

- [x] Added tests for all unit error kind variants (Definition, Consistency, Inference)
- [x] Added tests for `simlin_project_is_simulatable` with valid/invalid/null projects
- [x] All 81 libsimlin tests pass
- [x] Pre-commit checks pass (formatting, clippy, tests, AI quality check)