### PR TITLE
diagram: fix newline handling in Find in Model search box

### DIFF
--- a/src/diagram/Editor.tsx
+++ b/src/diagram/Editor.tsx
@@ -78,7 +78,7 @@ import { VariableDetails } from './VariableDetails';
 import { ErrorDetails } from './ErrorDetails';
 import { ZoomBar } from './ZoomBar';
 import { Canvas, fauxCloudTargetUid, inCreationCloudUid, inCreationUid } from './drawing/Canvas';
-import { Point } from './drawing/common';
+import { Point, searchableName } from './drawing/common';
 import { takeoffθ } from './drawing/Connector';
 import { UpdateCloudAndFlow, UpdateFlow, UpdateStockAndFlows } from './drawing/Flow';
 
@@ -1485,7 +1485,7 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     if (elements) {
       autocompleteOptions = elements
         .filter((e) => e.isNamed())
-        .map((e) => (e as NamedViewElement).name.replace('\\n', ' '))
+        .map((e) => searchableName((e as NamedViewElement).name))
         .toArray();
     }
 
@@ -1493,7 +1493,7 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     let name;
     let placeholder: string | undefined = 'Find in Model';
     if (namedElement) {
-      name = defined((namedElement as NamedViewElement).name).replace('\\n', ' ');
+      name = searchableName(defined((namedElement as NamedViewElement).name));
       placeholder = undefined;
     }
 

--- a/src/diagram/drawing/common.ts
+++ b/src/diagram/drawing/common.ts
@@ -78,6 +78,12 @@ export const displayName = (name: string): string => {
   return name.replace(/\\n/g, '\n').replace(/_/g, ' ');
 };
 
+// Convert a display name to a single-line searchable format.
+// Handles both actual newlines (from XMILE parsing) and escaped newlines (from edits).
+export const searchableName = (name: string): string => {
+  return name.replace(/\\n|\n/g, ' ');
+};
+
 // FIXME: this is sort of gross, but works.  The main use is to check
 // the result
 export const isInf = (n: number): boolean => {

--- a/src/diagram/tests/common.test.ts
+++ b/src/diagram/tests/common.test.ts
@@ -4,7 +4,7 @@
 
 import { List } from 'immutable';
 
-import { calcViewBox, mergeBounds, Rect } from '../drawing/common';
+import { calcViewBox, mergeBounds, Rect, searchableName } from '../drawing/common';
 
 describe('common', () => {
   describe('mergeBounds', () => {
@@ -83,6 +83,42 @@ describe('common', () => {
       ]);
       const result = calcViewBox(elements);
       expect(result).toEqual({ top: -50, left: -100, right: 100, bottom: 100 });
+    });
+  });
+
+  describe('searchableName', () => {
+    it('should convert actual newlines to spaces', () => {
+      const name = 'maximum\ngrowth rate';
+      expect(searchableName(name)).toBe('maximum growth rate');
+    });
+
+    it('should convert escaped newlines to spaces', () => {
+      const name = 'maximum\\ngrowth rate';
+      expect(searchableName(name)).toBe('maximum growth rate');
+    });
+
+    it('should handle multiple actual newlines', () => {
+      const name = 'fraction\nof carrying\ncapacity used';
+      expect(searchableName(name)).toBe('fraction of carrying capacity used');
+    });
+
+    it('should handle multiple escaped newlines', () => {
+      const name = 'fraction\\nof carrying\\ncapacity used';
+      expect(searchableName(name)).toBe('fraction of carrying capacity used');
+    });
+
+    it('should handle mixed actual and escaped newlines', () => {
+      const name = 'mixed\nnewline\\nformat';
+      expect(searchableName(name)).toBe('mixed newline format');
+    });
+
+    it('should return unchanged names without newlines', () => {
+      const name = 'simple name';
+      expect(searchableName(name)).toBe('simple name');
+    });
+
+    it('should handle empty strings', () => {
+      expect(searchableName('')).toBe('');
     });
   });
 });


### PR DESCRIPTION
## Summary

- Fixed a bug where variable names with newlines (like "maximum\ngrowth rate") were displayed incorrectly as "maximumgrowth rate" in the Find in Model search box
- Added a `searchableName` helper function to handle both actual newlines (from XMILE parsing) and escaped newlines (from edits)
- Added comprehensive tests for the new function

## Test plan

- [x] Added unit tests in `src/diagram/tests/common.test.ts` covering:
  - Actual newlines converted to spaces
  - Escaped newlines converted to spaces
  - Multiple newlines (both types)
  - Mixed actual and escaped newlines
  - Names without newlines unchanged
  - Empty strings handled correctly
- [ ] Manual test: Open `default_projects/logistic-growth/model.xmile` in web editor, select "maximum growth rate" variable, verify search box shows "maximum growth rate" (with space, not "maximumgrowth rate")