### PR TITLE
Migrate diagram package from engine to engine2 API

### DIFF
--- a/src/app/config/rsbuild/shared.config.js
+++ b/src/app/config/rsbuild/shared.config.js
@@ -137,7 +137,6 @@ const sharedConfig = defineConfig({
           '@': resolveApp('.'),
           '@system-dynamics/core': resolveApp('../core'),
           '@system-dynamics/diagram': resolveApp('../diagram'),
-          '@system-dynamics/engine': resolveApp('../engine'),
           '@system-dynamics/engine2': resolveApp('../engine2'),
           '@system-dynamics/xmutil': resolveApp('../xmutil-js'),
         },

--- a/src/diagram/ErrorDetails.tsx
+++ b/src/diagram/ErrorDetails.tsx
@@ -10,7 +10,7 @@ import { Card, CardContent, Typography } from '@mui/material';
 import { styled } from '@mui/material/styles';
 
 import { SimError, ModelError, EquationError, ErrorCode, UnitError } from '@system-dynamics/core/datamodel';
-import { errorCodeDescription } from '@system-dynamics/engine';
+import { errorCodeDescription } from '@system-dynamics/engine2';
 
 const SearchbarWidthSm = 359;
 const SearchbarWidthMd = 420;

--- a/src/diagram/VariableDetails.tsx
+++ b/src/diagram/VariableDetails.tsx
@@ -31,7 +31,7 @@ import { defined, Series } from '@system-dynamics/core/common';
 import { plainDeserialize, plainSerialize } from './drawing/common';
 import { CustomElement, FormattedText, CustomEditor } from './drawing/SlateEditor';
 import { LookupEditor } from './LookupEditor';
-import { errorCodeDescription } from '@system-dynamics/engine';
+import { errorCodeDescription } from '@system-dynamics/engine2';
 
 const SearchbarWidthSm = 359;
 const SearchbarWidthMd = 420;

--- a/src/diagram/package.json
+++ b/src/diagram/package.json
@@ -24,7 +24,6 @@
     "@emotion/styled": "^11.0.0",
     "@mui/material": "^5.0.0",
     "@system-dynamics/core": "^1.3.5",
-    "@system-dynamics/engine": "^1.3.1",
     "@system-dynamics/engine2": "^2.0.0",
     "chroma-js": "^3.1.2",
     "google-protobuf": "^4.0.0",

--- a/src/diagram/view-conversion.ts
+++ b/src/diagram/view-conversion.ts
@@ -1,0 +1,160 @@
+// Copyright 2025 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import type { JsonView, JsonViewElement, JsonRect, JsonFlowPoint, JsonLinkPoint } from '@system-dynamics/engine2';
+
+import {
+  ViewElement,
+  StockViewElement,
+  FlowViewElement,
+  AuxViewElement,
+  CloudViewElement,
+  LinkViewElement,
+  ModuleViewElement,
+  AliasViewElement,
+  StockFlowView,
+  Rect,
+  Point,
+} from '@system-dynamics/core/datamodel';
+
+function rectToJson(rect: Rect): JsonRect {
+  return {
+    x: rect.x,
+    y: rect.y,
+    width: rect.width,
+    height: rect.height,
+  };
+}
+
+function pointToFlowPoint(point: Point): JsonFlowPoint {
+  return {
+    x: point.x,
+    y: point.y,
+    attached_to_uid: point.attachedToUid,
+  };
+}
+
+function pointToLinkPoint(point: Point): JsonLinkPoint {
+  return {
+    x: point.x,
+    y: point.y,
+  };
+}
+
+function elementToJson(element: ViewElement): JsonViewElement | null {
+  if (element instanceof StockViewElement) {
+    return {
+      type: 'stock',
+      uid: element.uid,
+      name: element.name,
+      x: element.x,
+      y: element.y,
+      label_side: element.labelSide,
+    };
+  }
+
+  if (element instanceof FlowViewElement) {
+    return {
+      type: 'flow',
+      uid: element.uid,
+      name: element.name,
+      x: element.x,
+      y: element.y,
+      points: element.points.map(pointToFlowPoint).toArray(),
+      label_side: element.labelSide,
+    };
+  }
+
+  if (element instanceof AuxViewElement) {
+    return {
+      type: 'aux',
+      uid: element.uid,
+      name: element.name,
+      x: element.x,
+      y: element.y,
+      label_side: element.labelSide,
+    };
+  }
+
+  if (element instanceof CloudViewElement) {
+    return {
+      type: 'cloud',
+      uid: element.uid,
+      flow_uid: element.flowUid,
+      x: element.x,
+      y: element.y,
+    };
+  }
+
+  if (element instanceof LinkViewElement) {
+    const result: JsonViewElement = {
+      type: 'link',
+      uid: element.uid,
+      from_uid: element.fromUid,
+      to_uid: element.toUid,
+    };
+
+    if (element.arc !== undefined) {
+      (result as any).arc = element.arc;
+    }
+
+    if (element.multiPoint) {
+      (result as any).multi_points = element.multiPoint.map(pointToLinkPoint).toArray();
+    }
+
+    return result;
+  }
+
+  if (element instanceof ModuleViewElement) {
+    return {
+      type: 'module',
+      uid: element.uid,
+      name: element.name,
+      x: element.x,
+      y: element.y,
+      label_side: element.labelSide,
+    };
+  }
+
+  if (element instanceof AliasViewElement) {
+    return {
+      type: 'alias',
+      uid: element.uid,
+      alias_of_uid: element.aliasOfUid,
+      x: element.x,
+      y: element.y,
+      label_side: element.labelSide,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Convert a StockFlowView (datamodel) to a JsonView (engine2).
+ */
+export function stockFlowViewToJson(view: StockFlowView): JsonView {
+  const elements: JsonViewElement[] = [];
+
+  for (const element of view.elements) {
+    const jsonElement = elementToJson(element);
+    if (jsonElement) {
+      elements.push(jsonElement);
+    }
+  }
+
+  const result: JsonView = {
+    elements,
+  };
+
+  if (view.viewBox && view.viewBox.width > 0 && view.viewBox.height > 0) {
+    result.view_box = rectToJson(view.viewBox);
+  }
+
+  if (view.zoom > 0) {
+    result.zoom = view.zoom;
+  }
+
+  return result;
+}

--- a/src/engine2/src/errors.ts
+++ b/src/engine2/src/errors.ts
@@ -1,0 +1,115 @@
+// Copyright 2025 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import { ErrorCode } from '@system-dynamics/core/datamodel';
+
+export { ErrorCode };
+
+export function errorCodeDescription(code: ErrorCode): string {
+  switch (code) {
+    case ErrorCode.NoError:
+      return 'Internal error';
+    case ErrorCode.DoesNotExist:
+      return 'Does not exist';
+    case ErrorCode.XmlDeserialization:
+      return 'XML deserialization error';
+    case ErrorCode.VensimConversion:
+      return 'Vensim conversion error';
+    case ErrorCode.ProtobufDecode:
+      return 'Internal error (protocol buffer decoding)';
+    case ErrorCode.InvalidToken:
+      return 'Invalid input in equation';
+    case ErrorCode.UnrecognizedEof:
+      return 'Unexpectedly reached the end of the equation';
+    case ErrorCode.UnrecognizedToken:
+      return 'Unrecognized input in equation';
+    case ErrorCode.ExtraToken:
+      return 'Extra input after equation fully parsed';
+    case ErrorCode.UnclosedComment:
+      return 'Unclosed comment';
+    case ErrorCode.UnclosedQuotedIdent:
+      return 'Unclosed quoted identifier';
+    case ErrorCode.ExpectedNumber:
+      return 'Expected a literal number';
+    case ErrorCode.UnknownBuiltin:
+      return 'Reference to unknown or unimplemented builtin';
+    case ErrorCode.BadBuiltinArgs:
+      return 'Incorrect arguments to a builtin function (e.g. too many, too few)';
+    case ErrorCode.EmptyEquation:
+      return 'Variable has empty equation';
+    case ErrorCode.BadModuleInputDst:
+      return 'Module input destination is unknown';
+    case ErrorCode.BadModuleInputSrc:
+      return 'Module input source is unknown';
+    case ErrorCode.NotSimulatable:
+      return 'Model has errors and is not simulatable';
+    case ErrorCode.BadTable:
+      return 'No graphical function for specified variable';
+    case ErrorCode.BadSimSpecs:
+      return 'Simulation Specs are not valid';
+    case ErrorCode.NoAbsoluteReferences:
+      return 'Absolute references are not supported';
+    case ErrorCode.CircularDependency:
+      return 'Circular dependency';
+    case ErrorCode.ArraysNotImplemented:
+      return 'Arrays not implemented';
+    case ErrorCode.MultiDimensionalArraysNotImplemented:
+      return 'Multi-dimensional arrays not implemented';
+    case ErrorCode.BadDimensionName:
+      return 'Unknown dimension name';
+    case ErrorCode.BadModelName:
+      return 'Unknown model name';
+    case ErrorCode.MismatchedDimensions:
+      return 'Mismatched dimensions';
+    case ErrorCode.ArrayReferenceNeedsExplicitSubscripts:
+      return 'Array reference needs explicit subscripts';
+    case ErrorCode.DuplicateVariable:
+      return 'Duplicate variable';
+    case ErrorCode.UnknownDependency:
+      return 'Equation refers to unknown variable';
+    case ErrorCode.VariablesHaveErrors:
+      return 'Variables have equation errors';
+    case ErrorCode.UnitDefinitionErrors:
+      return "The project's unit definitions have errors";
+    case ErrorCode.Generic:
+      return 'Generic error from core engine';
+    case ErrorCode.NoAppInUnits:
+      return 'Function calls are not allowed in unit definition';
+    case ErrorCode.NoSubscriptInUnits:
+      return 'Subscripts are not allowed in unit definition';
+    case ErrorCode.NoIfInUnits:
+      return 'If statements are not allowed in unit definition';
+    case ErrorCode.NoUnaryOpInUnits:
+      return "Negative units like `-people` don't make sense. Try e.g. `1/people`";
+    case ErrorCode.BadBinaryOpInUnits:
+      return 'Only * and / operations are supported in unit definitions';
+    case ErrorCode.NoConstInUnits:
+      return 'Constants are not supported in unit definitions';
+    case ErrorCode.ExpectedInteger:
+      return 'Expected an integer';
+    case ErrorCode.ExpectedIntegerOne:
+      return 'Expected the integer `1`';
+    case ErrorCode.DuplicateUnit:
+      return 'Duplicate unit definition';
+    case ErrorCode.ExpectedModule:
+      return 'Expected a module, found a non-module';
+    case ErrorCode.ExpectedIdent:
+      return 'Expected an identifier';
+    case ErrorCode.UnitMismatch:
+      return 'Unit mismatch';
+    case ErrorCode.TodoWildcard:
+      return 'Wildcard subscripts not yet implemented';
+    case ErrorCode.TodoStarRange:
+      return 'Star range subscripts not yet implemented';
+    case ErrorCode.TodoRange:
+      return 'Range subscripts not yet implemented';
+    case ErrorCode.TodoArrayBuiltin:
+      return 'Array builtin not yet implemented';
+    case ErrorCode.CantSubscriptScalar:
+      return 'Cannot subscript a scalar variable';
+    case ErrorCode.DimensionInScalarContext:
+      return 'Dimension used in scalar context';
+  }
+  return 'Unknown error from core engine';
+}

--- a/src/engine2/src/index.ts
+++ b/src/engine2/src/index.ts
@@ -38,9 +38,16 @@ export { Sim } from './sim';
 export { Run } from './run';
 export { ModelPatchBuilder } from './patch';
 
+// Error utilities
+export { errorCodeDescription, ErrorCode } from './errors';
+
 // High-level types
 export * from './types';
 export * from './json-types';
+
+// Internal types needed for error handling
+export type { ErrorDetail } from './internal/types';
+export { SimlinErrorKind, SimlinUnitErrorKind } from './internal/types';
 
 // Optional WASM configuration for advanced use cases
 export {

--- a/src/engine2/src/model.ts
+++ b/src/engine2/src/model.ts
@@ -15,6 +15,7 @@ import {
   simlin_model_unref,
   simlin_model_get_incoming_links,
   simlin_model_get_links,
+  simlin_model_get_latex_equation,
 } from './internal/model';
 import { readLinks, simlin_free_links } from './internal/analysis';
 import { SimlinModelPtr, SimlinLinkPolarity, Link as LowLevelLink } from './internal/types';
@@ -424,6 +425,16 @@ export class Model {
     }
 
     throw new Error(`Variable '${variable}' not found in model`);
+  }
+
+  /**
+   * Get the LaTeX representation of a variable's equation.
+   * @param ident Variable identifier
+   * @returns LaTeX string, or null if not found
+   */
+  getLatexEquation(ident: string): string | null {
+    this.checkDisposed();
+    return simlin_model_get_latex_equation(this._ptr, ident);
   }
 
   /**


### PR DESCRIPTION
## Summary

- Replace the old `@system-dynamics/engine` WASM wrapper with the modern `@system-dynamics/engine2` TypeScript API throughout the diagram package
- Add `getLatexEquation()` method to engine2 Model class
- Export `errorCodeDescription`, `ErrorCode`, `ErrorDetail`, `SimlinErrorKind`, and `SimlinUnitErrorKind` from engine2
- Create `view-conversion.ts` utility to convert datamodel ViewElement types to engine2 JSON types for patch operations
- Remove `@system-dynamics/engine` dependency from diagram/package.json
- Remove engine alias from app build configuration

## Test plan

- [x] `yarn tsc` - TypeScript type checking passes
- [x] `yarn lint` - Linting passes
- [x] `cargo test` - Rust tests pass
- [x] Engine2 tests pass
- [x] Pysimlin tests pass
- [x] No remaining references to old engine in src/app or src/diagram
- [ ] Manual testing: Create/edit/delete variables in the diagram editor
- [ ] Manual testing: Run simulations and verify results display correctly
- [ ] Manual testing: Verify error display for invalid equations