### PR TITLE
engine: add updateStockFlows operation for safe flow attach/detach

### DIFF
--- a/src/diagram/Editor.tsx
+++ b/src/diagram/Editor.tsx
@@ -845,13 +845,11 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       const stockVar = model.variables.get(sourceStockIdent);
       if (stockVar instanceof StockVar) {
         ops.push({
-          type: 'upsertStock',
+          type: 'updateStockFlows',
           payload: {
-            stock: {
-              name: stockVar.ident,
-              inflows: stockVar.inflows.toArray(),
-              outflows: stockVar.outflows.push(flow.ident).toArray(),
-            },
+            ident: stockVar.ident,
+            inflows: stockVar.inflows.toArray(),
+            outflows: stockVar.outflows.push(flow.ident).toArray(),
           },
         });
       }
@@ -863,13 +861,11 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       const stockVar = model.variables.get(sourceStockAttachingIdent);
       if (stockVar instanceof StockVar) {
         ops.push({
-          type: 'upsertStock',
+          type: 'updateStockFlows',
           payload: {
-            stock: {
-              name: stockVar.ident,
-              inflows: stockVar.inflows.toArray(),
-              outflows: stockVar.outflows.push(flow.ident).toArray(),
-            },
+            ident: stockVar.ident,
+            inflows: stockVar.inflows.toArray(),
+            outflows: stockVar.outflows.push(flow.ident).toArray(),
           },
         });
       }
@@ -881,13 +877,11 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       const stockVar = model.variables.get(sourceStockDetachingIdent);
       if (stockVar instanceof StockVar) {
         ops.push({
-          type: 'upsertStock',
+          type: 'updateStockFlows',
           payload: {
-            stock: {
-              name: stockVar.ident,
-              inflows: stockVar.inflows.toArray(),
-              outflows: stockVar.outflows.filter((f) => f !== flow.ident).toArray(),
-            },
+            ident: stockVar.ident,
+            inflows: stockVar.inflows.toArray(),
+            outflows: stockVar.outflows.filter((f) => f !== flow.ident).toArray(),
           },
         });
       }
@@ -899,13 +893,11 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       const stockVar = model.variables.get(stockAttachingIdent);
       if (stockVar instanceof StockVar) {
         ops.push({
-          type: 'upsertStock',
+          type: 'updateStockFlows',
           payload: {
-            stock: {
-              name: stockVar.ident,
-              inflows: stockVar.inflows.push(flow.ident).toArray(),
-              outflows: stockVar.outflows.toArray(),
-            },
+            ident: stockVar.ident,
+            inflows: stockVar.inflows.push(flow.ident).toArray(),
+            outflows: stockVar.outflows.toArray(),
           },
         });
       }
@@ -917,13 +909,11 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       const stockVar = model.variables.get(stockDetachingIdent);
       if (stockVar instanceof StockVar) {
         ops.push({
-          type: 'upsertStock',
+          type: 'updateStockFlows',
           payload: {
-            stock: {
-              name: stockVar.ident,
-              inflows: stockVar.inflows.filter((f) => f !== flow.ident).toArray(),
-              outflows: stockVar.outflows.toArray(),
-            },
+            ident: stockVar.ident,
+            inflows: stockVar.inflows.filter((f) => f !== flow.ident).toArray(),
+            outflows: stockVar.outflows.toArray(),
           },
         });
       }
@@ -937,6 +927,8 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
         engine2.applyPatch(patch);
       } catch (e: any) {
         this.appendModelError(e?.message ?? 'Unknown error during flow attach');
+        this.setState({ selection, flowStillBeingCreated: inCreation });
+        return;
       }
     }
 

--- a/src/engine2/src/json-types.ts
+++ b/src/engine2/src/json-types.ts
@@ -418,6 +418,16 @@ export interface DeleteViewPayload {
 }
 
 /**
+ * Payload for update stock flows operation.
+ * Updates only the inflows/outflows of an existing stock, preserving all other fields.
+ */
+export interface UpdateStockFlowsPayload {
+  ident: string;
+  inflows: string[];
+  outflows: string[];
+}
+
+/**
  * Payload for set sim specs operation.
  */
 export interface SetSimSpecsPayload {
@@ -471,6 +481,11 @@ export interface SetSimSpecsOp {
   payload: SetSimSpecsPayload;
 }
 
+export interface UpdateStockFlowsOp {
+  type: 'updateStockFlows';
+  payload: UpdateStockFlowsPayload;
+}
+
 /**
  * Union type for model operations.
  */
@@ -482,7 +497,8 @@ export type JsonModelOperation =
   | DeleteVariableOp
   | RenameVariableOp
   | UpsertViewOp
-  | DeleteViewOp;
+  | DeleteViewOp
+  | UpdateStockFlowsOp;
 
 /**
  * Union type for project operations.
@@ -539,4 +555,8 @@ export function isUpsertView(op: JsonModelOperation): op is UpsertViewOp {
 
 export function isDeleteView(op: JsonModelOperation): op is DeleteViewOp {
   return op.type === 'deleteView';
+}
+
+export function isUpdateStockFlows(op: JsonModelOperation): op is UpdateStockFlowsOp {
+  return op.type === 'updateStockFlows';
 }

--- a/src/libsimlin/src/lib.rs
+++ b/src/libsimlin/src/lib.rs
@@ -3146,6 +3146,11 @@ enum JsonModelOperation {
     DeleteView {
         index: u32,
     },
+    UpdateStockFlows {
+        ident: String,
+        inflows: Vec<String>,
+        outflows: Vec<String>,
+    },
 }
 
 fn convert_json_project_patch(
@@ -3267,6 +3272,15 @@ fn convert_json_model_operation(
         JsonModelOperation::DeleteView { index } => {
             model_operation::Op::DeleteView(project_io::DeleteViewOp { index })
         }
+        JsonModelOperation::UpdateStockFlows {
+            ident,
+            inflows,
+            outflows,
+        } => model_operation::Op::UpdateStockFlows(project_io::UpdateStockFlowsOp {
+            ident,
+            inflows,
+            outflows,
+        }),
     };
 
     Ok(result)

--- a/src/simlin-engine/src/project_io.proto
+++ b/src/simlin-engine/src/project_io.proto
@@ -349,7 +349,16 @@ message ModelOperation {
     RenameVariableOp rename_variable = 6;
     UpsertViewOp upsert_view = 7;
     DeleteViewOp delete_view = 8;
+    UpdateStockFlowsOp update_stock_flows = 9;
   }
+};
+
+// Updates only the inflows/outflows of an existing stock, preserving all other fields.
+// Use this when connecting/disconnecting flows from stocks in the UI.
+message UpdateStockFlowsOp {
+  string ident = 1;
+  repeated string inflows = 2;
+  repeated string outflows = 3;
 };
 
 message SetSimSpecsOp {


### PR DESCRIPTION
## Summary

- Adds new `updateStockFlows` operation that only modifies inflows/outflows while preserving all other stock fields
- Changes Editor.tsx to use this operation when attaching/detaching flows from stocks
- Fixes UI/model desync by returning early when patch fails

## Problem

When disconnecting a flow from a stock in the UI:
1. User saw "Unknown error" toast
2. Charts didn't update because the model wasn't actually modified
3. The UI showed disconnection but the underlying model was out of sync

The root cause was that `upsertStock` does full replacement. When `Editor.tsx` used it with only `name`, `inflows`, and `outflows`, the stock's other fields (like `initialEquation`) were replaced with defaults, causing simulation errors.

## Test plan

- [x] Added unit tests verifying equation and field preservation
- [x] Added unit test for error handling when stock doesn't exist
- [x] All 636 Rust tests pass
- [x] TypeScript compiles and lints clean
- [ ] Manual test: Create model with stock (equation="100") connected to flow, disconnect flow by dragging, verify no error and stock equation still "100"