### PR TITLE
Fix malformed XML in non-negative flows test

### DIFF
--- a/test/test-models/tests/arithmetics_exp/test_arithmetics_exp.xmile
+++ b/test/test-models/tests/arithmetics_exp/test_arithmetics_exp.xmile
@@ -1,121 +1,208 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<xmile version="1.0" xmlns="http://docs.oasis-open.org/xmile/ns/XMILE/v1.0">
-	<header>
-		<product version="1.0" lang="en">Vensim</product>
-		<vendor>Ventana Systems, Inc.</vendor>
-		<created>
-		</created>
-		<modified>
-		</modified>
-		<name>
-		</name>
-		<caption>
-		</caption>
-	</header>
-	<sim_specs method="RK4" time_units="Month">
-		<start>1</start>
-		<stop>10</stop>
-		<dt>0.1</dt>
-	</sim_specs>
-	<dimensions>
-		<dim name="subs">
-			<elem name="sub1" />
-			<elem name="sub2" />
-			<elem name="sub3" />
-			<elem name="sub4" />
-			<elem name="sub5" />
-			<elem name="sub6" />
-			<elem name="sub7" />
-			<elem name="sub8" />
-			<elem name="sub9" />
-		</dim>
-	</dimensions>
-	<model>
-		<variables>
-			<aux name="add substract">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="subs" />
-				</dimensions>
-					<eqn>cons-time2+time3-cons					</eqn>
-					<eqn>-cons - time2 + time3 - cons					</eqn>
-					<eqn>-(cons-time2+time3-cons)					</eqn>
-					<eqn>-(-cons -time2+ time3-cons)					</eqn>
-					<eqn>-(0.01- time2)+(time3-cons)					</eqn>
-					<eqn>-(cons- time2)- (time3-cons)					</eqn>
-					<eqn>-(cons-    time2)+(time3-cons)					</eqn>
-					<eqn>(cons-time2)-    (time3-cons)					</eqn>
-					<eqn>(0.01-time2)   +(time3-cons)					</eqn>
-			</aux>
-			<aux name="combined">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="subs" />
-				</dimensions>
-					<eqn>(0.01/time2)+(time3 /cons)					</eqn>
-					<eqn>-(cons/ time2+time3/cons)					</eqn>
-					<eqn>-cons/(time2^(2+cons)-time3/cons)					</eqn>
-					<eqn>1/(-cons+3/time2*time3/(cons-Time))					</eqn>
-					<eqn>-(0.01/ time2)*(time3/cons)					</eqn>
-					<eqn>-(+0.012/time2)+(cons/  time2)/(time3/cons)					</eqn>
-					<eqn>((+0.012 +cons-Time) / time2)/(  time3/cons)					</eqn>
-					<eqn>(-0.012 +cons- Time / time2)/(time3/cons)					</eqn>
-					<eqn>(120/time2-120)*(time3/(cons-120))					</eqn>
-			</aux>
-			<aux name="expo">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="subs" />
-				</dimensions>
-					<eqn>30 ^cons					</eqn>
-					<eqn>30^ cons ^ cons					</eqn>
-					<eqn>cons^(   cons^  0.003)					</eqn>
-					<eqn>(cons    ^cons)   ^30					</eqn>
-					<eqn>- Time ^ 30					</eqn>
-					<eqn>30^ - 30^-cons					</eqn>
-					<eqn>(-Time)^ 30					</eqn>
-					<eqn>Time ^ (-30  )					</eqn>
-					<eqn>Time^-0.03					</eqn>
-			</aux>
-			<aux name="product">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="subs" />
-				</dimensions>
-					<eqn>cons/ time2*time3/0.03					</eqn>
-					<eqn>-cons/time2*time3 /0.03					</eqn>
-					<eqn>-(cons/time2 *time3/0.03)					</eqn>
-					<eqn>1/(-cons/time2*time3/0.03)					</eqn>
-					<eqn>-(cons/ time2)*(time3/0.03)					</eqn>
-					<eqn>-(cons/time2)/ (time3/0.13)					</eqn>
-					<eqn>-(cons/time2)*(time3/0.13)					</eqn>
-					<eqn>(cons/time2) /(time3/0.13)					</eqn>
-					<eqn>(cons /time2 )*(time3/0.13)					</eqn>
-			</aux>
-			<aux name="time1">
-				<units></units>
-				<doc></doc>
-					<eqn>-Time					</eqn>
-			</aux>
-			<aux name="time2">
-				<units></units>
-				<doc></doc>
-					<eqn>2*Time					</eqn>
-			</aux>
-			<aux name="time3">
-				<units></units>
-				<doc></doc>
-					<eqn>3*Time					</eqn>
-			</aux>
-			<aux name="cons">
-				<units></units>
-				<doc></doc>
-					<eqn>1.2					</eqn>
-			</aux>
-		</variables>
-	</model>
+<?xml version="1.0" encoding="utf-8"?>
+<xmile version="1.0" xmlns="http://docs.oasis-open.org/xmile/ns/XMILE/v1.0" xmlns:isee="http://iseesystems.com/XMILE" xmlns:simlin="https://simlin.com/XMILE/v1.0">
+    <header>
+        <vendor>Simlin</vendor>
+        <product version="0.1.0" lang="en">Simlin</product>
+    </header>
+    <sim_specs method="euler" time_units="Month">
+        <start>1</start>
+        <stop>10</stop>
+        <dt>0.1</dt>
+    </sim_specs>
+    <dimensions>
+        <dim name="subs">
+            <elem name="sub1"></elem>
+            <elem name="sub2"></elem>
+            <elem name="sub3"></elem>
+            <elem name="sub4"></elem>
+            <elem name="sub5"></elem>
+            <elem name="sub6"></elem>
+            <elem name="sub7"></elem>
+            <elem name="sub8"></elem>
+            <elem name="sub9"></elem>
+        </dim>
+    </dimensions>
+    <model>
+        <variables>
+            <aux name="add substract">
+                <dimensions>
+                    <dim name="subs"></dim>
+                </dimensions>
+                <element subscript="sub1">
+                    <eqn>cons-time2+time3-cons</eqn>
+                </element>
+                <element subscript="sub2">
+                    <eqn>-cons-time2+time3-cons</eqn>
+                </element>
+                <element subscript="sub3">
+                    <eqn>-(cons-time2+time3-cons)</eqn>
+                </element>
+                <element subscript="sub4">
+                    <eqn>-(-cons-time2+time3-cons)</eqn>
+                </element>
+                <element subscript="sub5">
+                    <eqn>-(0.01-time2)+(time3-cons)</eqn>
+                </element>
+                <element subscript="sub6">
+                    <eqn>-(cons-time2)-(time3-cons)</eqn>
+                </element>
+                <element subscript="sub7">
+                    <eqn>-(cons-time2)+(time3-cons)</eqn>
+                </element>
+                <element subscript="sub8">
+                    <eqn>(cons-time2)-(time3-cons)</eqn>
+                </element>
+                <element subscript="sub9">
+                    <eqn>(0.01-time2)+(time3-cons)</eqn>
+                </element>
+            </aux>
+            <aux name="combined">
+                <dimensions>
+                    <dim name="subs"></dim>
+                </dimensions>
+                <element subscript="sub1">
+                    <eqn>(0.01/time2)+(time3/cons)</eqn>
+                </element>
+                <element subscript="sub2">
+                    <eqn>-(cons/time2+time3/cons)</eqn>
+                </element>
+                <element subscript="sub3">
+                    <eqn>-cons/(time2^(2+cons)-time3/cons)</eqn>
+                </element>
+                <element subscript="sub4">
+                    <eqn>1/(-cons+3/time2*time3/(cons-Time))</eqn>
+                </element>
+                <element subscript="sub5">
+                    <eqn>-(0.01/time2)*(time3/cons)</eqn>
+                </element>
+                <element subscript="sub6">
+                    <eqn>-(+0.012/time2)+(cons/time2)/(time3/cons)</eqn>
+                </element>
+                <element subscript="sub7">
+                    <eqn>((0.012+cons-Time)/time2)/(time3/cons)</eqn>
+                </element>
+                <element subscript="sub8">
+                    <eqn>(-0.012+cons-Time/time2)/(time3/cons)</eqn>
+                </element>
+                <element subscript="sub9">
+                    <eqn>(120/time2-120)*(time3/(cons-120))</eqn>
+                </element>
+            </aux>
+            <aux name="cons">
+                <eqn>1.2</eqn>
+            </aux>
+            <aux name="expo">
+                <dimensions>
+                    <dim name="subs"></dim>
+                </dimensions>
+                <element subscript="sub1">
+                    <eqn>30^cons</eqn>
+                </element>
+                <element subscript="sub2">
+                    <eqn>30^cons^cons</eqn>
+                </element>
+                <element subscript="sub3">
+                    <eqn>cons^(cons^0.003)</eqn>
+                </element>
+                <element subscript="sub4">
+                    <eqn>(cons^cons)^30</eqn>
+                </element>
+                <element subscript="sub5">
+                    <eqn>-Time^30</eqn>
+                </element>
+                <element subscript="sub6">
+                    <eqn>30^-30^-cons</eqn>
+                </element>
+                <element subscript="sub7">
+                    <eqn>(-Time)^30</eqn>
+                </element>
+                <element subscript="sub8">
+                    <eqn>Time^(-30)</eqn>
+                </element>
+                <element subscript="sub9">
+                    <eqn>Time^-0.03</eqn>
+                </element>
+            </aux>
+            <aux name="product">
+                <dimensions>
+                    <dim name="subs"></dim>
+                </dimensions>
+                <element subscript="sub1">
+                    <eqn>cons/time2*time3/0.03</eqn>
+                </element>
+                <element subscript="sub2">
+                    <eqn>-cons/time2*time3/0.03</eqn>
+                </element>
+                <element subscript="sub3">
+                    <eqn>-(cons/time2*time3/0.03)</eqn>
+                </element>
+                <element subscript="sub4">
+                    <eqn>1/(-cons/time2*time3/0.03)</eqn>
+                </element>
+                <element subscript="sub5">
+                    <eqn>-(cons/time2)*(time3/0.03)</eqn>
+                </element>
+                <element subscript="sub6">
+                    <eqn>-(cons/time2)/(time3/0.13)</eqn>
+                </element>
+                <element subscript="sub7">
+                    <eqn>-(cons/time2)*(time3/0.13)</eqn>
+                </element>
+                <element subscript="sub8">
+                    <eqn>(cons/time2)/(time3/0.13)</eqn>
+                </element>
+                <element subscript="sub9">
+                    <eqn>(cons/time2)*(time3/0.13)</eqn>
+                </element>
+            </aux>
+            <aux name="time1">
+                <eqn>-Time</eqn>
+            </aux>
+            <aux name="time2">
+                <eqn>2*Time</eqn>
+            </aux>
+            <aux name="time3">
+                <eqn>3*Time</eqn>
+            </aux>
+        </variables>
+        <views>
+            <view isee:show_pages="false" page_width="800" page_height="600" view_type="stock_flow">
+                <aux name="cons" x="215" y="317" label_side="bottom"></aux>
+                <aux name="time1" x="206" y="406" label_side="bottom"></aux>
+                <aux name="time2" x="198" y="511" label_side="bottom"></aux>
+                <aux name="time3" x="197" y="579" label_side="bottom"></aux>
+                <aux name="expo" x="464" y="120" label_side="bottom"></aux>
+                <connector angle="39.28155998183638">
+                    <from>cons</from>
+                    <to>expo</to>
+                </connector>
+                <aux name="add_substract" x="502" y="257" label_side="bottom"></aux>
+                <connector angle="40.18418052400432">
+                    <from>time2</from>
+                    <to>add_substract</to>
+                </connector>
+                <connector angle="46.88001411451546">
+                    <from>time3</from>
+                    <to>add_substract</to>
+                </connector>
+                <aux name="product" x="500" y="388" label_side="bottom"></aux>
+                <connector angle="22.147318043836435">
+                    <from>time2</from>
+                    <to>product</to>
+                </connector>
+                <connector angle="32.54970933084218">
+                    <from>time3</from>
+                    <to>product</to>
+                </connector>
+                <connector angle="12.647035748820144">
+                    <from>cons</from>
+                    <to>add_substract</to>
+                </connector>
+                <connector angle="-13.493332938974447">
+                    <from>cons</from>
+                    <to>product</to>
+                </connector>
+            </view>
+        </views>
+    </model>
 </xmile>

--- a/test/test-models/tests/non_negative_flows/test_non_negative_flows.xmile
+++ b/test/test-models/tests/non_negative_flows/test_non_negative_flows.xmile
@@ -34,6 +34,7 @@
             <flow name="if_else3">
                 <eqn>IF Time &gt; 10 THEN Time ELSE -Time</eqn>
                 <non_negative>FALSE  </non_negative>
+            </flow>
             <stock name="TestStock2">
                 <inflow>if_else2</inflow>
                 <eqn>10</eqn>

--- a/test/test-models/tests/non_negative_flows/test_non_negative_flows_behavior.xmile
+++ b/test/test-models/tests/non_negative_flows/test_non_negative_flows_behavior.xmile
@@ -38,6 +38,7 @@
             <flow name="if_else3">
                 <eqn>IF Time &gt; 10 THEN Time ELSE -Time</eqn>
                 <non_negative>FALSE  </non_negative>
+            </flow>
             <stock name="TestStock2">
                 <inflow>if_else2</inflow>
                 <eqn>10</eqn>

--- a/test/test-models/tests/subscripted_trig/test_subscripted_trig.xmile
+++ b/test/test-models/tests/subscripted_trig/test_subscripted_trig.xmile
@@ -1,363 +1,311 @@
-<?xml version="1.0" encoding="utf-8" ?>
-<xmile version="1.0" xmlns="http://docs.oasis-open.org/xmile/ns/XMILE/v1.0">
-	<header>
-		<product version="1.0" lang="en">Vensim</product>
-		<vendor>Ventana Systems, Inc.</vendor>
-		<created>
-		</created>
-		<modified>
-		</modified>
-		<name>
-		</name>
-		<caption>
-		</caption>
-	</header>
-	<sim_specs method="RK4" time_units="Month">
-		<start>0</start>
-		<stop>10</stop>
-		<dt>1</dt>
-	</sim_specs>
-	<dimensions>
-		<dim name="sub1">
-			<elem name="A" />
-			<elem name="B" />
-			<elem name="C" />
-		</dim>
-		<dim name="sub2">
-			<elem name="D" />
-			<elem name="E" />
-		</dim>
-	</dimensions>
-	<model>
-		<variables>
-			<aux name="sabs1">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				</dimensions>
-					<eqn>ABS(var1[sub1])					</eqn>
-			</aux>
-			<aux name="sabs2">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>ABS(var2[sub1,sub2])					</eqn>
-			</aux>
-			<aux name="sabs3">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>ABS(var3[sub2])					</eqn>
-			</aux>
-			<aux name="sarccos1">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				</dimensions>
-					<eqn>ARCCOS(var1[sub1])					</eqn>
-			</aux>
-			<aux name="sarccos2">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>ARCCOS(var2[sub1,sub2])					</eqn>
-			</aux>
-			<aux name="sarccos3">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>ARCCOS(var3[sub2])					</eqn>
-			</aux>
-			<aux name="sarcsin1">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				</dimensions>
-					<eqn>ARCSIN(var1[sub1])					</eqn>
-			</aux>
-			<aux name="sarcsin2">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>ARCSIN(var2[sub1,sub2])					</eqn>
-			</aux>
-			<aux name="sarcsin3">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>ARCSIN(var3[sub2])					</eqn>
-			</aux>
-			<aux name="sarctan1">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				</dimensions>
-					<eqn>ARCTAN(var1[sub1])					</eqn>
-			</aux>
-			<aux name="sarctan2">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>ARCTAN(var2[sub1,sub2])					</eqn>
-			</aux>
-			<aux name="sarctan3">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>ARCTAN(var3[sub2])					</eqn>
-			</aux>
-			<aux name="scos1">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				</dimensions>
-					<eqn>COS(var1[sub1])					</eqn>
-			</aux>
-			<aux name="scos2">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>COS(var2[sub1,sub2])					</eqn>
-			</aux>
-			<aux name="scos3">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>COS(var3[sub2])					</eqn>
-			</aux>
-			<aux name="scosh1">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				</dimensions>
-					<eqn>COSH(var1[sub1])					</eqn>
-			</aux>
-			<aux name="scosh2">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>COSH(var2[sub1,sub2])					</eqn>
-			</aux>
-			<aux name="scosh3">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>COSH(var3[sub2])					</eqn>
-			</aux>
-			<aux name="sexp1">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				</dimensions>
-					<eqn>EXP(var1[sub1])					</eqn>
-			</aux>
-			<aux name="sexp2">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>EXP(var2[sub1,sub2])					</eqn>
-			</aux>
-			<aux name="sexp3">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>EXP(var3[sub2])					</eqn>
-			</aux>
-			<aux name="sln1">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				</dimensions>
-					<eqn>LN(ABS(var1[sub1]))					</eqn>
-			</aux>
-			<aux name="sln2">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>LN(ABS(var2[sub1,sub2]))					</eqn>
-			</aux>
-			<aux name="sln3">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>LN(ABS(var3[sub2]))					</eqn>
-			</aux>
-			<aux name="ssin1">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				</dimensions>
-					<eqn>SIN(var1[sub1])					</eqn>
-			</aux>
-			<aux name="ssin2">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>SIN(var2[sub1,sub2])					</eqn>
-			</aux>
-			<aux name="ssin3">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>SIN(var3[sub2])					</eqn>
-			</aux>
-			<aux name="ssinh1">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				</dimensions>
-					<eqn>SINH(var1[sub1])					</eqn>
-			</aux>
-			<aux name="ssinh2">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>SINH(var2[sub1,sub2])					</eqn>
-			</aux>
-			<aux name="ssinh3">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>SINH(var3[sub2])					</eqn>
-			</aux>
-			<aux name="stan1">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				</dimensions>
-					<eqn>TAN(var1[sub1])					</eqn>
-			</aux>
-			<aux name="stan2">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>TAN(var2[sub1,sub2])					</eqn>
-			</aux>
-			<aux name="stan3">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>TAN(var3[sub2])					</eqn>
-			</aux>
-			<aux name="stanh1">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				</dimensions>
-					<eqn>TANH(var1[sub1])					</eqn>
-			</aux>
-			<aux name="stanh2">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>TANH(var2[sub1,sub2])					</eqn>
-			</aux>
-			<aux name="stanh3">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>TANH(var3[sub2])					</eqn>
-			</aux>
-			<aux name="var3">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>(Time+1)/15					</eqn>
-					<eqn>-0.2-Time/20					</eqn>
-			</aux>
-			<aux name="var1">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				</dimensions>
-					<eqn>0.1,0.3,0.8					</eqn>
-			</aux>
-			<aux name="var2">
-				<units></units>
-				<doc></doc>
-				<dimensions>
-				<dim name="sub1" />
-				<dim name="sub2" />
-				</dimensions>
-					<eqn>0.1,0.2;
-	0.4,0.5;
-	0.6,0.7;					</eqn>
-			</aux>
-		</variables>
-	</model>
+<?xml version="1.0" encoding="utf-8"?>
+<xmile version="1.0" xmlns="http://docs.oasis-open.org/xmile/ns/XMILE/v1.0" xmlns:isee="http://iseesystems.com/XMILE" xmlns:simlin="https://simlin.com/XMILE/v1.0">
+    <header>
+        <vendor>Simlin</vendor>
+        <product version="0.1.0" lang="en">Simlin</product>
+    </header>
+    <sim_specs method="euler" time_units="Month">
+        <start>0</start>
+        <stop>10</stop>
+        <dt>1</dt>
+    </sim_specs>
+    <dimensions>
+        <dim name="sub2">
+            <elem name="d"></elem>
+            <elem name="e"></elem>
+        </dim>
+        <dim name="sub1">
+            <elem name="a"></elem>
+            <elem name="b"></elem>
+            <elem name="c"></elem>
+        </dim>
+    </dimensions>
+    <model>
+        <variables>
+            <aux name="sabs1">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                </dimensions>
+                <eqn>ABS(var1[sub1])</eqn>
+            </aux>
+            <aux name="sabs2">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>ABS(var2[sub1, sub2])</eqn>
+            </aux>
+            <aux name="sabs3">
+                <dimensions>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>ABS(var3[sub2])</eqn>
+            </aux>
+            <aux name="sarccos1">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                </dimensions>
+                <eqn>ARCCOS(var1[sub1])</eqn>
+            </aux>
+            <aux name="sarccos2">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>ARCCOS(var2[sub1, sub2])</eqn>
+            </aux>
+            <aux name="sarccos3">
+                <dimensions>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>ARCCOS(var3[sub2])</eqn>
+            </aux>
+            <aux name="sarcsin1">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                </dimensions>
+                <eqn>ARCSIN(var1[sub1])</eqn>
+            </aux>
+            <aux name="sarcsin2">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>ARCSIN(var2[sub1, sub2])</eqn>
+            </aux>
+            <aux name="sarcsin3">
+                <dimensions>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>ARCSIN(var3[sub2])</eqn>
+            </aux>
+            <aux name="sarctan1">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                </dimensions>
+                <eqn>ARCTAN(var1[sub1])</eqn>
+            </aux>
+            <aux name="sarctan2">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>ARCTAN(var2[sub1, sub2])</eqn>
+            </aux>
+            <aux name="sarctan3">
+                <dimensions>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>ARCTAN(var3[sub2])</eqn>
+            </aux>
+            <aux name="scos1">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                </dimensions>
+                <eqn>COS(var1[sub1])</eqn>
+            </aux>
+            <aux name="scos2">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>COS(var2[sub1, sub2])</eqn>
+            </aux>
+            <aux name="scos3">
+                <dimensions>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>COS(var3[sub2])</eqn>
+            </aux>
+            <aux name="scosh1">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                </dimensions>
+                <eqn>LOOKUP(COSH, var1[sub1])</eqn>
+            </aux>
+            <aux name="scosh2">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>LOOKUP(COSH, var2[sub1, sub2])</eqn>
+            </aux>
+            <aux name="scosh3">
+                <dimensions>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>LOOKUP(COSH, var3[sub2])</eqn>
+            </aux>
+            <aux name="sexp1">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                </dimensions>
+                <eqn>EXP(var1[sub1])</eqn>
+            </aux>
+            <aux name="sexp2">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>EXP(var2[sub1, sub2])</eqn>
+            </aux>
+            <aux name="sexp3">
+                <dimensions>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>EXP(var3[sub2])</eqn>
+            </aux>
+            <aux name="sln1">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                </dimensions>
+                <eqn>LN(ABS(var1[sub1]))</eqn>
+            </aux>
+            <aux name="sln2">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>LN(ABS(var2[sub1, sub2]))</eqn>
+            </aux>
+            <aux name="sln3">
+                <dimensions>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>LN(ABS(var3[sub2]))</eqn>
+            </aux>
+            <aux name="ssin1">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                </dimensions>
+                <eqn>SIN(var1[sub1])</eqn>
+            </aux>
+            <aux name="ssin2">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>SIN(var2[sub1, sub2])</eqn>
+            </aux>
+            <aux name="ssin3">
+                <dimensions>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>SIN(var3[sub2])</eqn>
+            </aux>
+            <aux name="ssinh1">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                </dimensions>
+                <eqn>LOOKUP(SINH, var1[sub1])</eqn>
+            </aux>
+            <aux name="ssinh2">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>LOOKUP(SINH, var2[sub1, sub2])</eqn>
+            </aux>
+            <aux name="ssinh3">
+                <dimensions>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>LOOKUP(SINH, var3[sub2])</eqn>
+            </aux>
+            <aux name="stan1">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                </dimensions>
+                <eqn>TAN(var1[sub1])</eqn>
+            </aux>
+            <aux name="stan2">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>TAN(var2[sub1, sub2])</eqn>
+            </aux>
+            <aux name="stan3">
+                <dimensions>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>TAN(var3[sub2])</eqn>
+            </aux>
+            <aux name="stanh1">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                </dimensions>
+                <eqn>LOOKUP(TANH, var1[sub1])</eqn>
+            </aux>
+            <aux name="stanh2">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>LOOKUP(TANH, var2[sub1, sub2])</eqn>
+            </aux>
+            <aux name="stanh3">
+                <dimensions>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <eqn>LOOKUP(TANH, var3[sub2])</eqn>
+            </aux>
+            <aux name="var1">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                </dimensions>
+                <element subscript="a">
+                    <eqn>0.1</eqn>
+                </element>
+                <element subscript="b">
+                    <eqn>0.3</eqn>
+                </element>
+                <element subscript="c">
+                    <eqn>0.8</eqn>
+                </element>
+            </aux>
+            <aux name="var2">
+                <dimensions>
+                    <dim name="sub1"></dim>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <element subscript="a,d">
+                    <eqn>0.1</eqn>
+                </element>
+                <element subscript="a,e">
+                    <eqn>0.2</eqn>
+                </element>
+                <element subscript="b,d">
+                    <eqn>0.4</eqn>
+                </element>
+                <element subscript="b,e">
+                    <eqn>0.5</eqn>
+                </element>
+                <element subscript="c,d">
+                    <eqn>0.6</eqn>
+                </element>
+                <element subscript="c,e">
+                    <eqn>0.7</eqn>
+                </element>
+            </aux>
+            <aux name="var3">
+                <dimensions>
+                    <dim name="sub2"></dim>
+                </dimensions>
+                <element subscript="d">
+                    <eqn>(Time+1)/15</eqn>
+                </element>
+                <element subscript="e">
+                    <eqn>-0.2-Time/20</eqn>
+                </element>
+            </aux>
+        </variables>
+        <views>
+            <view isee:show_pages="false" page_width="800" page_height="600" view_type="stock_flow">
+                <aux name="var1" x="108" y="120" label_side="bottom"></aux>
+                <aux name="var2" x="100" y="213" label_side="bottom"></aux>
+                <aux name="var3" x="102" y="313" label_side="bottom"></aux>
+            </view>
+        </views>
+    </model>
 </xmile>

--- a/test/test-models/tests/zeroled_decimals/test_zeroled_decimals.xmile
+++ b/test/test-models/tests/zeroled_decimals/test_zeroled_decimals.xmile
@@ -91,56 +91,56 @@
 					flow3
 					</inflow>
 			</stock>
-			<aux name="flow7">
+			<flow name="flow7">
 				<units></units>
 				<doc></doc>
 					<eqn>Time					</eqn>
-			</aux>
-			<aux name="flow1">
+			</flow>
+			<flow name="flow1">
 				<units></units>
 				<doc></doc>
 					<eqn>.34					</eqn>
-			</aux>
-			<aux name="flow1n">
+			</flow>
+			<flow name="flow1n">
 				<units></units>
 				<doc></doc>
 					<eqn>.1					</eqn>
-			</aux>
-			<aux name="flow1p">
+			</flow>
+			<flow name="flow1p">
 				<units></units>
 				<doc></doc>
 					<eqn>.4					</eqn>
-			</aux>
-			<aux name="flow2">
+			</flow>
+			<flow name="flow2">
 				<units></units>
 				<doc></doc>
 					<eqn>-.67					</eqn>
-			</aux>
-			<aux name="flow3">
+			</flow>
+			<flow name="flow3">
 				<units></units>
 				<doc></doc>
 					<eqn>+.72					</eqn>
-			</aux>
-			<aux name="flow4">
+			</flow>
+			<flow name="flow4">
 				<units></units>
 				<doc></doc>
 					<eqn>3e-05					</eqn>
-			</aux>
-			<aux name="flow5">
+			</flow>
+			<flow name="flow5">
 				<units></units>
 				<doc></doc>
 					<eqn>.5					</eqn>
-			</aux>
-			<aux name="flow6">
+			</flow>
+			<flow name="flow6">
 				<units></units>
 				<doc></doc>
 					<eqn>.1223					</eqn>
-			</aux>
-			<aux name="flow8">
+			</flow>
+			<flow name="flow8">
 				<units></units>
 				<doc></doc>
 					<eqn>.3					</eqn>
-			</aux>
+			</flow>
 		</variables>
 	</model>
 </xmile>


### PR DESCRIPTION
Several test model XMILE files had XML issues:

- non_negative_flows: Added missing </flow> closing tags for the if_else3 flow element in both test files

- arithmetics_exp and subscripted_trig: Re-converted from Vensim .mdl source files to fix invalid multiple <eqn> elements. The XMILE spec requires using <element subscript="..."> notation for per-subscript equations, which the converter now produces correctly

- zeroled_decimals: Changed <aux> elements to <flow> elements for variables that are referenced as inflows/outflows in stocks