### PR TITLE
libsimlin: add JSON APIs for model variable retrieval

### DIFF
--- a/src/engine2/src/internal/model.ts
+++ b/src/engine2/src/internal/model.ts
@@ -14,6 +14,7 @@ import {
   readOutPtr,
   allocOutUsize,
   readOutUsize,
+  copyFromWasm,
 } from './memory';
 import { SimlinModelPtr, SimlinLinksPtr } from './types';
 import {
@@ -279,6 +280,132 @@ export function simlin_model_get_incoming_links(model: SimlinModelPtr, varName: 
   } finally {
     free(varNamePtr);
     free(outCountPtr);
+    free(outErrPtr);
+  }
+}
+
+/**
+ * Get all stocks in a model as JSON bytes.
+ * @param model Model pointer
+ * @returns JSON bytes (UTF-8 encoded array of stock objects)
+ */
+export function simlin_model_get_stocks_json(model: SimlinModelPtr): Uint8Array {
+  const exports = getExports();
+  const fn = exports.simlin_model_get_stocks_json as (
+    model: number,
+    outBuf: number,
+    outLen: number,
+    outErr: number,
+  ) => void;
+
+  const outBufPtr = allocOutPtr();
+  const outLenPtr = allocOutUsize();
+  const outErrPtr = allocOutPtr();
+
+  try {
+    fn(model, outBufPtr, outLenPtr, outErrPtr);
+    const errPtr = readOutPtr(outErrPtr);
+
+    if (errPtr !== 0) {
+      const code = simlin_error_get_code(errPtr);
+      const message = simlin_error_get_message(errPtr) ?? 'Unknown error';
+      const details = readAllErrorDetails(errPtr);
+      simlin_error_free(errPtr);
+      throw new SimlinError(message, code, details);
+    }
+
+    const bufPtr = readOutPtr(outBufPtr);
+    const len = readOutUsize(outLenPtr);
+    const data = copyFromWasm(bufPtr, len);
+    free(bufPtr);
+    return data;
+  } finally {
+    free(outBufPtr);
+    free(outLenPtr);
+    free(outErrPtr);
+  }
+}
+
+/**
+ * Get all flows in a model as JSON bytes.
+ * @param model Model pointer
+ * @returns JSON bytes (UTF-8 encoded array of flow objects)
+ */
+export function simlin_model_get_flows_json(model: SimlinModelPtr): Uint8Array {
+  const exports = getExports();
+  const fn = exports.simlin_model_get_flows_json as (
+    model: number,
+    outBuf: number,
+    outLen: number,
+    outErr: number,
+  ) => void;
+
+  const outBufPtr = allocOutPtr();
+  const outLenPtr = allocOutUsize();
+  const outErrPtr = allocOutPtr();
+
+  try {
+    fn(model, outBufPtr, outLenPtr, outErrPtr);
+    const errPtr = readOutPtr(outErrPtr);
+
+    if (errPtr !== 0) {
+      const code = simlin_error_get_code(errPtr);
+      const message = simlin_error_get_message(errPtr) ?? 'Unknown error';
+      const details = readAllErrorDetails(errPtr);
+      simlin_error_free(errPtr);
+      throw new SimlinError(message, code, details);
+    }
+
+    const bufPtr = readOutPtr(outBufPtr);
+    const len = readOutUsize(outLenPtr);
+    const data = copyFromWasm(bufPtr, len);
+    free(bufPtr);
+    return data;
+  } finally {
+    free(outBufPtr);
+    free(outLenPtr);
+    free(outErrPtr);
+  }
+}
+
+/**
+ * Get all auxiliaries in a model as JSON bytes.
+ * @param model Model pointer
+ * @returns JSON bytes (UTF-8 encoded array of auxiliary objects)
+ */
+export function simlin_model_get_auxs_json(model: SimlinModelPtr): Uint8Array {
+  const exports = getExports();
+  const fn = exports.simlin_model_get_auxs_json as (
+    model: number,
+    outBuf: number,
+    outLen: number,
+    outErr: number,
+  ) => void;
+
+  const outBufPtr = allocOutPtr();
+  const outLenPtr = allocOutUsize();
+  const outErrPtr = allocOutPtr();
+
+  try {
+    fn(model, outBufPtr, outLenPtr, outErrPtr);
+    const errPtr = readOutPtr(outErrPtr);
+
+    if (errPtr !== 0) {
+      const code = simlin_error_get_code(errPtr);
+      const message = simlin_error_get_message(errPtr) ?? 'Unknown error';
+      const details = readAllErrorDetails(errPtr);
+      simlin_error_free(errPtr);
+      throw new SimlinError(message, code, details);
+    }
+
+    const bufPtr = readOutPtr(outBufPtr);
+    const len = readOutUsize(outLenPtr);
+    const data = copyFromWasm(bufPtr, len);
+    free(bufPtr);
+    return data;
+  } finally {
+    free(outBufPtr);
+    free(outLenPtr);
     free(outErrPtr);
   }
 }

--- a/src/engine2/src/model.ts
+++ b/src/engine2/src/model.ts
@@ -15,6 +15,9 @@ import {
   simlin_model_get_incoming_links,
   simlin_model_get_links,
   simlin_model_get_latex_equation,
+  simlin_model_get_stocks_json,
+  simlin_model_get_flows_json,
+  simlin_model_get_auxs_json,
 } from './internal/model';
 import { readLinks, simlin_free_links } from './internal/analysis';
 import { SimlinModelPtr, SimlinLinkPolarity, Link as LowLevelLink } from './internal/types';
@@ -215,8 +218,12 @@ export class Model {
       return this._cachedStocks;
     }
 
-    const model = this.getModelJson();
-    this._cachedStocks = (model.stocks || []).map((s: JsonStock) => ({
+    // Use direct JSON API instead of serializing entire project
+    const jsonBytes = simlin_model_get_stocks_json(this._ptr);
+    const jsonStr = new TextDecoder().decode(jsonBytes);
+    const stocksJson: JsonStock[] = JSON.parse(jsonStr);
+
+    this._cachedStocks = stocksJson.map((s: JsonStock) => ({
       type: 'stock' as const,
       name: s.name,
       initialEquation: this.extractEquation(s.initialEquation, s.arrayedEquation, 'initialEquation'),
@@ -240,8 +247,12 @@ export class Model {
       return this._cachedFlows;
     }
 
-    const model = this.getModelJson();
-    this._cachedFlows = (model.flows || []).map((f: JsonFlow) => {
+    // Use direct JSON API instead of serializing entire project
+    const jsonBytes = simlin_model_get_flows_json(this._ptr);
+    const jsonStr = new TextDecoder().decode(jsonBytes);
+    const flowsJson: JsonFlow[] = JSON.parse(jsonStr);
+
+    this._cachedFlows = flowsJson.map((f: JsonFlow) => {
       let gf: GraphicalFunction | undefined;
       if (f.graphicalFunction) {
         gf = this.parseJsonGraphicalFunction(f.graphicalFunction);
@@ -271,8 +282,12 @@ export class Model {
       return this._cachedAuxs;
     }
 
-    const model = this.getModelJson();
-    this._cachedAuxs = (model.auxiliaries || []).map((a: JsonAuxiliary) => {
+    // Use direct JSON API instead of serializing entire project
+    const jsonBytes = simlin_model_get_auxs_json(this._ptr);
+    const jsonStr = new TextDecoder().decode(jsonBytes);
+    const auxsJson: JsonAuxiliary[] = JSON.parse(jsonStr);
+
+    this._cachedAuxs = auxsJson.map((a: JsonAuxiliary) => {
       let gf: GraphicalFunction | undefined;
       if (a.graphicalFunction) {
         gf = this.parseJsonGraphicalFunction(a.graphicalFunction);

--- a/src/libsimlin/simlin.h
+++ b/src/libsimlin/simlin.h
@@ -388,6 +388,63 @@ char *simlin_model_get_latex_equation(SimlinModel *model,
                                       const char *ident,
                                       SimlinError **out_error);
 
+// Returns all stocks in a model as a JSON array.
+//
+// The returned JSON is an array of stock objects, each containing fields like
+// `name`, `initialEquation`, `inflows`, `outflows`, `units`, etc.
+//
+// # Safety
+// - `model` must be a valid pointer to a SimlinModel
+// - `out_buffer` and `out_len` must be valid pointers where the serialized
+//   bytes and length will be written
+// - `out_error` may be null or a valid pointer to receive error details
+//
+// # Ownership
+// - The returned buffer is exclusively owned by the caller and MUST be freed with `simlin_free`.
+// - The caller is responsible for freeing the buffer even if subsequent operations fail.
+void simlin_model_get_stocks_json(SimlinModel *model,
+                                  uint8_t **out_buffer,
+                                  uintptr_t *out_len,
+                                  SimlinError **out_error);
+
+// Returns all flows in a model as a JSON array.
+//
+// The returned JSON is an array of flow objects, each containing fields like
+// `name`, `equation`, `units`, `nonNegative`, `graphicalFunction`, etc.
+//
+// # Safety
+// - `model` must be a valid pointer to a SimlinModel
+// - `out_buffer` and `out_len` must be valid pointers where the serialized
+//   bytes and length will be written
+// - `out_error` may be null or a valid pointer to receive error details
+//
+// # Ownership
+// - The returned buffer is exclusively owned by the caller and MUST be freed with `simlin_free`.
+// - The caller is responsible for freeing the buffer even if subsequent operations fail.
+void simlin_model_get_flows_json(SimlinModel *model,
+                                 uint8_t **out_buffer,
+                                 uintptr_t *out_len,
+                                 SimlinError **out_error);
+
+// Returns all auxiliaries in a model as a JSON array.
+//
+// The returned JSON is an array of auxiliary objects, each containing fields like
+// `name`, `equation`, `initialEquation`, `units`, `graphicalFunction`, etc.
+//
+// # Safety
+// - `model` must be a valid pointer to a SimlinModel
+// - `out_buffer` and `out_len` must be valid pointers where the serialized
+//   bytes and length will be written
+// - `out_error` may be null or a valid pointer to receive error details
+//
+// # Ownership
+// - The returned buffer is exclusively owned by the caller and MUST be freed with `simlin_free`.
+// - The caller is responsible for freeing the buffer even if subsequent operations fail.
+void simlin_model_get_auxs_json(SimlinModel *model,
+                                uint8_t **out_buffer,
+                                uintptr_t *out_len,
+                                SimlinError **out_error);
+
 // Creates a new simulation context
 //
 // # Safety

--- a/src/pysimlin/simlin/_ffi.py
+++ b/src/pysimlin/simlin/_ffi.py
@@ -246,6 +246,81 @@ def open_json(json_data: bytes) -> Any:
     return project_ptr
 
 
+def get_stocks_json(model_ptr: Any) -> bytes:
+    """Get all stocks in a model as JSON.
+
+    Args:
+        model_ptr: Pointer to a SimlinModel
+
+    Returns:
+        JSON-encoded array of stock objects (UTF-8 bytes)
+
+    Raises:
+        SimlinRuntimeError: If the operation fails
+    """
+    output_ptr = ffi.new("uint8_t **")
+    output_len_ptr = ffi.new("uintptr_t *")
+    err_ptr = ffi.new("SimlinError **")
+
+    lib.simlin_model_get_stocks_json(model_ptr, output_ptr, output_len_ptr, err_ptr)
+    check_out_error(err_ptr, "Get stocks JSON")
+
+    try:
+        return bytes(ffi.buffer(output_ptr[0], output_len_ptr[0]))
+    finally:
+        lib.simlin_free(output_ptr[0])
+
+
+def get_flows_json(model_ptr: Any) -> bytes:
+    """Get all flows in a model as JSON.
+
+    Args:
+        model_ptr: Pointer to a SimlinModel
+
+    Returns:
+        JSON-encoded array of flow objects (UTF-8 bytes)
+
+    Raises:
+        SimlinRuntimeError: If the operation fails
+    """
+    output_ptr = ffi.new("uint8_t **")
+    output_len_ptr = ffi.new("uintptr_t *")
+    err_ptr = ffi.new("SimlinError **")
+
+    lib.simlin_model_get_flows_json(model_ptr, output_ptr, output_len_ptr, err_ptr)
+    check_out_error(err_ptr, "Get flows JSON")
+
+    try:
+        return bytes(ffi.buffer(output_ptr[0], output_len_ptr[0]))
+    finally:
+        lib.simlin_free(output_ptr[0])
+
+
+def get_auxs_json(model_ptr: Any) -> bytes:
+    """Get all auxiliaries in a model as JSON.
+
+    Args:
+        model_ptr: Pointer to a SimlinModel
+
+    Returns:
+        JSON-encoded array of auxiliary objects (UTF-8 bytes)
+
+    Raises:
+        SimlinRuntimeError: If the operation fails
+    """
+    output_ptr = ffi.new("uint8_t **")
+    output_len_ptr = ffi.new("uintptr_t *")
+    err_ptr = ffi.new("SimlinError **")
+
+    lib.simlin_model_get_auxs_json(model_ptr, output_ptr, output_len_ptr, err_ptr)
+    check_out_error(err_ptr, "Get auxiliaries JSON")
+
+    try:
+        return bytes(ffi.buffer(output_ptr[0], output_len_ptr[0]))
+    finally:
+        lib.simlin_free(output_ptr[0])
+
+
 __all__ = [
     "ffi",
     "lib",
@@ -259,6 +334,9 @@ __all__ = [
     "apply_patch_json",
     "serialize_json",
     "open_json",
+    "get_stocks_json",
+    "get_flows_json",
+    "get_auxs_json",
     "_register_finalizer",
     "_finalizer_refs",
 ]

--- a/src/pysimlin/simlin/_ffi_build.py
+++ b/src/pysimlin/simlin/_ffi_build.py
@@ -149,6 +149,9 @@ void simlin_model_get_var_count(SimlinModel *model, uintptr_t *out_count, OutErr
 void simlin_model_get_var_names(SimlinModel *model, char **result, uintptr_t max, uintptr_t *out_written, OutError out_error);
 void simlin_model_get_incoming_links(SimlinModel *model, const char *var_name, char **result, uintptr_t max, uintptr_t *out_written, OutError out_error);
 SimlinLinks *simlin_model_get_links(SimlinModel *model, OutError out_error);
+void simlin_model_get_stocks_json(SimlinModel *model, uint8_t **out_buffer, uintptr_t *out_len, OutError out_error);
+void simlin_model_get_flows_json(SimlinModel *model, uint8_t **out_buffer, uintptr_t *out_len, OutError out_error);
+void simlin_model_get_auxs_json(SimlinModel *model, uint8_t **out_buffer, uintptr_t *out_len, OutError out_error);
 SimlinSim *simlin_sim_new(SimlinModel *model, bool enable_ltm, OutError out_error);
 void simlin_sim_ref(SimlinSim *sim);
 void simlin_sim_unref(SimlinSim *sim);


### PR DESCRIPTION
Add three new functions to libsimlin for directly retrieving variable
details as JSON arrays: simlin_model_get_stocks_json,
simlin_model_get_flows_json, and simlin_model_get_auxs_json. These
functions allow callers to get stocks, flows, or auxiliaries without
serializing the entire project.

The new APIs follow the existing libsimlin memory ownership pattern -
the returned buffer is owned by the caller and must be freed with
simlin_free(). This provides a significant simplification for engine2
and pysimlin, which previously had to serialize the entire project to
JSON just to access variable information.

Changes include:
- libsimlin: Three new FFI functions with proper documentation and tests
- engine2: WASM bindings and Model class simplification using direct APIs
- pysimlin: FFI bindings and Model class simplification using direct APIs

The simplification is particularly beneficial for large projects where
serializing the entire project is expensive when only variable info is
needed.

https://claude.ai/code/session_01PujQhTADskFsjJVY3GLuUQ