### PR TITLE
build: rename cloud-init.sh to dev-init.sh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,15 +72,15 @@ When navigating or editing, treat these paths as generated output or transient b
 - `src/app/build/**`, `website/build/**`
 - `node_modules/**`, `target/**`, `playwright-report/**`, `test-results/**`
 
-### Initial Environment Setup
+### Environment Setup
 
-For Claude Code on the web, Codex Web, or any fresh checkout, run the initialization script:
+**Always run at the start of every session** (agent or human, fresh container or long-running host):
 
 ```bash
-./scripts/cloud-init.sh
+./scripts/dev-init.sh
 ```
 
-**Important**: This script should be run any time the development environment is initialized or re-initialized (e.g., when a new container session starts, after a fresh clone, or when resuming work in a cloud environment). Running this script ensures the environment is properly configured so that you and other agents can be successful and productive.
+The script is idempotent and fast -- it short-circuits work that is already done (git hooks installed, pnpm deps up to date, AI tool already configured).  Run it unconditionally; there is no need to check whether it has already been run.
 
 ### Pre-commit Hooks
 

--- a/scripts/dev-init.sh
+++ b/scripts/dev-init.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 #
-# Cloud initialization script for Claude Code on the web and Codex Web.
-# This script sets up the development environment for Simlin, ensuring
-# that git hooks are installed and basic dependencies are checked.
+# Development environment initialization script.
+# Sets up git hooks, checks toolchain dependencies, installs pnpm
+# packages, and configures AI tools for the pre-commit hook.
 #
-# This script is idempotent - it can be run multiple times safely.
+# This script is idempotent and fast -- run it at the start of every
+# session (agent or human) to ensure the environment is ready.
 #
 set -euo pipefail
 
@@ -21,7 +22,7 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$REPO_ROOT"
 
 AI_CONFIG_FILE="$REPO_ROOT/.ai-tool-config"
-NODE_DEPS_STAMP_FILE="$REPO_ROOT/node_modules/.simlin-cloud-init-stamp"
+NODE_DEPS_STAMP_FILE="$REPO_ROOT/node_modules/.simlin-dev-init-stamp"
 INSTALL_CODEX="${SIMLIN_INIT_INSTALL_CODEX:-0}"
 PROBE_AI_TOOLS="${SIMLIN_INIT_AI_PROBE:-1}"
 REFRESH_AI_CONFIG="${SIMLIN_INIT_REFRESH_AI_CONFIG:-0}"

--- a/scripts/pre-commit
+++ b/scripts/pre-commit
@@ -61,7 +61,7 @@ fi
 # Check if node_modules exists
 if [ ! -d "node_modules" ]; then
     echo -e "${RED}node_modules is missing.${NC}"
-    echo -e "${YELLOW}Run './scripts/cloud-init.sh' to install dependencies and configure the environment.${NC}"
+    echo -e "${YELLOW}Run './scripts/dev-init.sh' to install dependencies and configure the environment.${NC}"
     exit 1
 fi
 
@@ -255,7 +255,7 @@ case "$SELECTED_AI_TOOL" in
         ;;
     none|*)
         echo -e " ${YELLOW}skipped (no AI tool available)${NC}"
-        echo -e "${YELLOW}Warning: No AI tool configured. Run ./scripts/cloud-init.sh to set up.${NC}"
+        echo -e "${YELLOW}Warning: No AI tool configured. Run ./scripts/dev-init.sh to set up.${NC}"
         rm -f "$AI_OUTPUT"
         ;;
 esac


### PR DESCRIPTION
The script is already fast and idempotent (git hook symlink check,
pnpm lockfile stamp, cached AI tool config), so there is no reason
to limit it to cloud/fresh-container environments.  Rename to
dev-init.sh and update CLAUDE.md to instruct agents and humans to
run it unconditionally at the start of every session.

https://claude.ai/code/session_01H8jKwLHh6MGqiY9L6jfmei