### PR TITLE
Add SAFEDIV operator support to parser

### DIFF
--- a/src/simlin-engine/src/equation.lalrpop
+++ b/src/simlin-engine/src/equation.lalrpop
@@ -64,6 +64,7 @@ Add: Expr = {
 Mul: Expr = {
     <lpos:@L> <l:Mul> "*" <r:Unary> <rpos:@R> => Op2(Mul, Box::new(l), Box::new(r), Loc::new(lpos, rpos)),
     <lpos:@L> <l:Mul> "/" <r:Unary> <rpos:@R> => Op2(Div, Box::new(l), Box::new(r), Loc::new(lpos, rpos)),
+    <lpos:@L> <l:Mul> "//" <r:Unary> <rpos:@R> => App(UntypedBuiltinFn("safediv".to_string(), vec![l, r]), Loc::new(lpos, rpos)),
     <lpos:@L> <l:Mul> "%" <r:Unary> <rpos:@R> => Op2(Mod, Box::new(l), Box::new(r), Loc::new(lpos, rpos)),
     Unary,
 };
@@ -142,6 +143,7 @@ extern {
         "-" => Token::Minus,
         "*" => Token::Mul,
         "/" => Token::Div,
+        "//" => Token::SafeDiv,
         "%" => Token::Mod,
         "!" => Token::Not,
         "(" => Token::LParen,

--- a/src/simlin-engine/src/token/mod.rs
+++ b/src/simlin-engine/src/token/mod.rs
@@ -43,6 +43,7 @@ pub enum Token<'input> {
     Minus,
     Mul,
     Div,
+    SafeDiv,
     LParen,
     RParen,
     LBracket,
@@ -221,7 +222,13 @@ impl<'input> Iterator for Lexer<'input> {
     fn next(&mut self) -> Option<Self::Item> {
         loop {
             return match self.lookahead {
-                Some((i, '/')) => self.consume(i, Div, 1),
+                Some((i, '/')) => {
+                    match self.bump() {
+                        Some((_, '/')) => self.consume(i, SafeDiv, 2),
+                        // we've already bumped, don't consume
+                        _ => Some(Ok((i, Div, i + 1))),
+                    }
+                }
                 Some((i, '=')) => self.consume(i, Eq, 1),
                 Some((i, '^')) => self.consume(i, Exp, 1),
                 Some((i, '<')) => {

--- a/src/simlin-engine/src/token/test.rs
+++ b/src/simlin-engine/src/token/test.rs
@@ -244,3 +244,30 @@ fn unrecognized_token() {
 fn unclosed_quoted_ident() {
     test_err("\"ohno", ("~~~~~", UnclosedQuotedIdent));
 }
+
+#[test]
+fn safediv_operator() {
+    test(
+        "a // b",
+        vec![
+            ("~     ", Ident("a")),
+            ("  ~~  ", SafeDiv),
+            ("     ~", Ident("b")),
+        ],
+    );
+}
+
+#[test]
+fn safediv_mixed_with_div() {
+    // a / b // c should be: a / b, then // c
+    test(
+        "a / b // c",
+        vec![
+            ("~         ", Ident("a")),
+            ("  ~       ", Div),
+            ("    ~     ", Ident("b")),
+            ("      ~~  ", SafeDiv),
+            ("         ~", Ident("c")),
+        ],
+    );
+}


### PR DESCRIPTION
Some system dynamics software uses // as a special syntax for safe division (dividing while avoiding division by zero). This change adds support for parsing // as equivalent to calling the SAFEDIV() function.

The // operator has the same precedence as / (and * and %) and follows left-associativity, so "a * b // c" parses as "safediv(a * b, c)".

Implementation details:
- Added SafeDiv token to the lexer with // pattern recognition
- Added parser rule to transform // into an App(safediv, args) AST node
- Lexer handles // vs / correctly (// takes precedence when two slashes appear consecutively)