### PR TITLE
app: fix CSS module styles being overridden by MUI defaults

### DIFF
--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -14,7 +14,7 @@ import {
 } from '@firebase/auth';
 
 import { useLocation, Route, RouteComponentProps, Switch, Redirect } from 'wouter';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
+import { createTheme, ThemeProvider, StyledEngineProvider } from '@mui/material/styles';
 import CssBaseline from '@mui/material/CssBaseline';
 
 import { defined } from '@system-dynamics/core/common';
@@ -270,9 +270,11 @@ export class App extends React.PureComponent {
   render(): React.JSX.Element {
     return (
       <React.StrictMode>
-        <ThemeProvider theme={theme}>
-          <InnerApp />
-        </ThemeProvider>
+        <StyledEngineProvider injectFirst>
+          <ThemeProvider theme={theme}>
+            <InnerApp />
+          </ThemeProvider>
+        </StyledEngineProvider>
       </React.StrictMode>
     );
   }


### PR DESCRIPTION
## Summary

- Wraps the app root with `StyledEngineProvider injectFirst` so MUI's emotion-injected styles are placed at the beginning of `<head>`, allowing CSS module styles to win at equal specificity
- Fixes invisible "New Project" button on the home page (MUI's blue outlined-button defaults overrode our `color: white`)
- Fixes misaligned back arrow and close button in the model properties drawer (MUI's `position: relative` on IconButton overrode our `position: absolute`)

The migration from MUI `styled()` to CSS Modules (PR #187) dropped CSS specificity from (0,2,0) to (0,1,0). MUI's emotion runtime injects component styles after static CSS module stylesheets in the `<head>`, so at equal specificity MUI's styles won via cascade order. `StyledEngineProvider injectFirst` is MUI's recommended approach for using CSS modules alongside MUI components.

## Test plan

- [ ] Verify the "New Project" button in the upper-right of the project list page is visible (white text/border on blue AppBar)
- [ ] Verify the back arrow and close "X" in the model properties drawer are positioned correctly (top-left and top-right corners of the drawer header)
- [ ] Smoke-test that other MUI component styling hasn't regressed