### PR TITLE
diagram: allow dragging clouds onto stocks to connect flows

### DIFF
--- a/src/diagram/drawing/Cloud.tsx
+++ b/src/diagram/drawing/Cloud.tsx
@@ -29,6 +29,7 @@ const CloudPath =
 
 export interface CloudProps {
   isSelected: boolean;
+  isHidden?: boolean;
   onSelection: (element: ViewElement, e: React.PointerEvent<SVGElement>, isText?: boolean) => void;
   element: CloudViewElement;
 }
@@ -60,7 +61,7 @@ export class Cloud extends React.PureComponent<CloudProps> {
   };
 
   render() {
-    const { element } = this.props;
+    const { element, isHidden } = this.props;
     const x = defined(element.x);
     const y = defined(element.y);
 
@@ -70,11 +71,15 @@ export class Cloud extends React.PureComponent<CloudProps> {
     const scale = diameter / CloudWidth;
     const t = `matrix(${scale}, 0, 0, ${scale}, ${x - radius}, ${y - radius})`;
 
+    // Keep cloud in DOM (for pointer capture) but visually hidden when dragging
+    const style = isHidden ? { visibility: 'hidden' as const } : undefined;
+
     return (
       <path
         d={CloudPath}
         className={`${styles.cloud} simlin-cloud`}
         transform={t}
+        style={style}
         onPointerDown={this.handlePointerDown}
       />
     );

--- a/src/diagram/drawing/Connector.tsx
+++ b/src/diagram/drawing/Connector.tsx
@@ -85,8 +85,12 @@ export function takeoffθ(props: Pick<ConnectorProps, 'element' | 'from' | 'to' 
     // check if the user's cursor and the center of the arc's circle are on the same
     // side of the straight line connecting the from and to elements.  If so, we need
     // to set the sweep flag.
-    const side1 = (circ.x - fromVisual.cx) * (toVisual.cy - fromVisual.cy) - (circ.y - fromVisual.cy) * (toVisual.cx - fromVisual.cx);
-    const side2 = (arcPoint.x - fromVisual.cx) * (toVisual.cy - fromVisual.cy) - (arcPoint.y - fromVisual.cy) * (toVisual.cx - fromVisual.cx);
+    const side1 =
+      (circ.x - fromVisual.cx) * (toVisual.cy - fromVisual.cy) -
+      (circ.y - fromVisual.cy) * (toVisual.cx - fromVisual.cx);
+    const side2 =
+      (arcPoint.x - fromVisual.cx) * (toVisual.cy - fromVisual.cy) -
+      (arcPoint.y - fromVisual.cy) * (toVisual.cx - fromVisual.cx);
 
     const sweep = side1 < 0 === side2 < 0;
 
@@ -349,14 +353,18 @@ export class Connector extends React.PureComponent<ConnectorProps> {
     // inverse flag
     let inv: boolean = spanθ > 0 || spanθ <= degToRad(-180);
 
-    const side1 = (circ.x - fromVisual.cx) * (toVisual.cy - fromVisual.cy) - (circ.y - fromVisual.cy) * (toVisual.cx - fromVisual.cx);
+    const side1 =
+      (circ.x - fromVisual.cx) * (toVisual.cy - fromVisual.cy) -
+      (circ.y - fromVisual.cy) * (toVisual.cx - fromVisual.cx);
     const startA = intersectElementArc(from, circ, inv);
     const startR = sqrt(square(startA.x - fromVisual.cx) + square(startA.y - fromVisual.cy));
     const takeoffPoint = {
       x: fromVisual.cx + startR * cos(takeoffAngle),
       y: fromVisual.cy + startR * sin(takeoffAngle),
     };
-    const side2 = (takeoffPoint.x - fromVisual.cx) * (toVisual.cy - fromVisual.cy) - (takeoffPoint.y - fromVisual.cy) * (toVisual.cx - fromVisual.cx);
+    const side2 =
+      (takeoffPoint.x - fromVisual.cx) * (toVisual.cy - fromVisual.cy) -
+      (takeoffPoint.y - fromVisual.cy) * (toVisual.cx - fromVisual.cx);
 
     const sweep = side1 < 0 === side2 < 0;
 

--- a/src/diagram/drawing/cloud-utils.ts
+++ b/src/diagram/drawing/cloud-utils.ts
@@ -1,0 +1,32 @@
+// Copyright 2025 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import { CloudViewElement, FlowViewElement } from '@system-dynamics/core/datamodel';
+import { defined } from '@system-dynamics/core/common';
+
+/**
+ * Determines if a cloud is on the source side (first point) of a flow.
+ * Returns true if the flow's first point is attached to this cloud.
+ * Throws if the flow has fewer than 2 points (which would be invalid).
+ */
+export function isCloudOnSourceSide(cloud: CloudViewElement, flow: FlowViewElement): boolean {
+  if (flow.points.size < 2) {
+    throw new Error(`Flow ${flow.uid} has fewer than 2 points`);
+  }
+  const firstPoint = defined(flow.points.first());
+  return firstPoint.attachedToUid === cloud.uid;
+}
+
+/**
+ * Determines if a cloud is on the sink side (last point) of a flow.
+ * Returns true if the flow's last point is attached to this cloud.
+ * Throws if the flow has fewer than 2 points (which would be invalid).
+ */
+export function isCloudOnSinkSide(cloud: CloudViewElement, flow: FlowViewElement): boolean {
+  if (flow.points.size < 2) {
+    throw new Error(`Flow ${flow.uid} has fewer than 2 points`);
+  }
+  const lastPoint = defined(flow.points.last());
+  return lastPoint.attachedToUid === cloud.uid;
+}

--- a/src/diagram/tests/cloud-utils.test.ts
+++ b/src/diagram/tests/cloud-utils.test.ts
@@ -1,0 +1,163 @@
+// Copyright 2025 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import { List } from 'immutable';
+
+import { Point, FlowViewElement, CloudViewElement } from '@system-dynamics/core/datamodel';
+
+import { isCloudOnSourceSide, isCloudOnSinkSide } from '../drawing/cloud-utils';
+
+function makeFlow(
+  uid: number,
+  x: number,
+  y: number,
+  points: Array<{ x: number; y: number; attachedToUid?: number }>,
+): FlowViewElement {
+  return new FlowViewElement({
+    uid,
+    name: 'TestFlow',
+    ident: 'test_flow',
+    var: undefined,
+    x,
+    y,
+    labelSide: 'center',
+    points: List(points.map((p) => new Point({ x: p.x, y: p.y, attachedToUid: p.attachedToUid }))),
+    isZeroRadius: false,
+  });
+}
+
+function makeCloud(uid: number, flowUid: number, x: number, y: number): CloudViewElement {
+  return new CloudViewElement({
+    uid,
+    flowUid,
+    x,
+    y,
+    isZeroRadius: false,
+  });
+}
+
+describe('Cloud to stock attachment', () => {
+  const stockUid = 1;
+  const flowUid = 2;
+  const sourceCloudUid = 3;
+  const sinkCloudUid = 4;
+
+  describe('isCloudOnSourceSide', () => {
+    it('should return true when cloud is attached to first point of flow', () => {
+      const cloud = makeCloud(sourceCloudUid, flowUid, 100, 100);
+      const flow = makeFlow(flowUid, 150, 100, [
+        { x: 100, y: 100, attachedToUid: sourceCloudUid },
+        { x: 200, y: 100, attachedToUid: stockUid },
+      ]);
+
+      expect(isCloudOnSourceSide(cloud, flow)).toBe(true);
+    });
+
+    it('should return false when cloud is attached to last point of flow', () => {
+      const cloud = makeCloud(sinkCloudUid, flowUid, 200, 100);
+      const flow = makeFlow(flowUid, 150, 100, [
+        { x: 100, y: 100, attachedToUid: stockUid },
+        { x: 200, y: 100, attachedToUid: sinkCloudUid },
+      ]);
+
+      expect(isCloudOnSourceSide(cloud, flow)).toBe(false);
+    });
+
+    it('should return false when cloud is not attached to the flow', () => {
+      const cloud = makeCloud(99, flowUid, 300, 100);
+      const flow = makeFlow(flowUid, 150, 100, [
+        { x: 100, y: 100, attachedToUid: stockUid },
+        { x: 200, y: 100, attachedToUid: sinkCloudUid },
+      ]);
+
+      expect(isCloudOnSourceSide(cloud, flow)).toBe(false);
+    });
+  });
+
+  describe('isCloudOnSinkSide', () => {
+    it('should return true when cloud is attached to last point of flow', () => {
+      const cloud = makeCloud(sinkCloudUid, flowUid, 200, 100);
+      const flow = makeFlow(flowUid, 150, 100, [
+        { x: 100, y: 100, attachedToUid: stockUid },
+        { x: 200, y: 100, attachedToUid: sinkCloudUid },
+      ]);
+
+      expect(isCloudOnSinkSide(cloud, flow)).toBe(true);
+    });
+
+    it('should return false when cloud is attached to first point of flow', () => {
+      const cloud = makeCloud(sourceCloudUid, flowUid, 100, 100);
+      const flow = makeFlow(flowUid, 150, 100, [
+        { x: 100, y: 100, attachedToUid: sourceCloudUid },
+        { x: 200, y: 100, attachedToUid: stockUid },
+      ]);
+
+      expect(isCloudOnSinkSide(cloud, flow)).toBe(false);
+    });
+
+    it('should return false when cloud is not attached to the flow', () => {
+      const cloud = makeCloud(99, flowUid, 300, 100);
+      const flow = makeFlow(flowUid, 150, 100, [
+        { x: 100, y: 100, attachedToUid: stockUid },
+        { x: 200, y: 100, attachedToUid: sinkCloudUid },
+      ]);
+
+      expect(isCloudOnSinkSide(cloud, flow)).toBe(false);
+    });
+  });
+
+  describe('invalid flow handling', () => {
+    it('should throw if flow has fewer than 2 points', () => {
+      const cloud = makeCloud(sourceCloudUid, flowUid, 100, 100);
+      const invalidFlow = makeFlow(flowUid, 100, 100, [{ x: 100, y: 100, attachedToUid: sourceCloudUid }]);
+
+      expect(() => isCloudOnSourceSide(cloud, invalidFlow)).toThrow('has fewer than 2 points');
+      expect(() => isCloudOnSinkSide(cloud, invalidFlow)).toThrow('has fewer than 2 points');
+    });
+  });
+
+  describe('cloud attached to middle point', () => {
+    it('should return false for both source and sink when cloud is attached to middle point', () => {
+      const middleCloudUid = 5;
+      const cloud = makeCloud(middleCloudUid, flowUid, 150, 100);
+      // 3-point flow with cloud attached to the middle point (not at source or sink)
+      const flow = makeFlow(flowUid, 150, 100, [
+        { x: 100, y: 100, attachedToUid: stockUid },
+        { x: 150, y: 100, attachedToUid: middleCloudUid },
+        { x: 200, y: 100, attachedToUid: sinkCloudUid },
+      ]);
+
+      expect(isCloudOnSourceSide(cloud, flow)).toBe(false);
+      expect(isCloudOnSinkSide(cloud, flow)).toBe(false);
+    });
+  });
+
+  describe('L-shaped flow cloud positioning', () => {
+    it('should correctly identify source cloud on L-shaped flow', () => {
+      const cloud = makeCloud(sourceCloudUid, flowUid, 100, 50);
+      // L-shaped flow: cloud at top-left, corner in middle, stock at right
+      const flow = makeFlow(flowUid, 150, 100, [
+        { x: 100, y: 50, attachedToUid: sourceCloudUid },
+        { x: 100, y: 100 }, // corner
+        { x: 200, y: 100, attachedToUid: stockUid },
+      ]);
+
+      expect(isCloudOnSourceSide(cloud, flow)).toBe(true);
+      expect(isCloudOnSinkSide(cloud, flow)).toBe(false);
+    });
+
+    it('should correctly identify sink cloud on L-shaped flow', () => {
+      const cloud = makeCloud(sinkCloudUid, flowUid, 200, 150);
+      // L-shaped flow: stock at left, corner in middle, cloud at bottom-right
+      const flow = makeFlow(flowUid, 150, 100, [
+        { x: 100, y: 100, attachedToUid: stockUid },
+        { x: 200, y: 100 }, // corner
+        { x: 200, y: 150, attachedToUid: sinkCloudUid },
+      ]);
+
+      expect(isCloudOnSourceSide(cloud, flow)).toBe(false);
+      expect(isCloudOnSinkSide(cloud, flow)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Add ability to drag a flow's cloud (source or sink) onto a stock to connect the flow
- Stocks highlight green when they are valid targets during the drag operation
- The cloud is hidden during the drag and disappears when dropped on a valid stock
- Reuses existing flow-to-stock connection logic by detecting cloud drags and setting up the appropriate movement mode

## Test plan

- [x] Unit tests for `isCloudOnSourceSide` and `isCloudOnSinkSide` helper functions
- [ ] Manual testing: drag a source-side cloud onto a stock and verify the flow connects
- [ ] Manual testing: drag a sink-side cloud onto a stock and verify the flow connects
- [ ] Manual testing: verify stock highlights green when cloud is dragged over it
- [ ] Manual testing: verify invalid targets (same stock as other end) don't allow connection