### PR TITLE
Add Vensim MDL file support detection

### DIFF
--- a/src/engine2/build.sh
+++ b/src/engine2/build.sh
@@ -7,9 +7,9 @@ cd "$DIR"
 # Clean previous builds (including tsbuildinfo for incremental compilation)
 rm -rf lib lib.browser core *.tsbuildinfo
 
-# Build libsimlin as WASM (without vensim feature due to C++ xmutil dependency)
+# Build libsimlin as WASM with vensim support
 echo "Building libsimlin for wasm32-unknown-unknown..."
-cargo build -p simlin --lib --release --target wasm32-unknown-unknown --no-default-features
+cargo build -p simlin --lib --release --target wasm32-unknown-unknown
 
 # Create core directory and copy WASM
 mkdir -p core


### PR DESCRIPTION
Now that engine2 is built with Vensim support enabled (via the xmutil C++ code compiled to WASM), we no longer need the fallback path that converted MDL files through the separate xmutil WASM module.

This simplifies the MDL import code to just call openVensim() directly, removing the hasVensimSupport() check and the convertMdlToXmile import. The engine2/build.sh was updated to build with default features instead of --no-default-features, enabling the vensim feature.