### PR TITLE
diagram, app: clean up MUI-isms in CSS and add component tests

### DIFF
--- a/src/app/Login.module.css
+++ b/src/app/Login.module.css
@@ -3,20 +3,21 @@
 }
 
 .outer {
-  display: table;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   position: absolute;
   height: 100%;
   width: 100%;
 }
 
 .middle {
-  display: table-cell;
-  vertical-align: middle;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
 
 .inner {
-  margin-left: auto;
-  margin-right: auto;
   text-align: center;
 }
 
@@ -24,10 +25,16 @@
   display: inline-block;
 }
 
+.optionsButtons {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+}
+
 .optionsButtons button {
-  margin: var(--spacing-1);
-  width: 220px;
-  justify-content: left;
+  width: 240px;
+  justify-content: flex-start;
 }
 
 .recoverInstructions {
@@ -43,8 +50,28 @@
 .logo {
   width: 160px;
   height: 160px;
+  margin-bottom: 24px;
+}
+
+.appleButton {
+  background-color: black;
+}
+
+.appleButton:hover {
+  background-color: #333;
+}
+
+.emailButton {
+  background-color: #db4437;
+}
+
+.emailButton:hover {
+  background-color: #c33d2e;
 }
 
 .emailForm {
   text-align: left;
+  min-width: 275px;
+  max-width: 360px;
+  width: 100%;
 }

--- a/src/app/Login.tsx
+++ b/src/app/Login.tsx
@@ -15,8 +15,6 @@ import {
   sendPasswordResetEmail,
   signInWithEmailAndPassword,
 } from '@firebase/auth';
-import clsx from 'clsx';
-
 import {
   AppleIcon,
   EmailIcon,
@@ -225,7 +223,6 @@ export class Login extends React.Component<LoginProps, LoginState> {
           loginUI = (
             <Card
               variant="outlined"
-              style={{ minWidth: 275, maxWidth: 360, width: '100%' }}
               className={styles.emailForm}
             >
               <form onSubmit={this.onNullSubmit}>
@@ -260,7 +257,6 @@ export class Login extends React.Component<LoginProps, LoginState> {
           loginUI = (
             <Card
               variant="outlined"
-              style={{ minWidth: 275, maxWidth: 360, width: '100%' }}
               className={styles.emailForm}
             >
               <form onSubmit={this.onNullSubmit}>
@@ -309,7 +305,6 @@ export class Login extends React.Component<LoginProps, LoginState> {
           loginUI = (
             <Card
               variant="outlined"
-              style={{ minWidth: 275, maxWidth: 360, width: '100%' }}
               className={styles.emailForm}
             >
               <form onSubmit={this.onNullSubmit}>
@@ -367,7 +362,6 @@ export class Login extends React.Component<LoginProps, LoginState> {
           loginUI = (
             <Card
               variant="outlined"
-              style={{ minWidth: 275, maxWidth: 360, width: '100%' }}
               className={styles.emailForm}
             >
               <form onSubmit={this.onNullSubmit}>
@@ -396,7 +390,6 @@ export class Login extends React.Component<LoginProps, LoginState> {
           loginUI = (
             <Card
               variant="outlined"
-              style={{ minWidth: 275, maxWidth: 360, width: '100%' }}
               className={styles.emailForm}
             >
               <form onSubmit={this.onNullSubmit}>
@@ -435,37 +428,33 @@ export class Login extends React.Component<LoginProps, LoginState> {
             <div className={styles.optionsButtons}>
               <Button
                 variant="contained"
-                style={{ backgroundColor: 'black' }}
+                className={styles.appleButton}
                 startIcon={<AppleIcon />}
                 onClick={this.appleLoginClick}
               >
                 Sign in with Apple
               </Button>
-              <br />
               <Button variant="contained" color="primary" startIcon={<GoogleIcon />} onClick={this.googleLoginClick}>
                 Sign in with Google
               </Button>
-              <br />
               <Button
                 variant="contained"
-                style={{ backgroundColor: '#db4437' }}
+                className={styles.emailButton}
                 startIcon={<EmailIcon />}
                 onClick={this.emailLoginClick}
               >
                 Sign in with email
               </Button>
-              <br />
             </div>
           );
       }
     }
 
     return (
-      <div className={clsx(styles.outer)}>
+      <div className={styles.outer}>
         <div className={styles.middle}>
           <div className={styles.inner}>
             <ModelIcon className={styles.logo} />
-            <br />
             <div className={disabledClass}>{loginUI}</div>
           </div>
         </div>

--- a/src/diagram/components/Button.module.css
+++ b/src/diagram/components/Button.module.css
@@ -14,7 +14,6 @@
   font-weight: 500;
   line-height: 1.75;
   letter-spacing: 0.02857em;
-  text-transform: uppercase;
   border-radius: 4px;
   min-width: 64px;
   transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1),
@@ -30,12 +29,12 @@
 
 /* Size variants */
 .sizeSmall {
-  padding: 4px 5px;
+  padding: 4px 10px;
   font-size: 0.8125rem;
 }
 
 .sizeMedium {
-  padding: 6px 8px;
+  padding: 6px 16px;
   font-size: 0.875rem;
 }
 

--- a/src/diagram/components/Card.module.css
+++ b/src/diagram/components/Card.module.css
@@ -20,12 +20,8 @@
   padding: 16px;
 }
 
-.cardContent:last-child {
-  padding-bottom: 24px;
-}
-
 .cardActions {
   display: flex;
   align-items: center;
-  padding: 8px;
+  padding: 8px 16px;
 }

--- a/src/diagram/components/Dialog.module.css
+++ b/src/diagram/components/Dialog.module.css
@@ -51,7 +51,7 @@
 
 .title {
   margin: 0;
-  padding: 16px 24px;
+  padding: 16px 24px 8px;
   font-size: 1.25rem;
   font-weight: 500;
   line-height: 1.6;
@@ -59,7 +59,7 @@
 }
 
 .dialogContent {
-  padding: 8px 24px;
+  padding: 12px 24px;
   flex: 1 1 auto;
   overflow-y: auto;
 }
@@ -74,7 +74,7 @@
 .actions {
   display: flex;
   align-items: center;
-  padding: 8px;
+  padding: 12px 16px;
   justify-content: flex-end;
   gap: 8px;
 }

--- a/src/diagram/components/FormControlLabel.module.css
+++ b/src/diagram/components/FormControlLabel.module.css
@@ -3,10 +3,9 @@
   align-items: center;
   cursor: pointer;
   vertical-align: middle;
-  margin-left: -11px;
-  margin-right: 16px;
+  gap: 8px;
 }
 
 .label {
-  padding: 9px;
+  line-height: 1.5;
 }

--- a/src/diagram/components/Menu.module.css
+++ b/src/diagram/components/Menu.module.css
@@ -25,9 +25,8 @@
 .menuItem {
   display: flex;
   align-items: center;
-  padding: 6px 16px;
-  min-height: 48px;
-  font-size: 1rem;
+  padding: 8px 16px;
+  font-size: 0.875rem;
   line-height: 1.5;
   cursor: pointer;
   color: rgba(0, 0, 0, 0.87);

--- a/src/diagram/components/Tabs.module.css
+++ b/src/diagram/components/Tabs.module.css
@@ -16,7 +16,6 @@
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;
   font-size: 0.875rem;
   font-weight: 500;
-  text-transform: uppercase;
   letter-spacing: 0.02857em;
   color: rgba(0, 0, 0, 0.6);
   transition: color 250ms cubic-bezier(0.4, 0, 0.2, 1);

--- a/src/diagram/components/TextField.module.css
+++ b/src/diagram/components/TextField.module.css
@@ -40,7 +40,7 @@
 
 .outlinedInput {
   font: inherit;
-  padding: 16.5px 14px;
+  padding: 10px 12px;
   border: none;
   outline: none;
   background: transparent;
@@ -50,10 +50,10 @@
 
 .outlinedLabel {
   display: block;
-  margin-bottom: 6px;
+  margin-bottom: 4px;
   color: rgba(0, 0, 0, 0.6);
-  font-size: 0.875rem;
   font: inherit;
+  font-size: 0.875rem;
   line-height: 1.4;
 }
 
@@ -97,7 +97,7 @@
 
 .standardInput {
   font: inherit;
-  padding: 4px 0 5px;
+  padding: 6px 0;
   border: none;
   outline: none;
   background: transparent;
@@ -107,10 +107,10 @@
 
 .standardLabel {
   display: block;
-  margin-bottom: 6px;
+  margin-bottom: 4px;
   color: rgba(0, 0, 0, 0.6);
-  font-size: 0.875rem;
   font: inherit;
+  font-size: 0.875rem;
   line-height: 1.4;
 }
 

--- a/src/diagram/tests/appbar-toolbar.test.tsx
+++ b/src/diagram/tests/appbar-toolbar.test.tsx
@@ -1,0 +1,70 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import AppBar from '../components/AppBar';
+import Toolbar from '../components/Toolbar';
+
+describe('AppBar', () => {
+  test('renders children', () => {
+    render(<AppBar>App Bar Content</AppBar>);
+    expect(screen.getByText('App Bar Content')).not.toBeNull();
+  });
+
+  test('renders as a header element', () => {
+    render(<AppBar>Content</AppBar>);
+    const header = screen.getByText('Content').closest('header');
+    expect(header).not.toBeNull();
+  });
+
+  test('applies static position by default', () => {
+    const { container } = render(<AppBar>Content</AppBar>);
+    const header = container.querySelector('header')!;
+    expect(header.className).toContain('positionStatic');
+  });
+
+  test('applies fixed position class', () => {
+    const { container } = render(<AppBar position="fixed">Content</AppBar>);
+    const header = container.querySelector('header')!;
+    expect(header.className).toContain('positionFixed');
+  });
+
+  test('applies sticky position class', () => {
+    const { container } = render(<AppBar position="sticky">Content</AppBar>);
+    const header = container.querySelector('header')!;
+    expect(header.className).toContain('positionSticky');
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(<AppBar className="custom-bar">Content</AppBar>);
+    const header = container.querySelector('header')!;
+    expect(header.className).toContain('custom-bar');
+  });
+});
+
+describe('Toolbar', () => {
+  test('renders children', () => {
+    render(<Toolbar>Toolbar Content</Toolbar>);
+    expect(screen.getByText('Toolbar Content')).not.toBeNull();
+  });
+
+  test('applies regular variant by default', () => {
+    const { container } = render(<Toolbar>Content</Toolbar>);
+    const toolbar = container.firstChild as HTMLElement;
+    expect(toolbar.className).toContain('regular');
+  });
+
+  test('applies dense variant', () => {
+    const { container } = render(<Toolbar variant="dense">Content</Toolbar>);
+    const toolbar = container.firstChild as HTMLElement;
+    expect(toolbar.className).toContain('dense');
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(<Toolbar className="custom-toolbar">Content</Toolbar>);
+    const toolbar = container.firstChild as HTMLElement;
+    expect(toolbar.className).toContain('custom-toolbar');
+  });
+});

--- a/src/diagram/tests/avatar.test.tsx
+++ b/src/diagram/tests/avatar.test.tsx
@@ -1,0 +1,50 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import Avatar from '../components/Avatar';
+
+describe('Avatar', () => {
+  test('renders an image when src is provided', () => {
+    render(<Avatar src="https://example.com/photo.jpg" alt="User" />);
+    const img = screen.getByRole('img');
+    expect(img.getAttribute('src')).toBe('https://example.com/photo.jpg');
+    expect(img.getAttribute('alt')).toBe('User');
+  });
+
+  test('renders children when no src is provided', () => {
+    render(<Avatar>AB</Avatar>);
+    expect(screen.getByText('AB')).not.toBeNull();
+  });
+
+  test('prefers image over children when src is provided', () => {
+    render(
+      <Avatar src="https://example.com/photo.jpg" alt="User">
+        AB
+      </Avatar>,
+    );
+    expect(screen.getByRole('img')).not.toBeNull();
+    expect(screen.queryByText('AB')).toBeNull();
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(<Avatar className="custom-avatar">AB</Avatar>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('custom-avatar');
+  });
+
+  test('applies custom style', () => {
+    const { container } = render(<Avatar style={{ width: 64, height: 64 }}>AB</Avatar>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.style.width).toBe('64px');
+  });
+
+  test('uses empty alt when alt is not provided', () => {
+    const { container } = render(<Avatar src="https://example.com/photo.jpg" />);
+    // Empty alt="" gives the image a presentation role, so query the DOM directly
+    const img = container.querySelector('img')!;
+    expect(img.getAttribute('alt')).toBe('');
+  });
+});

--- a/src/diagram/tests/button.test.tsx
+++ b/src/diagram/tests/button.test.tsx
@@ -1,0 +1,160 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import Button from '../components/Button';
+
+describe('Button', () => {
+  test('renders children text', () => {
+    render(<Button>Click me</Button>);
+    expect(screen.getByText('Click me')).not.toBeNull();
+  });
+
+  test('renders as a button element by default', () => {
+    render(<Button>Test</Button>);
+    const button = screen.getByRole('button');
+    expect(button.tagName).toBe('BUTTON');
+  });
+
+  test('renders as a label when component="label"', () => {
+    const { container } = render(<Button component="label">Label Button</Button>);
+    const label = container.querySelector('label');
+    expect(label).not.toBeNull();
+    expect(label!.textContent).toBe('Label Button');
+  });
+
+  test('calls onClick when clicked', () => {
+    const onClick = jest.fn();
+    render(<Button onClick={onClick}>Click</Button>);
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not call onClick when disabled', () => {
+    const onClick = jest.fn();
+    render(
+      <Button onClick={onClick} disabled>
+        Click
+      </Button>,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('applies contained primary classes', () => {
+    render(
+      <Button variant="contained" color="primary">
+        Primary
+      </Button>,
+    );
+    const button = screen.getByRole('button');
+    expect(button.className).toContain('containedPrimary');
+  });
+
+  test('applies contained secondary classes', () => {
+    render(
+      <Button variant="contained" color="secondary">
+        Secondary
+      </Button>,
+    );
+    const button = screen.getByRole('button');
+    expect(button.className).toContain('containedSecondary');
+  });
+
+  test('applies text variant by default', () => {
+    render(<Button>Text</Button>);
+    const button = screen.getByRole('button');
+    expect(button.className).toContain('textPrimary');
+  });
+
+  test('applies outlined primary classes', () => {
+    render(
+      <Button variant="outlined" color="primary">
+        Outlined
+      </Button>,
+    );
+    const button = screen.getByRole('button');
+    expect(button.className).toContain('outlinedPrimary');
+  });
+
+  test('applies outlined inherit classes', () => {
+    render(
+      <Button variant="outlined" color="inherit">
+        Inherit
+      </Button>,
+    );
+    const button = screen.getByRole('button');
+    expect(button.className).toContain('outlinedInherit');
+  });
+
+  test('applies size classes', () => {
+    const { rerender } = render(<Button size="small">Small</Button>);
+    expect(screen.getByRole('button').className).toContain('sizeSmall');
+
+    rerender(<Button size="large">Large</Button>);
+    expect(screen.getByRole('button').className).toContain('sizeLarge');
+  });
+
+  test('applies medium size by default', () => {
+    render(<Button>Medium</Button>);
+    expect(screen.getByRole('button').className).toContain('sizeMedium');
+  });
+
+  test('renders startIcon', () => {
+    render(<Button startIcon={<span data-testid="icon">★</span>}>With Icon</Button>);
+    expect(screen.getByTestId('icon')).not.toBeNull();
+    const iconWrapper = screen.getByTestId('icon').parentElement;
+    expect(iconWrapper!.className).toContain('startIcon');
+  });
+
+  test('applies disabled class for text variant', () => {
+    render(<Button disabled>Disabled</Button>);
+    expect(screen.getByRole('button').className).toContain('disabledText');
+  });
+
+  test('applies disabled class for contained variant', () => {
+    render(
+      <Button variant="contained" disabled>
+        Disabled
+      </Button>,
+    );
+    expect(screen.getByRole('button').className).toContain('disabledContained');
+  });
+
+  test('applies disabled class for outlined variant', () => {
+    render(
+      <Button variant="outlined" disabled>
+        Disabled
+      </Button>,
+    );
+    expect(screen.getByRole('button').className).toContain('disabledOutlined');
+  });
+
+  test('applies custom className', () => {
+    render(<Button className="custom">Custom</Button>);
+    expect(screen.getByRole('button').className).toContain('custom');
+  });
+
+  test('passes through aria attributes', () => {
+    render(
+      <Button aria-label="test label" aria-haspopup="true">
+        Aria
+      </Button>,
+    );
+    const button = screen.getByRole('button');
+    expect(button.getAttribute('aria-label')).toBe('test label');
+    expect(button.getAttribute('aria-haspopup')).toBe('true');
+  });
+
+  test('sets button type', () => {
+    render(<Button type="submit">Submit</Button>);
+    expect(screen.getByRole('button').getAttribute('type')).toBe('submit');
+  });
+
+  test('defaults to type="button"', () => {
+    render(<Button>Default</Button>);
+    expect(screen.getByRole('button').getAttribute('type')).toBe('button');
+  });
+});

--- a/src/diagram/tests/card.test.tsx
+++ b/src/diagram/tests/card.test.tsx
@@ -1,0 +1,89 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import Card, { CardContent, CardActions } from '../components/Card';
+
+describe('Card', () => {
+  test('renders children', () => {
+    render(<Card>Card content</Card>);
+    expect(screen.getByText('Card content')).not.toBeNull();
+  });
+
+  test('applies elevation variant by default', () => {
+    const { container } = render(<Card>Content</Card>);
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toContain('elevation');
+  });
+
+  test('applies outlined variant', () => {
+    const { container } = render(<Card variant="outlined">Content</Card>);
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toContain('outlined');
+    expect(card.className).not.toContain('elevation');
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(<Card className="custom">Content</Card>);
+    const card = container.firstChild as HTMLElement;
+    expect(card.className).toContain('custom');
+  });
+
+  test('applies custom style', () => {
+    const { container } = render(<Card style={{ maxWidth: 300 }}>Content</Card>);
+    const card = container.firstChild as HTMLElement;
+    expect(card.style.maxWidth).toBe('300px');
+  });
+});
+
+describe('CardContent', () => {
+  test('renders children', () => {
+    render(<CardContent>Inner content</CardContent>);
+    expect(screen.getByText('Inner content')).not.toBeNull();
+  });
+
+  test('applies cardContent class', () => {
+    const { container } = render(<CardContent>Content</CardContent>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('cardContent');
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(<CardContent className="custom">Content</CardContent>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('custom');
+  });
+});
+
+describe('CardActions', () => {
+  test('renders children', () => {
+    render(
+      <CardActions>
+        <button>Action</button>
+      </CardActions>,
+    );
+    expect(screen.getByText('Action')).not.toBeNull();
+  });
+
+  test('applies cardActions class', () => {
+    const { container } = render(
+      <CardActions>
+        <button>Action</button>
+      </CardActions>,
+    );
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('cardActions');
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(
+      <CardActions className="custom">
+        <button>Action</button>
+      </CardActions>,
+    );
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('custom');
+  });
+});

--- a/src/diagram/tests/checkbox.test.tsx
+++ b/src/diagram/tests/checkbox.test.tsx
@@ -1,0 +1,66 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import Checkbox from '../components/Checkbox';
+
+describe('Checkbox', () => {
+  test('renders a checkbox role', () => {
+    render(<Checkbox />);
+    expect(screen.getByRole('checkbox')).not.toBeNull();
+  });
+
+  test('calls onChange when clicked', () => {
+    const onChange = jest.fn();
+    render(<Checkbox onChange={onChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith(true);
+  });
+
+  test('toggles checked state', () => {
+    const onChange = jest.fn();
+    render(<Checkbox checked={true} onChange={onChange} />);
+    fireEvent.click(screen.getByRole('checkbox'));
+    expect(onChange).toHaveBeenCalledWith(false);
+  });
+
+  test('applies primary class by default', () => {
+    render(<Checkbox />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox.className).toContain('primary');
+  });
+
+  test('applies secondary class', () => {
+    render(<Checkbox color="secondary" />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox.className).toContain('secondary');
+  });
+
+  test('respects disabled prop', () => {
+    const onChange = jest.fn();
+    render(<Checkbox disabled onChange={onChange} />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox).toHaveProperty('disabled', true);
+  });
+
+  test('applies custom className', () => {
+    render(<Checkbox className="custom-check" />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox.className).toContain('custom-check');
+  });
+
+  test('renders with checked state', () => {
+    render(<Checkbox checked={true} />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox.getAttribute('data-state')).toBe('checked');
+  });
+
+  test('renders with unchecked state', () => {
+    render(<Checkbox checked={false} />);
+    const checkbox = screen.getByRole('checkbox');
+    expect(checkbox.getAttribute('data-state')).toBe('unchecked');
+  });
+});

--- a/src/diagram/tests/dialog.test.tsx
+++ b/src/diagram/tests/dialog.test.tsx
@@ -1,0 +1,117 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions } from '../components/Dialog';
+
+describe('Dialog', () => {
+  test('renders children when open', () => {
+    render(
+      <Dialog open={true}>
+        <div data-testid="dialog-child">Hello</div>
+      </Dialog>,
+    );
+    expect(screen.getByTestId('dialog-child')).not.toBeNull();
+  });
+
+  test('does not render children when closed', () => {
+    render(
+      <Dialog open={false}>
+        <div data-testid="dialog-child">Hello</div>
+      </Dialog>,
+    );
+    expect(screen.queryByTestId('dialog-child')).toBeNull();
+  });
+
+  test('applies custom className to content', () => {
+    render(
+      <Dialog open={true} className="custom-dialog">
+        <div>Content</div>
+      </Dialog>,
+    );
+    const content = document.querySelector('.custom-dialog');
+    expect(content).not.toBeNull();
+  });
+});
+
+describe('DialogTitle', () => {
+  // DialogTitle uses RadixDialog.Title which requires a Dialog context
+  test('renders children within Dialog', () => {
+    render(
+      <Dialog open={true}>
+        <DialogTitle>My Title</DialogTitle>
+      </Dialog>,
+    );
+    expect(screen.getByText('My Title')).not.toBeNull();
+  });
+
+  test('applies id attribute within Dialog', () => {
+    render(
+      <Dialog open={true}>
+        <DialogTitle id="test-title">Title</DialogTitle>
+      </Dialog>,
+    );
+    const title = screen.getByText('Title');
+    expect(title.id).toBe('test-title');
+  });
+
+  test('applies custom className within Dialog', () => {
+    render(
+      <Dialog open={true}>
+        <DialogTitle className="custom">Title</DialogTitle>
+      </Dialog>,
+    );
+    const title = screen.getByText('Title');
+    expect(title.className).toContain('custom');
+  });
+});
+
+describe('DialogContent', () => {
+  test('renders children', () => {
+    render(<DialogContent>Content area</DialogContent>);
+    expect(screen.getByText('Content area')).not.toBeNull();
+  });
+
+  test('applies dialogContent class', () => {
+    const { container } = render(<DialogContent>Content</DialogContent>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('dialogContent');
+  });
+});
+
+describe('DialogContentText', () => {
+  test('renders as a paragraph', () => {
+    render(<DialogContentText>Some text</DialogContentText>);
+    const p = screen.getByText('Some text');
+    expect(p.tagName).toBe('P');
+  });
+
+  test('applies contentText class', () => {
+    render(<DialogContentText>Text</DialogContentText>);
+    const p = screen.getByText('Text');
+    expect(p.className).toContain('contentText');
+  });
+});
+
+describe('DialogActions', () => {
+  test('renders children', () => {
+    render(
+      <DialogActions>
+        <button>OK</button>
+      </DialogActions>,
+    );
+    expect(screen.getByText('OK')).not.toBeNull();
+  });
+
+  test('applies actions class', () => {
+    const { container } = render(
+      <DialogActions>
+        <button>OK</button>
+      </DialogActions>,
+    );
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('actions');
+  });
+});

--- a/src/diagram/tests/form-control-label.test.tsx
+++ b/src/diagram/tests/form-control-label.test.tsx
@@ -1,0 +1,49 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import FormControlLabel from '../components/FormControlLabel';
+
+describe('FormControlLabel', () => {
+  test('renders label text', () => {
+    render(<FormControlLabel control={<input type="checkbox" />} label="Accept terms" />);
+    expect(screen.getByText('Accept terms')).not.toBeNull();
+  });
+
+  test('renders control element', () => {
+    render(<FormControlLabel control={<input type="checkbox" data-testid="ctrl" />} label="Label" />);
+    expect(screen.getByTestId('ctrl')).not.toBeNull();
+  });
+
+  test('wraps in a label element', () => {
+    const { container } = render(<FormControlLabel control={<input type="checkbox" />} label="Label" />);
+    const label = container.querySelector('label');
+    expect(label).not.toBeNull();
+  });
+
+  test('applies formControlLabel class', () => {
+    const { container } = render(<FormControlLabel control={<input type="checkbox" />} label="Label" />);
+    const label = container.querySelector('label');
+    expect(label!.className).toContain('formControlLabel');
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(
+      <FormControlLabel control={<input type="checkbox" />} label="Label" className="custom" />,
+    );
+    const label = container.querySelector('label');
+    expect(label!.className).toContain('custom');
+  });
+
+  test('renders React element as label', () => {
+    const complexLabel = (
+      <span>
+        I agree to the <a href="/terms">terms</a>
+      </span>
+    );
+    render(<FormControlLabel control={<input type="checkbox" />} label={complexLabel} />);
+    expect(screen.getByText('terms')).not.toBeNull();
+  });
+});

--- a/src/diagram/tests/icon-button.test.tsx
+++ b/src/diagram/tests/icon-button.test.tsx
@@ -1,0 +1,111 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import IconButton from '../components/IconButton';
+
+describe('IconButton', () => {
+  test('renders children', () => {
+    render(
+      <IconButton aria-label="test">
+        <span data-testid="icon">★</span>
+      </IconButton>,
+    );
+    expect(screen.getByTestId('icon')).not.toBeNull();
+  });
+
+  test('calls onClick when clicked', () => {
+    const onClick = jest.fn();
+    render(
+      <IconButton aria-label="test" onClick={onClick}>
+        ★
+      </IconButton>,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not call onClick when disabled', () => {
+    const onClick = jest.fn();
+    render(
+      <IconButton aria-label="test" onClick={onClick} disabled>
+        ★
+      </IconButton>,
+    );
+    fireEvent.click(screen.getByRole('button'));
+    expect(onClick).not.toHaveBeenCalled();
+  });
+
+  test('applies color inherit class', () => {
+    render(
+      <IconButton aria-label="test" color="inherit">
+        ★
+      </IconButton>,
+    );
+    expect(screen.getByRole('button').className).toContain('colorInherit');
+  });
+
+  test('applies size classes', () => {
+    const { rerender } = render(
+      <IconButton aria-label="test" size="small">
+        ★
+      </IconButton>,
+    );
+    expect(screen.getByRole('button').className).toContain('sizeSmall');
+
+    rerender(
+      <IconButton aria-label="test" size="large">
+        ★
+      </IconButton>,
+    );
+    expect(screen.getByRole('button').className).toContain('sizeLarge');
+  });
+
+  test('applies edge start class', () => {
+    render(
+      <IconButton aria-label="test" edge="start">
+        ★
+      </IconButton>,
+    );
+    expect(screen.getByRole('button').className).toContain('edgeStart');
+  });
+
+  test('applies edge end class', () => {
+    render(
+      <IconButton aria-label="test" edge="end">
+        ★
+      </IconButton>,
+    );
+    expect(screen.getByRole('button').className).toContain('edgeEnd');
+  });
+
+  test('applies disabled class', () => {
+    render(
+      <IconButton aria-label="test" disabled>
+        ★
+      </IconButton>,
+    );
+    expect(screen.getByRole('button').className).toContain('disabled');
+  });
+
+  test('applies custom className', () => {
+    render(
+      <IconButton aria-label="test" className="custom">
+        ★
+      </IconButton>,
+    );
+    expect(screen.getByRole('button').className).toContain('custom');
+  });
+
+  test('passes through aria-label', () => {
+    render(<IconButton aria-label="close menu">★</IconButton>);
+    expect(screen.getByRole('button').getAttribute('aria-label')).toBe('close menu');
+  });
+
+  test('renders as type="button"', () => {
+    render(<IconButton aria-label="test">★</IconButton>);
+    expect(screen.getByRole('button').getAttribute('type')).toBe('button');
+  });
+});

--- a/src/diagram/tests/image-list.test.tsx
+++ b/src/diagram/tests/image-list.test.tsx
@@ -1,0 +1,92 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import ImageList, { ImageListItem } from '../components/ImageList';
+
+describe('ImageList', () => {
+  test('renders as a list element', () => {
+    render(
+      <ImageList>
+        <ImageListItem>Item 1</ImageListItem>
+      </ImageList>,
+    );
+    const list = screen.getByRole('list');
+    expect(list.tagName).toBe('UL');
+  });
+
+  test('renders children', () => {
+    render(
+      <ImageList>
+        <ImageListItem>Item 1</ImageListItem>
+        <ImageListItem>Item 2</ImageListItem>
+      </ImageList>,
+    );
+    expect(screen.getByText('Item 1')).not.toBeNull();
+    expect(screen.getByText('Item 2')).not.toBeNull();
+  });
+
+  test('sets grid-template-columns based on cols prop', () => {
+    const { container } = render(
+      <ImageList cols={3}>
+        <ImageListItem>Item</ImageListItem>
+      </ImageList>,
+    );
+    const list = container.querySelector('ul')!;
+    expect(list.style.gridTemplateColumns).toBe('repeat(3, 1fr)');
+  });
+
+  test('defaults to 2 columns', () => {
+    const { container } = render(
+      <ImageList>
+        <ImageListItem>Item</ImageListItem>
+      </ImageList>,
+    );
+    const list = container.querySelector('ul')!;
+    expect(list.style.gridTemplateColumns).toBe('repeat(2, 1fr)');
+  });
+
+  test('sets gap based on gap prop', () => {
+    const { container } = render(
+      <ImageList gap={16}>
+        <ImageListItem>Item</ImageListItem>
+      </ImageList>,
+    );
+    const list = container.querySelector('ul')!;
+    expect(list.style.gap).toBe('16px');
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(
+      <ImageList className="custom-grid">
+        <ImageListItem>Item</ImageListItem>
+      </ImageList>,
+    );
+    const list = container.querySelector('ul')!;
+    expect(list.className).toContain('custom-grid');
+  });
+});
+
+describe('ImageListItem', () => {
+  test('renders as a list item', () => {
+    render(
+      <ImageList>
+        <ImageListItem>Content</ImageListItem>
+      </ImageList>,
+    );
+    const item = screen.getByText('Content');
+    expect(item.tagName).toBe('LI');
+  });
+
+  test('applies imageListItem class', () => {
+    render(
+      <ImageList>
+        <ImageListItem>Content</ImageListItem>
+      </ImageList>,
+    );
+    const item = screen.getByText('Content');
+    expect(item.className).toContain('imageListItem');
+  });
+});

--- a/src/diagram/tests/input-adornment.test.tsx
+++ b/src/diagram/tests/input-adornment.test.tsx
@@ -1,0 +1,36 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import InputAdornment from '../components/InputAdornment';
+
+describe('InputAdornment', () => {
+  test('renders children', () => {
+    render(<InputAdornment position="start">$</InputAdornment>);
+    expect(screen.getByText('$')).not.toBeNull();
+  });
+
+  test('applies start position class', () => {
+    const { container } = render(<InputAdornment position="start">$</InputAdornment>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('positionStart');
+  });
+
+  test('applies end position class', () => {
+    const { container } = render(<InputAdornment position="end">kg</InputAdornment>);
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('positionEnd');
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(
+      <InputAdornment position="start" className="custom">
+        $
+      </InputAdornment>,
+    );
+    const div = container.firstChild as HTMLElement;
+    expect(div.className).toContain('custom');
+  });
+});

--- a/src/diagram/tests/paper.test.tsx
+++ b/src/diagram/tests/paper.test.tsx
@@ -1,0 +1,50 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+import Paper from '../components/Paper';
+
+describe('Paper', () => {
+  test('renders children', () => {
+    render(<Paper>Paper content</Paper>);
+    expect(screen.getByText('Paper content')).not.toBeNull();
+  });
+
+  test('applies elevation1 class by default', () => {
+    const { container } = render(<Paper>Content</Paper>);
+    const paper = container.firstChild as HTMLElement;
+    expect(paper.className).toContain('elevation1');
+  });
+
+  test('applies elevation0 class when elevation is 0', () => {
+    const { container } = render(<Paper elevation={0}>Content</Paper>);
+    const paper = container.firstChild as HTMLElement;
+    expect(paper.className).toContain('elevation0');
+  });
+
+  test('applies elevation1 class for low elevations', () => {
+    const { container } = render(<Paper elevation={4}>Content</Paper>);
+    const paper = container.firstChild as HTMLElement;
+    expect(paper.className).toContain('elevation1');
+  });
+
+  test('applies elevation2 class for high elevations', () => {
+    const { container } = render(<Paper elevation={8}>Content</Paper>);
+    const paper = container.firstChild as HTMLElement;
+    expect(paper.className).toContain('elevation2');
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(<Paper className="custom">Content</Paper>);
+    const paper = container.firstChild as HTMLElement;
+    expect(paper.className).toContain('custom');
+  });
+
+  test('applies custom style', () => {
+    const { container } = render(<Paper style={{ padding: 20 }}>Content</Paper>);
+    const paper = container.firstChild as HTMLElement;
+    expect(paper.style.padding).toBe('20px');
+  });
+});

--- a/src/diagram/tests/svg-icon.test.tsx
+++ b/src/diagram/tests/svg-icon.test.tsx
@@ -1,0 +1,79 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render } from '@testing-library/react';
+import SvgIcon from '../components/SvgIcon';
+
+describe('SvgIcon', () => {
+  test('renders an svg element', () => {
+    const { container } = render(
+      <SvgIcon>
+        <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+      </SvgIcon>,
+    );
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+  });
+
+  test('applies default viewBox', () => {
+    const { container } = render(
+      <SvgIcon>
+        <path d="M10 20v-6h4v6h5v-8h3L12 3 2 12h3v8z" />
+      </SvgIcon>,
+    );
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('viewBox')).toBe('0 0 24 24');
+  });
+
+  test('applies custom viewBox', () => {
+    const { container } = render(
+      <SvgIcon viewBox="0 0 48 48">
+        <path d="M10 20" />
+      </SvgIcon>,
+    );
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('viewBox')).toBe('0 0 48 48');
+  });
+
+  test('sets aria-hidden', () => {
+    const { container } = render(
+      <SvgIcon>
+        <path d="M10 20" />
+      </SvgIcon>,
+    );
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  test('sets focusable to false', () => {
+    const { container } = render(
+      <SvgIcon>
+        <path d="M10 20" />
+      </SvgIcon>,
+    );
+    const svg = container.querySelector('svg')!;
+    expect(svg.getAttribute('focusable')).toBe('false');
+  });
+
+  test('applies svgIcon class', () => {
+    const { container } = render(
+      <SvgIcon>
+        <path d="M10 20" />
+      </SvgIcon>,
+    );
+    const svg = container.querySelector('svg')!;
+    expect(svg.className.baseVal).toContain('svgIcon');
+  });
+
+  test('applies custom className', () => {
+    const { container } = render(
+      <SvgIcon className="custom-icon">
+        <path d="M10 20" />
+      </SvgIcon>,
+    );
+    const svg = container.querySelector('svg')!;
+    expect(svg.className.baseVal).toContain('custom-icon');
+  });
+});

--- a/src/diagram/tests/text-link.test.tsx
+++ b/src/diagram/tests/text-link.test.tsx
@@ -1,0 +1,52 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import TextLink from '../components/TextLink';
+
+describe('TextLink', () => {
+  test('renders children', () => {
+    render(<TextLink>Click here</TextLink>);
+    expect(screen.getByText('Click here')).not.toBeNull();
+  });
+
+  test('renders as an anchor element', () => {
+    render(<TextLink href="https://example.com">Link</TextLink>);
+    const link = screen.getByText('Link');
+    expect(link.tagName).toBe('A');
+    expect(link.getAttribute('href')).toBe('https://example.com');
+  });
+
+  test('calls onClick when clicked', () => {
+    const onClick = jest.fn();
+    render(<TextLink onClick={onClick}>Click</TextLink>);
+    fireEvent.click(screen.getByText('Click'));
+    expect(onClick).toHaveBeenCalledTimes(1);
+  });
+
+  test('applies underline always by default', () => {
+    render(<TextLink>Link</TextLink>);
+    const link = screen.getByText('Link');
+    expect(link.className).toContain('underlineAlways');
+  });
+
+  test('applies underline hover class', () => {
+    render(<TextLink underline="hover">Link</TextLink>);
+    const link = screen.getByText('Link');
+    expect(link.className).toContain('underlineHover');
+  });
+
+  test('applies underline none class', () => {
+    render(<TextLink underline="none">Link</TextLink>);
+    const link = screen.getByText('Link');
+    expect(link.className).toContain('underlineNone');
+  });
+
+  test('applies custom className', () => {
+    render(<TextLink className="custom">Link</TextLink>);
+    const link = screen.getByText('Link');
+    expect(link.className).toContain('custom');
+  });
+});


### PR DESCRIPTION
Remove leftover Material UI design patterns from the Radix UI migration:
- Button: remove text-transform uppercase, increase padding from 6px 8px to
  6px 16px (medium) and 4px 10px (small) for better clickable area
- TextField: fix label font shorthand clobbering font-size, reduce outlined
  input padding from 16.5px to 10px, fix asymmetric standard input padding
- Card: remove last-child padding-bottom 24px hack, increase CardActions
  horizontal padding
- Dialog: improve spacing between title/content/actions
- FormControlLabel: replace negative margin-left with gap, remove 9px padding
- Menu: remove min-height 48px on items, use more compact sizing
- Tabs: remove text-transform uppercase

Login flow improvements:
- Replace <br> tags with flexbox gap for button spacing
- Move inline styles to CSS classes (card sizing, button colors)
- Modernize centering from display:table to flexbox
- Remove unused clsx import

Add unit tests for 12 previously untested diagram components: Button, Card,
IconButton, Dialog, Checkbox, Avatar, TextLink, FormControlLabel, AppBar,
Toolbar, Paper, ImageList, InputAdornment, SvgIcon.

https://claude.ai/code/session_01DSBRmxEbp7tktPzmtuWBFW