### PR TITLE
Fix variable creation 'Unknown error' toast

### DIFF
--- a/src/diagram/Editor.tsx
+++ b/src/diagram/Editor.tsx
@@ -470,8 +470,9 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     };
 
     try {
-      engine2.applyPatch(patch);
+      engine2.applyPatch(patch, { allowErrors: true });
     } catch (e: any) {
+      console.error('applyPatch error (rename):', e?.code, e?.message, e?.details);
       const msg = e?.message ?? 'Unknown error during rename';
       this.appendModelError(msg);
       return;
@@ -569,8 +570,9 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
         models: [{ name: modelName, ops: deleteOps }],
       };
       try {
-        engine2.applyPatch(patch);
+        engine2.applyPatch(patch, { allowErrors: true });
       } catch (e: any) {
+        console.error('applyPatch error (delete):', e?.code, e?.message, e?.details);
         this.appendModelError(e?.message ?? 'Unknown error during delete');
       }
     }
@@ -951,8 +953,9 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
         models: [{ name: this.state.modelName, ops }],
       };
       try {
-        engine2.applyPatch(patch);
+        engine2.applyPatch(patch, { allowErrors: true });
       } catch (e: any) {
+        console.error('applyPatch error (flow attach):', e?.code, e?.message, e?.details);
         this.appendModelError(e?.message ?? 'Unknown error during flow attach');
         this.setState({ selection, flowStillBeingCreated: inCreation });
         return;
@@ -1054,8 +1057,9 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
         models: [{ name: this.state.modelName, ops }],
       };
       try {
-        engine2.applyPatch(patch);
+        engine2.applyPatch(patch, { allowErrors: true });
       } catch (e: any) {
+        console.error('applyPatch error (view update):', e?.code, e?.message, e?.details);
         const msg = e?.message ?? 'Unknown error during view update';
         this.appendModelError(msg);
         return;
@@ -1116,8 +1120,9 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     };
 
     try {
-      engine2.applyPatch(patch);
+      engine2.applyPatch(patch, { allowErrors: true });
     } catch (e: any) {
+      console.error('applyPatch error (variable creation):', e?.code, e?.message, e?.details);
       this.appendModelError(e?.message ?? 'Unknown error during variable creation');
     }
 
@@ -1301,8 +1306,9 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     };
 
     try {
-      engine2.applyPatch(patch);
+      engine2.applyPatch(patch, { allowErrors: true });
     } catch (e: any) {
+      console.error('applyPatch error (sim specs):', e?.code, e?.message, e?.details);
       this.appendModelError(e?.message ?? 'Unknown error updating sim specs');
       return;
     }
@@ -1436,8 +1442,9 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
         models: [{ name: this.state.modelName, ops }],
       };
       try {
-        engine2.applyPatch(patch);
+        engine2.applyPatch(patch, { allowErrors: true });
       } catch (e: any) {
+        console.error('applyPatch error (queue view update):', e?.code, e?.message, e?.details);
         const msg = e?.message ?? 'Unknown error during view update';
         this.appendModelError(msg);
         return;
@@ -1839,8 +1846,9 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     };
 
     try {
-      engine2.applyPatch(patch);
+      engine2.applyPatch(patch, { allowErrors: true });
     } catch (e: any) {
+      console.error('applyPatch error (equation update):', e?.code, e?.message, e?.details);
       this.appendModelError(e?.message ?? 'Unknown error during equation update');
       return;
     }
@@ -1914,8 +1922,9 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     };
 
     try {
-      engine2.applyPatch(patch);
+      engine2.applyPatch(patch, { allowErrors: true });
     } catch (e: any) {
+      console.error('applyPatch error (table update):', e?.code, e?.message, e?.details);
       this.appendModelError(e?.message ?? 'Unknown error during table update');
       return;
     }

--- a/src/diagram/tests/editor-applyPatch.test.ts
+++ b/src/diagram/tests/editor-applyPatch.test.ts
@@ -1,0 +1,127 @@
+/**
+ * @jest-environment node
+ *
+ * Copyright 2025 The Simlin Authors. All rights reserved.
+ * Use of this source code is governed by the Apache License,
+ * Version 2.0, that can be found in the LICENSE file.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { Project as Engine2Project, configureWasm, ready } from '@system-dynamics/engine2';
+import { reset } from '@system-dynamics/engine2/internal/wasm';
+import { JsonProjectPatch } from '../json-types';
+
+async function loadWasm(): Promise<void> {
+  const wasmPath = path.join(__dirname, '..', '..', 'engine2', 'core', 'libsimlin.wasm');
+  const wasmBuffer = fs.readFileSync(wasmPath);
+  reset();
+  configureWasm({ source: wasmBuffer });
+  await ready();
+}
+
+function loadTestXmile(): Uint8Array {
+  const xmilePath = path.join(__dirname, '..', '..', 'pysimlin', 'tests', 'fixtures', 'teacup.stmx');
+  if (!fs.existsSync(xmilePath)) {
+    throw new Error('Required test XMILE model not found: ' + xmilePath);
+  }
+  return fs.readFileSync(xmilePath);
+}
+
+describe('applyPatch with variable creation', () => {
+  beforeAll(async () => {
+    await loadWasm();
+  });
+
+  it('should reject patch with empty equation when allowErrors is false', async () => {
+    const project = await Engine2Project.open(loadTestXmile());
+
+    const patch: JsonProjectPatch = {
+      models: [
+        {
+          name: 'main',
+          ops: [
+            {
+              type: 'upsertAux',
+              payload: { aux: { name: 'new_var', equation: '' } },
+            },
+          ],
+        },
+      ],
+    };
+
+    // Default behavior (allowErrors: false): throws when project has errors
+    expect(() => project.applyPatch(patch)).toThrow();
+
+    project.dispose();
+  });
+
+  it('should accept patch with empty equation when allowErrors is true', async () => {
+    const project = await Engine2Project.open(loadTestXmile());
+
+    const patch: JsonProjectPatch = {
+      models: [
+        {
+          name: 'main',
+          ops: [
+            {
+              type: 'upsertAux',
+              payload: { aux: { name: 'new_var', equation: '' } },
+            },
+          ],
+        },
+      ],
+    };
+
+    // With allowErrors: true, the patch should succeed
+    const errors = project.applyPatch(patch, { allowErrors: true });
+
+    // Variable should be created
+    const vars = project.mainModel.variables.map((v) => v.name);
+    expect(vars).toContain('new_var');
+
+    // Should return collected errors (empty equation warning)
+    expect(errors.length).toBeGreaterThan(0);
+    expect(errors.some((e) => e.variableName === 'new_var')).toBe(true);
+
+    project.dispose();
+  });
+
+  it('should provide descriptive error message when patch is rejected', async () => {
+    const project = await Engine2Project.open(loadTestXmile());
+
+    const patch: JsonProjectPatch = {
+      models: [
+        {
+          name: 'main',
+          ops: [
+            {
+              type: 'upsertAux',
+              payload: { aux: { name: 'bad_var', equation: '' } },
+            },
+          ],
+        },
+      ],
+    };
+
+    try {
+      project.applyPatch(patch); // allowErrors: false
+      throw new Error('Should have thrown');
+    } catch (e: unknown) {
+      const error = e as { message?: string; details?: Array<{ variableName?: string }> };
+      // Should NOT be "Unknown error"
+      if (error.message === 'Should have thrown') {
+        throw e;
+      }
+      expect(error.message).toBeDefined();
+      expect(error.message).not.toBe('Unknown error');
+      expect(error.message!.length).toBeGreaterThan(0);
+      // Should have details
+      expect(error.details).toBeDefined();
+      expect(error.details!.length).toBeGreaterThan(0);
+    }
+
+    project.dispose();
+  });
+});

--- a/src/libsimlin/src/lib.rs
+++ b/src/libsimlin/src/lib.rs
@@ -330,6 +330,14 @@ unsafe fn drop_links_vec(links: &mut Vec<SimlinLink>) {
 
 fn build_simlin_error(code: SimlinErrorCode, details: &[ErrorDetailData]) -> SimlinError {
     let mut error = SimlinError::new(code);
+
+    // Set top-level message from first detail's message, or construct from code
+    let message = details
+        .iter()
+        .find_map(|d| d.message.clone())
+        .unwrap_or_else(|| format!("{:?}", code));
+    error.set_message(Some(message));
+
     error.extend_details(details.iter().cloned());
     error
 }


### PR DESCRIPTION
## Summary

- Fix `build_simlin_error()` to set a top-level error message from the first detail's message (or construct one from the error code), preventing the JS side from falling back to "Unknown error"
- Update all 9 `applyPatch` calls in Editor.tsx to use `allowErrors: true`, allowing patches to succeed even when the model has errors (which are then shown in the UI rather than blocking the operation)
- Add console.error logging in catch blocks for debugging

## Test plan

- [x] Added `editor-applyPatch.test.ts` with tests verifying:
  - Patches with empty equations are rejected when `allowErrors: false`
  - Patches with empty equations succeed when `allowErrors: true`
  - Error messages are descriptive (not "Unknown error")
- [x] All existing tests pass (`cargo test && yarn test`)
- [ ] Manual testing: create a new variable in the editor, verify no error toast appears and the variable is created successfully