### PR TITLE
build: add design plan skills adapted from ed3d-plan-and-execute

### DIFF
--- a/.claude/skills/asking-clarifying-questions/SKILL.md
+++ b/.claude/skills/asking-clarifying-questions/SKILL.md
@@ -1,0 +1,326 @@
+---
+name: asking-clarifying-questions
+description: Use after initial design context is gathered, before brainstorming - resolves contradictions in requirements, disambiguates terminology, clarifies scope boundaries, and verifies assumptions to prevent building the wrong solution
+user-invocable: false
+---
+
+# Asking Clarifying Questions
+
+## Overview
+
+Bridge the gap between raw user input and structured brainstorming by understanding what the user actually means, not what they said.
+
+**Core principle:** Resolve contradictions first, then disambiguate. Conflicting goals must be reconciled before technical clarification - otherwise you're precisely defining the wrong thing.
+
+**Announce at start:** "I'm using the asking-clarifying-questions skill to make sure I understand your requirements correctly."
+
+## When to Use
+
+Use this skill:
+- After gathering initial context from user
+- Before starting brainstorming or design exploration
+- When user mentions technical terms that could mean multiple things
+- When scope boundaries are unclear
+- When assumptions need verification
+
+Do NOT use for:
+- Exploring design alternatives (that's brainstorming)
+- Proposing architectures (that's brainstorming)
+- Validating completed designs (that's brainstorming Phase 3)
+- Asking for initial requirements (that's start-design-plan Phase 1)
+
+## Before Clarifying
+
+Try to answer your own questions and disambiguate from the context of the working directory. Use the Task tool with `subagent_type: "Explore"` to search the codebase for existing work that can help explain the subject under clarification. When you recognize elements such as common technologies or proper nouns, use a `general-purpose` subagent with WebSearch/WebFetch instructions to synthesize both codebase and internet searches.
+
+## What to Clarify
+
+### 0. Contradictions (First Pass)
+
+Before disambiguating technical details, scan for logical contradictions in requirements. If the user has stated mutually exclusive goals, resolve these first - technical clarification is wasted effort if the foundation shifts.
+
+**Look for:**
+
+Explicit contradictions (user stated both):
+- "Real-time updates" + "batch processing is fine" → Which is the actual need?
+- "Keep it simple" + "handle every edge case" → Trade-off not acknowledged
+- "Use existing patterns" + "complete rewrite" → Mutually exclusive approaches
+- "No external dependencies" + "integrate with Stripe" → Implicit contradiction
+
+Impossible combinations:
+- "Offline-first" + "always-current data" → Physics problem
+- "Fast to build" + "infinitely extensible" → Classic impossible triangle
+- "Zero latency" + "synchronous validation" → Can't have both
+- "No breaking changes" + "fundamental redesign" → Pick one
+
+Unacknowledged trade-offs:
+- "Simple" often conflicts with "flexible"
+- "Fast" often conflicts with "thorough"
+- "Cheap" often conflicts with "custom"
+- "Secure" often conflicts with "convenient"
+
+**How to surface:**
+
+Don't accuse - illuminate the tension:
+- "I notice you mentioned X and Y - these can pull in different directions. Which takes priority?"
+- "There's a trade-off between A and B here. Which matters more for this project?"
+- "These two goals sometimes conflict - how should I balance them when they do?"
+
+**Why first:**
+- Contradictions reveal unconfronted trade-offs
+- Resolving them changes what "right" means
+- Technical disambiguation without this = building the wrong thing precisely
+
+**After contradictions are resolved**, proceed to technical clarification.
+
+### 1. Technical Terminology
+
+When user mentions technical terms, disambiguate what they actually mean.
+
+**Examples:**
+
+User says "OAuth2" -> Ask: Which flow?
+- Authorization code flow (for human users with browser redirect)
+- Client credentials flow (for service-to-service auth)
+- Both, depending on the use case
+
+User says "database" -> Ask: Which kind?
+- SQL (PostgreSQL, MySQL) for structured data
+- NoSQL (MongoDB, DynamoDB) for flexible schema
+- Already determined by existing infrastructure
+
+User says "caching" -> Ask: What layer?
+- Application-level (Redis, Memcached)
+- HTTP caching (CDN, browser cache)
+- Database query caching
+
+**Use AskUserQuestion for these** - present specific options with trade-offs.
+
+### 2. Scope Boundaries
+
+When user mentions broad concepts, identify what's included and excluded.
+
+**Examples:**
+
+User says "users" -> Ask: Who exactly?
+- Human users logging in via web browser
+- Service accounts for API access
+- Both, with different authentication flows
+- Internal employees vs external customers
+
+User says "integrate with X" -> Ask: What parts?
+- Just authentication
+- Full data sync
+- Specific API endpoints
+- Real-time webhooks vs batch imports
+
+User says "reporting" -> Ask: What scope?
+- Basic data export (CSV, Excel)
+- Interactive dashboards
+- Scheduled automated reports
+- Real-time analytics
+
+**Use AskUserQuestion** - present distinct scope options.
+
+### 3. Assumptions and Constraints
+
+When user states requirements, verify the underlying reasons and constraints.
+
+**Examples:**
+
+User says "must use library X" -> Ask: Why?
+- Regulatory requirement (cannot change)
+- Existing team expertise (preference, not hard requirement)
+- Already in use elsewhere (consistency benefit)
+- Misconception (might have better options)
+
+User says "needs to be fast" -> Ask: How fast?
+- Sub-100ms response time (hard requirement)
+- Faster than current implementation (relative improvement)
+- Perception of speed (optimistic UI, loading states)
+- Actual performance bottleneck identified
+
+User says "should follow pattern Y" -> Ask: Which aspect?
+- Exact implementation (strict consistency)
+- General approach (flexible adaptation)
+- Just using same libraries (tooling consistency)
+- Not actually required (outdated guideline)
+
+**Use open-ended questions** for understanding "why" - allows user to explain context.
+
+### 4. Version and API Specifics
+
+When user mentions external services or libraries, verify current state.
+
+**Examples:**
+
+User says "integrate with Stripe" -> Check:
+- Which Stripe API version (latest? specific?)
+- Payment Intents API or older Charges API
+- Which features needed (one-time, subscriptions, both)
+- Already have Stripe account setup
+
+User says "use React Router" -> Check:
+- React Router v5 or v6 (breaking changes between versions)
+- Already in use in codebase (follow existing patterns)
+- Browser Router vs Hash Router vs Memory Router
+
+**Quick agent queries for factual checks:**
+- "What version of X exists?" -> Quick web search or codebase check
+- "What's the current API?" -> Internet research for docs
+- "Is Y already in use?" -> Codebase investigation
+
+**Don't do deep research** - save that for brainstorming. Just verify basics.
+
+### 5. Definition of Done (Required Final Step)
+
+**Before handing off to brainstorming, you MUST establish the Definition of Done.**
+
+The Definition of Done answers: "What does success look like? What are the deliverables?"
+
+**After resolving contradictions and clarifying requirements:**
+
+1. **Infer the Definition of Done** from context gathered so far:
+   - What will exist when this is complete?
+   - What will users/systems be able to do?
+   - What are the concrete deliverables?
+
+2. **If you have a firm grasp**, state it back and confirm:
+   ```
+   Use AskUserQuestion:
+   "Based on our discussion, here's what I understand success looks like:
+
+   [State the definition of done in 2-4 bullet points]
+
+   Does this capture what you're trying to achieve?"
+
+   Options:
+   - "Yes, that's right" (proceed to brainstorming)
+   - "Partially, but..." (user will clarify)
+   - "No, let me explain..." (user will reframe)
+   ```
+
+3. **If the deliverables are still ambiguous**, ask targeted questions:
+   - "What should exist when this is done?"
+   - "How will you know this succeeded?"
+   - "What's the minimum viable deliverable?"
+
+**Why this matters:** Brainstorming explores *how* to achieve the goal. The goal must be locked in first. Otherwise you're exploring texture without knowing what shape you're filling.
+
+**The Definition of Done becomes part of the output bundle** and will appear prominently at the top of the final design document.
+
+## Question Techniques
+
+### Use AskUserQuestion for Choices
+
+When there are 2-4 distinct options with trade-offs:
+
+```
+Question: "Which OAuth2 flow are you targeting?"
+Options:
+  - "Authorization code flow" (human users with browser redirect)
+  - "Client credentials flow" (service-to-service automated auth)
+  - "Both flows" (supports human users AND service accounts)
+```
+
+**Benefits:**
+- Forces explicit choice
+- Shows trade-offs clearly
+- Prevents vague "maybe both" responses
+- Structured for decision-making
+
+### Use Open-Ended Questions for Why
+
+When you need to understand reasoning or context:
+
+"Why is X a requirement?"
+"What problem does Y solve?"
+"What happens if we don't include Z?"
+
+**Benefits:**
+- Uncovers hidden constraints
+- Reveals user's mental model
+- Identifies assumptions to challenge
+- Provides context for brainstorming
+
+### Use Quick Queries for Facts
+
+When you need to verify something factual:
+
+- Dispatch Explore agent: "Is library X already in use?"
+- Quick web search: "What's the current version of API Y?"
+- File read: "Check package.json for existing auth dependencies"
+
+**Don't get distracted** - these are quick checks, not research projects.
+
+## Output: Context Bundle for Brainstorming
+
+After clarification, create a clear summary to pass to brainstorming:
+
+**Resolved trade-offs:**
+- Speed over flexibility (chose simple implementation, accept less configurability)
+- Security over convenience (chose strict validation, accept more friction)
+- Consistency over ideal (chose existing patterns, accept suboptimal in isolation)
+
+**Clarified requirements:**
+- OAuth2 client credentials flow (service-to-service)
+- External customers only (not internal employees)
+- Stripe Payment Intents API (latest version)
+- Must comply with PCI DSS Level 1 (regulatory constraint)
+- "Fast" means sub-200ms p99 response time (measured requirement)
+
+**Verified assumptions:**
+- React Router v6 already in use (follow existing patterns)
+- PostgreSQL database (existing infrastructure)
+- No existing auth system (greenfield)
+
+**Scope boundaries:**
+- IN: Service account creation, token issuance, token validation
+- OUT: Human user login, SSO integration, password management
+
+This bundle gives brainstorming a concrete, unambiguous starting point.
+
+## Common Mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Ignoring contradictions in requirements | Surface conflicting goals before technical clarification |
+| Accepting vague terms at face value | Disambiguate every technical term |
+| Assuming scope without verification | Ask explicit boundary questions |
+| Not questioning "must have" requirements | Understand WHY behind constraints |
+| Doing deep research during clarification | Quick checks only, save research for brainstorming |
+| Proposing solutions while clarifying | Stay in understanding mode, no design yet |
+| Skipping clarification when "seems clear" | Always clarify, assumptions are dangerous |
+
+## When to Stop Clarifying
+
+Stop and move to brainstorming when:
+- Contradictions are resolved (trade-offs explicitly chosen)
+- Technical terms are disambiguated
+- Scope boundaries are explicit
+- Constraints are understood (not just stated)
+- Assumptions are verified
+- No major ambiguities remain
+
+**You don't need perfect information** - just enough to brainstorm effectively.
+
+If brainstorming reveals new ambiguities, you can return to clarification.
+
+## Integration with Design Workflow
+
+This skill sits between context gathering and brainstorming:
+
+```
+Context Gathering (start-design-plan Phase 1)
+  -> User provides: "Build OAuth2 integration for our API"
+
+Clarification (this skill)
+  -> Disambiguate: Which OAuth2 flow? What scope? Why OAuth2?
+  -> Output: Service accounts, client credentials, PCI compliance
+
+Brainstorming (start-design-plan Phase 4)
+  -> Explore: Architecture options, library choices, implementation phases
+  -> Uses clarified requirements as foundation
+```
+
+**Purpose:** Ensure brainstorming builds the right thing, not the wrong thing well.

--- a/.claude/skills/brainstorming/SKILL.md
+++ b/.claude/skills/brainstorming/SKILL.md
@@ -1,0 +1,340 @@
+---
+name: brainstorming
+description: Use when creating or developing anything, before writing code or implementation plans - refines rough ideas into fully-formed designs through structured Socratic questioning, alternative exploration, and incremental validation
+user-invocable: false
+---
+
+# Brainstorming Ideas Into Designs
+
+## Overview
+
+Transform rough ideas into fully-formed designs through structured questioning and alternative exploration.
+
+**Core principle:** Ask questions to understand, explore alternatives, present design incrementally for validation.
+
+**Announce at start:** "I'm using the brainstorming skill to refine your idea into a design."
+
+## Quick Reference
+
+| Phase | Key Activities | Tool Usage | Output |
+|-------|---------------|------------|--------|
+| **1. Understanding** | Ask questions (one at a time) | AskUserQuestion for choices, agents for research | Purpose, constraints, criteria |
+| **2. Exploration** | Propose 2-3 approaches | AskUserQuestion for approach selection, agents for patterns | Architecture options with trade-offs |
+| **3. Design Presentation** | Present in 200-300 word sections | Open-ended questions | Complete design with validation |
+
+## The Process
+
+**REQUIRED: Create task tracker at start**
+
+Use TaskCreate to create todos for each phase:
+
+- Phase 1: Understanding (purpose, constraints, criteria gathered)
+- Phase 2: Exploration (2-3 approaches proposed and evaluated)
+- Phase 3: Design Presentation (design validated in sections)
+
+Use TaskUpdate to mark each phase as in_progress when working on it, completed when finished.
+
+## Research Agents
+
+**DO NOT perform deep research yourself. Delegate to specialized agents.**
+
+### When to Use Explore Agents
+
+**Use the Task tool with `subagent_type: "Explore"` when you need to:**
+- Understand how existing features are implemented
+- Find where specific functionality lives in the codebase
+- Identify existing patterns to follow
+- Verify assumptions about codebase structure
+- Check if a feature already exists
+
+**Example delegation:**
+```
+Question: "How is authentication currently implemented?"
+Action: Dispatch Explore agent with: "Find authentication implementation, including file locations, patterns used, and dependencies"
+```
+
+### When to Use Internet Research
+
+**Use WebSearch/WebFetch aggressively when you need to:**
+- Find current API documentation for external services
+- Research library capabilities and best practices
+- Compare technology options
+- Understand current community recommendations
+- Find code examples and patterns from documentation
+- Verify "what's the latest version" type questions
+- Look up "how do people solve X" patterns
+
+**Example using WebSearch:**
+```
+Question: "What's the current Stripe API for subscriptions?"
+Action: Use WebSearch for: "Stripe subscriptions API latest version 2025"
+Then use WebFetch to read the official docs
+```
+
+For complex research requiring multiple queries, dispatch a `general-purpose` subagent (via the Task tool with `subagent_type: "general-purpose"`) with WebSearch/WebFetch instructions.
+
+**When to use internet research:**
+- External API documentation (always get latest)
+- "How do people solve X?" (community patterns)
+- Library comparison (which one is maintained?)
+- Best practices (what's current recommendation?)
+- Version checking (what's latest?)
+
+**Don't overdo it:**
+- Don't research things Claude already knows well
+- Don't research project-specific code (use Explore agents)
+- Don't research for every small decision
+
+**Balance:** Use research for external knowledge and current information. Use Claude's existing knowledge for general programming concepts.
+
+### Research Protocol
+
+**If codebase pattern exists:**
+1. Use Explore agent to find it
+2. Unless pattern is clearly unwise, assume it's the correct approach
+3. Design should follow existing patterns for consistency
+
+**If no codebase pattern exists:**
+1. Use internet research to find external patterns
+2. Present 2-3 approaches from research in Phase 2
+3. Let user choose which pattern to adopt
+
+**If research can't find answer:**
+- Redirect question to user via AskUserQuestion
+- Explain what was searched and not found
+- Present as a design decision for user to make
+
+**Be persistent with research:**
+- If first query doesn't yield results, refine the question
+- Try alternative search terms or approaches
+- Don't give up after one attempt
+
+## Phase 1: Understanding
+
+**Before asking questions:**
+
+1. **Investigate current state** - DON'T do this yourself:
+   - Dispatch Explore agent to verify project structure
+   - Ask it to find existing architecture and patterns
+   - Ask it to identify constraints from current codebase
+   - Review findings before proceeding
+
+2. **Then gather requirements:**
+   - Use TaskUpdate to mark Phase 1 as in_progress
+   - Ask ONE question at a time to refine the idea
+   - **Use AskUserQuestion tool** when you have multiple choice options
+   - **Use agents** when you need to verify technical information
+   - Gather: Purpose, constraints, success criteria
+   - Mark Phase 1 as completed when understanding is clear
+
+**Example using AskUserQuestion:**
+```
+Question: "Where should the authentication data be stored?"
+Options:
+  - "Session storage" (clears on tab close, more secure)
+  - "Local storage" (persists across sessions, more convenient)
+  - "Cookies" (works with SSR, compatible with older approach)
+```
+
+**When to delegate vs ask user:**
+- "Where is auth implemented?" -> Explore agent
+- "What auth library should we use?" -> WebSearch (if not in codebase)
+- "Do you want JWT or sessions?" -> AskUserQuestion (design decision)
+
+**Ask only useful, coherent, and effective questions:**
+Do not ask a question when only one answer is useful, coherent, and effective. For example, in an auth system with magic links and social logins:
+
+```
+Example (WRONG):
+What should happen when a logged-in user requests a magic link for their own email address?
+
+1. Send new magic link (allow re-login)
+   User can request magic links even when logged in. Useful for re-authentication or session refresh scenarios.
+2. Return error or redirect to home
+   Logged-in users can't request magic links. They must log out first. Simpler, prevents confusion.
+3. Silent success (no email sent)
+   Say 'check your email' but don't send anything. Prevents leaking login state but may confuse legitimate users.
+```
+
+In this case, only #1 is a useful, coherent, and effective option. Option #2 doesn't make any sense (magic links can be used to verify emails after a social login) and #3 is aggressively bad (lies to the user).
+
+```
+Example (WRONG):
+How should the magic link token verification be structured?
+
+1. Single-use token with immediate session creation
+   Token is consumed on first click, session created immediately. Simple flow. User can't re-click the link. Standard pattern for passwordless auth.
+2. Token valid for multiple users within TTL
+   Token can be used multiple times within 15 minutes. Allows re-clicking link if session cookie is lost. More complex state management.
+3. Token with idempotent verification
+   First use creates session, subsequent uses within TTL return same session. Safe re-clicking, prevents double-session creation. Moderate complexity.
+```
+
+No reasonably secure system would do either options #2 or #3. The way this question is written obviously indicates one acceptable answer and the other two answers are trap answers. Do not suggest trap answers for human users.
+
+**If you want to ask a question where there is only one useful, coherent, and effective path, state your assumption and continue onward.**
+
+**Do not ask questions just to ask them. If you have no useful, coherent, and effective questions, cease asking questions.**
+
+**If start-design-plan already gathered context:**
+- Phase 1 may be very short
+- Focus on remaining unknowns
+- Don't re-ask questions already answered in clarification
+- Still complete Phase 1 (don't skip it)
+
+## Phase 2: Exploration
+
+**Before proposing approaches:**
+
+1. **Research existing patterns** - DON'T do this yourself:
+   - Dispatch Explore agent: "Find similar features and patterns used"
+   - If similar feature exists, base one approach on that pattern
+   - If no codebase pattern, use internet research: "Find recommended approaches for [problem]"
+   - Review research findings before proposing
+
+2. **Then propose approaches:**
+   - Use TaskUpdate to mark Phase 2 as in_progress
+   - Propose 2-3 different approaches based on research
+   - At least one approach should follow codebase patterns (if they exist)
+   - For each: Core architecture, trade-offs, complexity assessment
+   - **Use AskUserQuestion tool** to present approaches as structured choices
+   - Mark Phase 2 as completed when approach is selected
+
+**Example using AskUserQuestion:**
+```
+Question: "Which architectural approach should we use?"
+Options:
+  - "Event-driven with message queue" (matches existing notification system, scalable, complex setup)
+  - "Direct API calls with retry logic" (simple, synchronous, easier to debug)
+  - "Hybrid with background jobs" (balanced, moderate complexity, best of both)
+```
+
+**Research integration:**
+- If codebase has pattern -> Present it as primary option (unless unwise)
+- If no codebase pattern -> Present internet research findings
+- If research yields nothing -> Ask user for direction
+
+## Phase 3: Design Presentation
+
+- Use TaskUpdate to mark Phase 3 as in_progress
+- Present in 200-300 word sections
+- Cover: Architecture, components, data flow, error handling, testing
+- **Use research agents if you need to verify technical details during presentation**
+- Ask after each section: "Does this look right so far?" (open-ended)
+- Use open-ended questions here to allow freeform feedback
+- Mark Phase 3 as completed when all sections validated
+
+**Level of detail:** Present architecture and components, not implementation code.
+
+- **Contracts/interfaces: OK.** If a component exposes an API or interface that other systems depend on, show the shape (types, method signatures, request/response formats).
+- **Implementation code: NOT OK.** Function bodies, algorithms, and executable logic belong in implementation plans, not design.
+
+The distinction: contracts define boundaries between components. Implementation defines behavior within components. Brainstorming validates the boundaries; implementation planning fills in the behavior.
+
+**Output:** Validated design held in conversation context, ready for documentation.
+
+## Question Patterns
+
+### When to Use AskUserQuestion Tool
+
+**Use AskUserQuestion for:**
+- Phase 1: Clarifying questions with 2-4 clear options
+- Phase 2: Architectural approach selection (2-3 alternatives)
+- Any decision with distinct, mutually exclusive choices
+- When options have clear trade-offs to explain
+- When research yields no answer (present as open decision)
+
+**Benefits:**
+- Structured presentation of options with descriptions
+- Clear trade-off visibility for partner
+- Forces explicit choice (prevents vague "maybe both" responses)
+
+### When to Use Open-Ended Questions
+
+**Use open-ended questions for:**
+- Phase 3: Design validation ("Does this look right so far?")
+- When you need detailed feedback or explanation
+- When partner should describe their own requirements
+- When structured options would limit creative input
+
+**Example decision flow:**
+- "What authentication method?" -> Use AskUserQuestion (2-4 options)
+- "Does this design handle your use case?" -> Open-ended (validation)
+
+### When to Use Research Agents
+
+**Use Explore agents for:**
+- "How is X implemented?" -> Agent finds and reports
+- "Where does Y live?" -> Agent locates files
+- "What pattern exists for Z?" -> Agent identifies pattern
+
+**Use internet research for:**
+- "What's the current API for X?" -> WebSearch finds docs
+- "How do other projects solve Y?" -> Research finds patterns
+- "What libraries exist for Z?" -> Research compares options
+
+**Don't do deep research yourself** - you'll consume context and may hallucinate. Delegate to agents or use web tools.
+
+## When to Revisit Earlier Phases
+
+**You can and should go backward when:**
+- Partner reveals new constraint during Phase 2 or 3 -> Return to Phase 1
+- Validation shows fundamental gap in requirements -> Return to Phase 1
+- Partner questions approach during Phase 3 -> Return to Phase 2
+- Something doesn't make sense -> Go back and clarify
+- Agent research reveals constraint you didn't know -> Reassess phase
+
+**Don't force forward linearly** when going backward would give better results.
+
+## Common Rationalizations - STOP
+
+These are violations of the skill requirements:
+
+| Excuse | Reality |
+|--------|---------|
+| "Idea is simple, can skip exploring alternatives" | Always propose 2-3 approaches. Comparison reveals issues. |
+| "Partner knows what they want, can skip questions" | Questions reveal hidden constraints. Always ask. |
+| "I'll present whole design at once for efficiency" | Incremental validation catches problems early. |
+| "Checklist is just a suggestion" | Create task todos with TaskCreate. Track progress properly. |
+| "I can research this quickly myself" | Use agents or web tools. You'll hallucinate or consume excessive context. |
+| "Agent didn't find it on first try, must not exist" | Be persistent. Refine query and try again. |
+| "Partner said yes, done with brainstorming" | Design is in conversation. Next step is documentation. |
+| "I know this codebase, don't need investigator" | You don't know current state. Always verify. |
+| "Obvious solution, skip research" | Codebase may have established pattern. Check first. |
+| "Don't need internet research for this" | External knowledge and current docs matter. Research when relevant. |
+| "I'll show the implementation so partner understands" | Show contracts/interfaces, not implementation. Implementation planning generates code later. |
+
+**All of these mean: STOP. Follow the requirements exactly.**
+
+## Key Principles
+
+| Principle | Application |
+|-----------|-------------|
+| **One question at a time** | YOU MUST ask single questions in Phase 1, use AskUserQuestion for choices |
+| **Delegate research** | YOU MUST use agents or web tools for codebase and internet research, never do it yourself |
+| **Be persistent with research** | If search doesn't find answer, refine query and try again before asking user |
+| **Follow existing patterns** | If codebase pattern exists and is reasonable, design must follow it |
+| **Structured choices** | YOU MUST use AskUserQuestion tool for 2-4 options with trade-offs |
+| **YAGNI ruthlessly** | Remove unnecessary features from all designs |
+| **Explore alternatives** | YOU MUST propose 2-3 approaches before settling |
+| **Incremental validation** | Present design in sections, validate each - never all at once |
+| **Task tracking** | YOU MUST create task todos at start with TaskCreate, update with TaskUpdate as you progress |
+| **Flexible progression** | Go backward when needed - flexibility > rigidity |
+| **Internet research matters** | Use WebSearch/WebFetch for external knowledge and current information |
+
+## After Brainstorming
+
+When Phase 3 is complete, announce:
+
+"Design is validated and ready for documentation."
+
+**Next step:** The orchestrating skill (start-design-plan) will invoke writing-design-plans to document this design.
+
+**You do NOT:**
+- Write design document (that's writing-design-plans)
+- Create implementation plans (that happens after /clear, in a fresh session)
+
+**You DO:**
+- Hold validated design in conversation context
+- Have clear understanding of architecture, components, and approach
+- Know which existing patterns were followed (from investigation)

--- a/.claude/skills/start-design-plan/SKILL.md
+++ b/.claude/skills/start-design-plan/SKILL.md
@@ -1,0 +1,363 @@
+---
+name: start-design-plan
+description: Start collaborative design process with brainstorming and planning
+---
+
+# Starting a Design Plan
+
+## Overview
+
+Orchestrate the complete design workflow from initial idea to implementation-ready documentation through six structured phases: context gathering, clarification, definition of done, brainstorming, design documentation, and planning handoff.
+
+**Core principle:** Progressive information gathering -> clear understanding -> creative exploration -> validated design -> documented plan.
+
+**Announce at start:** "I'm using the start-design-plan skill to guide us through the design process."
+
+## Quick Reference
+
+| Phase | Key Activities | Output |
+|-------|---------------|--------|
+| **1. Context Gathering** | Ask for freeform description, constraints, goals, URLs, files | Initial context bundle |
+| **2. Clarification** | Invoke asking-clarifying-questions skill | Disambiguated requirements |
+| **3. Definition of Done** | Synthesize and confirm deliverables before brainstorming | Confirmed success criteria |
+| **4. Brainstorming** | Invoke brainstorming skill | Validated design (in conversation) |
+| **5. Design Documentation** | Invoke writing-design-plans skill | Committed design document |
+| **6. Planning Handoff** | Provide plan-mode + review guidance | Implementation instructions |
+
+## The Process
+
+**REQUIRED: Create task tracker at start**
+
+Use TaskCreate to create todos for each phase:
+
+- Phase 1: Context Gathering (initial information collected)
+- (conditional) Read project design guidance (if `doc/design-plan-guidance.md` exists)
+- Phase 2: Clarification (requirements disambiguated)
+- Phase 3: Definition of Done (deliverables confirmed)
+- Phase 4: Brainstorming (design validated)
+- Phase 5: Design Documentation (design written to doc/design/)
+- Phase 6: Planning Handoff (implementation instructions provided)
+
+Use TaskUpdate to mark each phase as in_progress when working on it, completed when finished.
+
+### Phase 1: Context Gathering
+
+**Never skip this phase.** Even if the user provides detailed information, ask for anything missing.
+
+Use TaskUpdate to mark Phase 1 as in_progress.
+
+**Ask the user to provide (freeform, not AskUserQuestion):**
+
+"I need some information to start the design process. Please provide what you have:
+
+**What are you designing?**
+- High-level description of what you want to build
+- Goals or success criteria
+- Any known constraints or requirements
+
+**Context materials (very helpful if available):**
+- URLs to relevant documentation, APIs, or examples
+- File paths to existing code or specifications in this repository
+- Any research you've already done
+
+**Project state:**
+- Are you starting fresh or extending existing functionality?
+- Are there existing patterns in the codebase I should follow?
+- Any architectural decisions already made?
+
+Share whatever details you have. We'll clarify anything unclear in the next step."
+
+**Progressive prompting:** If user already provided some of this information, acknowledge what you have and ask only for what's missing.
+
+**Example:**
+"You mentioned OAuth2 integration. I have the high-level goal. To help design this effectively, I need:
+- Any constraints (regulatory, existing auth system, etc.)
+- URLs to the OAuth2 provider's documentation (if you have them)
+- Whether this is for human users, service accounts, or both"
+
+Mark Phase 1 as completed when you have initial context.
+
+### Between Phase 1 and Phase 2: Check for Project Guidance
+
+Before clarification, check for project-specific design guidance.
+
+**Check if `doc/design-plan-guidance.md` exists:**
+
+Use the Read tool to check if `doc/design-plan-guidance.md` exists in the session's working directory.
+
+**If the file exists:**
+
+1. Use TaskCreate to add: "Read project design guidance from [absolute path to doc/design-plan-guidance.md]"
+   - Set this task as blocked by Phase 1 (Context Gathering)
+   - Update Phase 2 (Clarification) to be blocked by this new task
+2. Mark the task in_progress
+3. Read the file and incorporate the guidance into your understanding
+4. Mark the task completed
+5. Proceed to Phase 2
+
+**If the file does not exist:**
+
+Proceed directly to Phase 2. Do not create a task or mention the missing file.
+
+**What project guidance provides:**
+- Domain-specific terminology to use in clarification
+- Architectural constraints or preferences
+- Technologies that are required, preferred, or forbidden
+- Stakeholders and their priorities
+- Project conventions that designs must follow
+
+The guidance informs what questions you ask during clarification.
+
+### Phase 2: Clarification
+
+Use TaskUpdate to mark Phase 2 as in_progress.
+
+**REQUIRED SUB-SKILL:** Use asking-clarifying-questions
+
+Announce: "I'm using the asking-clarifying-questions skill to make sure I understand your requirements correctly."
+
+The clarification skill will:
+- Use subagents to try to disambiguate before raising questions to the user
+- Disambiguate technical terms ("OAuth2" -> which flow?)
+- Identify scope boundaries ("users" -> humans? services? both?)
+- Clarify assumptions ("integrate with X" -> which version?)
+- Understand constraints ("must use Y" -> why?)
+
+**Output:** Clear understanding of what user means, ready to confirm Definition of Done.
+
+Mark Phase 2 as completed when requirements are disambiguated.
+
+### Phase 3: Definition of Done
+
+Before brainstorming the *how*, lock in the *what*. Brainstorming explores texture and approach -- it assumes the goal is already clear.
+
+Use TaskUpdate to mark Phase 3 as in_progress.
+
+**Synthesize the Definition of Done from context gathered so far:**
+
+From Phases 1-2 (Context Gathering and Clarification), you should be able to infer or extract:
+- What the deliverables are (what gets built/changed)
+- What success looks like (how we know it's done)
+- What's explicitly out of scope
+
+**If the Definition of Done is clear:**
+
+State it back to the user and confirm using AskUserQuestion:
+
+```
+Question: "Before we explore approaches, let me confirm what success looks like:"
+Options:
+  - "Yes, that's right" (Definition of Done is accurate)
+  - "Needs adjustment" (User will clarify what's missing or wrong)
+```
+
+Present the Definition of Done as a brief statement (2-4 sentences) covering:
+- Primary deliverable(s)
+- Success criteria
+- Key exclusions (if any were discussed)
+
+**If the Definition of Done is unclear:**
+
+Ask targeted questions to nail it down. Use AskUserQuestion when there are discrete options, or open-ended questions when you need the user to describe their vision.
+
+Examples of clarifying questions:
+- "What's the primary deliverable here -- is it [X] or [Y]?"
+- "How will you know this is done? What would you test or demonstrate?"
+- "You mentioned [feature]. Is that in scope for this design, or a future addition?"
+
+**Do not proceed to brainstorming until Definition of Done is confirmed.**
+
+#### Create Design Document Immediately After Confirmation
+
+**REQUIRED:** Once the user confirms the Definition of Done, create the design document file immediately. This captures the DoD at full fidelity before brainstorming begins.
+
+##### Step 1: Get Design Plan Name
+
+The slug becomes part of all acceptance criteria identifiers (e.g., `my-feature.AC1.1`) and appears in test names. Ask the user to choose it explicitly.
+
+**Generate 2-3 suggested slugs** based on the conversation context. Good slugs are:
+- Lowercase with hyphens (no spaces, underscores, or special characters)
+- **Terse but unambiguous** -- prefer short forms that don't create confusion (e.g., `authn` not `authentication`, but not `auth` since that's ambiguous with `authz`)
+- Recognizable months later
+
+**Use AskUserQuestion:**
+
+```
+Question: "What should we call this design plan? The name becomes the prefix for all acceptance criteria (e.g., `{slug}.AC1.1`) and appears in test names.
+
+If you have a ticketing system, you can use the ticket name (e.g., PROJ-1234)."
+
+Options:
+  - "[auto-generated-slug-1]" (e.g., "oauth2-svc-authn")
+  - "[auto-generated-slug-2]" (e.g., "svc-authn")
+  - "[auto-generated-slug-3]" (if meaningfully different)
+```
+
+**If user selects "Other":** They can provide any name. Normalize it:
+- Ticket names (pattern: `UPPERCASE-DIGITS`, e.g., `PROJ-1234`): keep as-is
+- Descriptive names: lowercase, hyphens for spaces, strip invalid characters (e.g., "My Cool Feature" -> `my-cool-feature`)
+
+##### Step 2: Create File
+
+**File location:** `doc/design/YYYY-MM-DD-{slug}.md`
+
+Use today's date and the user-chosen slug.
+
+**Initial file contents:**
+
+```markdown
+# [Feature Name] Design
+
+## Summary
+<!-- TO BE GENERATED after body is written -->
+
+## Definition of Done
+[The confirmed Definition of Done - copy exactly as confirmed with user]
+
+## Acceptance Criteria
+<!-- TO BE GENERATED and validated before glossary -->
+
+## Glossary
+<!-- TO BE GENERATED after body is written -->
+```
+
+**Why write immediately:**
+- Captures Definition of Done at peak resolution (right after user confirmation)
+- Prevents fidelity loss during brainstorming conversation
+- Creates working document that grows incrementally
+- Acceptance Criteria, Summary, and Glossary filled in later by writing-design-plans skill
+
+Mark Phase 3 as completed when user confirms the Definition of Done AND the file is created.
+
+### Phase 4: Brainstorming
+
+With clear understanding from Phases 1-3, explore design alternatives and validate the approach.
+
+Use TaskUpdate to mark Phase 4 as in_progress.
+
+**REQUIRED SUB-SKILL:** Use brainstorming
+
+Announce: "I'm using the brainstorming skill to explore design alternatives and validate the approach."
+
+**Pass context to brainstorming:**
+- Information gathered in Phase 1
+- Clarifications from Phase 2
+- Confirmed Definition of Done from Phase 3
+- This reduces Phase 1 of brainstorming (Understanding) since much is already known
+
+The brainstorming skill will:
+- Complete any remaining understanding gaps (Phase 1)
+- Propose 2-3 architectural approaches (Phase 2)
+- Present design incrementally for validation (Phase 3)
+- Use research agents for codebase patterns and external knowledge
+
+**Output:** Validated design held in conversation context.
+
+Mark Phase 4 as completed when design is validated.
+
+### Phase 5: Design Documentation
+
+Append the validated design to the document created in Phase 3.
+
+Use TaskUpdate to mark Phase 5 as in_progress.
+
+**REQUIRED SUB-SKILL:** Use writing-design-plans
+
+Announce: "I'm using the writing-design-plans skill to complete the design document."
+
+**Important:** The design document already exists from Phase 3 with:
+- Title
+- Summary placeholder
+- Confirmed Definition of Done
+- Acceptance Criteria placeholder
+- Glossary placeholder
+
+The writing-design-plans skill will:
+- Append body sections (Architecture, Existing Patterns, Implementation Phases, Additional Considerations) to the existing file
+- Structure with implementation phases (<=8 recommended)
+  - DO NOT pad out phases in order to reach the number of 8. 8 is the maximum, not the target.
+- Document existing patterns followed
+- Generate Acceptance Criteria (success + failure cases for each DoD item), get human validation
+- Generate Summary and Glossary to replace placeholders
+- Commit to git
+
+**Output:** Committed design document ready for implementation.
+
+Mark Phase 5 as completed when design document is committed.
+
+### Phase 6: Planning Handoff
+
+After design is documented, guide user to implement in fresh context.
+
+Use TaskUpdate to mark Phase 6 as in_progress.
+
+**Do NOT start implementation directly.** The user needs to /clear context first.
+
+Announce design completion and provide next steps:
+
+```
+Design complete! Design document committed to `doc/design/[filename]`.
+
+Ready to implement? This requires fresh context to work effectively.
+
+**IMPORTANT: Copy the instructions below BEFORE running /clear (it will erase this conversation).**
+
+(1) Copy these instructions now:
+    - Reference the design document: @doc/design/[full-filename].md
+    - Enter plan mode and ask Claude to implement the design
+    - Use the verification-before-completion skill: never claim work is done
+      without running verification commands and confirming output
+    - After plan approval and implementation, create a PR
+    - Run `/address-feedback-github` to iterate on review feedback
+
+(2) Clear your context:
+/clear
+
+(3) Start a new conversation referencing the design document.
+```
+
+**Why /clear instead of continuing:**
+- Implementation needs fresh context for codebase investigation
+- Long conversations accumulate context that degrades quality
+- /clear gives the next phase a clean slate
+
+Mark Phase 6 as completed after providing instructions.
+
+## When to Revisit Earlier Phases
+
+You can and should go backward when:
+- Phase 2 reveals fundamental gaps -> Return to Phase 1
+- Phase 3 reveals unclear deliverables -> Return to Phase 2 for more clarification
+- Phase 4 uncovers new constraints -> Return to Phase 1, 2, or 3
+- User questions approach during Phase 4 -> Return to Phase 2
+- Phase 4 changes the Definition of Done -> Return to Phase 3 to reconfirm
+- Design documentation reveals missing details -> Return to Phase 4
+
+**Don't force forward linearly** when going backward gives better results.
+
+## Common Rationalizations - STOP
+
+| Excuse | Reality |
+|--------|---------|
+| "User provided details, can skip context gathering" | Always run Phase 1. Ask for what's missing. |
+| "Requirements are clear, skip clarification" | Clarification prevents misunderstandings. Always run Phase 2. |
+| "I know what done looks like, skip confirmation" | Confirm Definition of Done explicitly. Always run Phase 3. |
+| "Simple idea, skip brainstorming" | Brainstorming explores alternatives. Always run Phase 4. |
+| "Design is in conversation, don't need documentation" | Documentation is the contract for implementation. Always run Phase 5. |
+| "Can start implementing directly" | Must /clear first for fresh context. Provide implementation handoff instructions. |
+| "I can combine phases for efficiency" | Each phase has distinct purpose. Run all six. |
+| "User knows what they want, less structure needed" | Structure ensures nothing is missed. Follow all phases. |
+
+**All of these mean: STOP. Run all six phases in order.**
+
+## Key Principles
+
+| Principle | Application |
+|-----------|-------------|
+| **Never skip brainstorming** | Even with detailed specs, always run Phase 4 (may be shorter) |
+| **Progressive prompting** | Ask for less if user already provided some context |
+| **Clarify before ideating** | Phase 2 prevents building the wrong thing |
+| **Lock in the goal before exploring** | Phase 3 confirms what "done" means before brainstorming the how |
+| **All brains in skills** | This skill orchestrates; sub-skills contain domain expertise |
+| **Task tracking** | YOU MUST create todos with TaskCreate and update with TaskUpdate for all phases |
+| **Flexible progression** | Go backward when needed to fill gaps |

--- a/.claude/skills/verification-before-completion/SKILL.md
+++ b/.claude/skills/verification-before-completion/SKILL.md
@@ -1,0 +1,138 @@
+---
+name: verification-before-completion
+description: Use when about to claim work is complete, fixed, or passing, before committing or creating PRs - requires running verification commands and confirming output before making any success claims; evidence before assertions always
+user-invocable: false
+---
+
+# Verification Before Completion
+
+## Overview
+
+Claiming work is complete without verification is dishonesty, not efficiency.
+
+**Core principle:** Evidence before claims, always.
+
+**Violating the letter of this rule is violating the spirit of this rule.**
+
+## The Iron Law
+
+```
+NO COMPLETION CLAIMS WITHOUT FRESH VERIFICATION EVIDENCE
+```
+
+If you haven't run the verification command in this message, you cannot claim it passes.
+
+## The Gate Function
+
+```
+BEFORE claiming any status or expressing satisfaction:
+
+1. IDENTIFY: What command proves this claim?
+2. RUN: Execute the FULL command (fresh, complete)
+3. READ: Full output, check exit code, count failures
+4. VERIFY: Does output confirm the claim?
+   - If NO: State actual status with evidence
+   - If YES: State claim WITH evidence
+5. ONLY THEN: Make the claim
+
+Skip any step = lying, not verifying
+```
+
+## Common Failures
+
+| Claim | Requires | Not Sufficient |
+|-------|----------|----------------|
+| Tests pass | Test command output: 0 failures | Previous run, "should pass" |
+| Linter clean | Linter output: 0 errors | Partial check, extrapolation |
+| Build succeeds | Build command: exit 0 | Linter passing, logs look good |
+| Bug fixed | Test original symptom: passes | Code changed, assumed fixed |
+| Regression test works | Red-green cycle verified | Test passes once |
+| Agent completed | VCS diff shows changes | Agent reports "success" |
+| Requirements met | Line-by-line checklist | Tests passing |
+
+## Red Flags - STOP
+
+- Using "should", "probably", "seems to"
+- Expressing satisfaction before verification ("Great!", "Perfect!", "Done!", etc.)
+- About to commit/push/PR without verification
+- Trusting agent success reports
+- Relying on partial verification
+- Thinking "just this once"
+- Tired and wanting work over
+- **ANY wording implying success without having run verification**
+
+## Rationalization Prevention
+
+| Excuse | Reality |
+|--------|---------|
+| "Should work now" | RUN the verification |
+| "I'm confident" | Confidence ≠ evidence |
+| "Just this once" | No exceptions |
+| "Linter passed" | Linter ≠ compiler |
+| "Agent said success" | Verify independently |
+| "I'm tired" | Exhaustion ≠ excuse |
+| "Partial check is enough" | Partial proves nothing |
+| "Different words so rule doesn't apply" | Spirit over letter |
+
+## Key Patterns
+
+**Tests:**
+```
+✅ [Run test command] [See: 34/34 pass] "All tests pass"
+❌ "Should pass now" / "Looks correct"
+```
+
+**Regression tests (TDD Red-Green):**
+```
+✅ Write → Run (pass) → Revert fix → Run (MUST FAIL) → Restore → Run (pass)
+❌ "I've written a regression test" (without red-green verification)
+```
+
+**Build:**
+```
+✅ [Run build] [See: exit 0] "Build passes"
+❌ "Linter passed" (linter doesn't check compilation)
+```
+
+**Requirements:**
+```
+✅ Re-read plan → Create checklist → Verify each → Report gaps or completion
+❌ "Tests pass, phase complete"
+```
+
+**Agent delegation:**
+```
+✅ Agent reports success → Check VCS diff → Verify changes → Report actual state
+❌ Trust agent report
+```
+
+## Why This Matters
+
+- Trust is fragile: claiming success without evidence breaks it
+- Undefined functions shipped would crash in production
+- Missing requirements shipped means incomplete features
+- Time wasted on false completion leads to redirect and rework
+
+## When To Apply
+
+**ALWAYS before:**
+- ANY variation of success/completion claims
+- ANY expression of satisfaction
+- ANY positive statement about work state
+- Committing, PR creation, task completion
+- Moving to next task
+- Delegating to agents
+
+**Rule applies to:**
+- Exact phrases
+- Paraphrases and synonyms
+- Implications of success
+- ANY communication suggesting completion/correctness
+
+## The Bottom Line
+
+**No shortcuts for verification.**
+
+Run the command. Read the output. THEN claim the result.
+
+This is non-negotiable.

--- a/.claude/skills/writing-design-plans/SKILL.md
+++ b/.claude/skills/writing-design-plans/SKILL.md
@@ -1,0 +1,652 @@
+---
+name: writing-design-plans
+description: Use after brainstorming completes - writes validated designs to doc/design/ with structured format and discrete implementation phases
+user-invocable: false
+---
+
+# Writing Design Plans
+
+## Overview
+
+Complete the design document by appending validated design from brainstorming to the existing file (created in Phase 3 of start-design-plan) and filling in the Summary and Glossary placeholders.
+
+**Core principle:** Append body to existing document. Generate Summary and Glossary. Commit for permanence.
+
+**Announce at start:** "I'm using the writing-design-plans skill to complete the design document."
+
+**Context:** Design document already exists with Title, Summary placeholder, confirmed Definition of Done, and Glossary placeholder. This skill appends the body and fills in placeholders.
+
+## Level of Detail: Design vs Implementation
+
+**Design plans are directional and archival.** They can be checked into git and referenced months later. Other design plans may depend on contracts specified here.
+
+**Implementation plans are tactical and just-in-time.** They verify current codebase state and generate executable code immediately before execution.
+
+**What belongs in design plans:**
+
+| Include | Exclude |
+|---------|---------|
+| Module and directory structure | Task-level breakdowns |
+| Component names and responsibilities | Implementation code |
+| File paths (from investigation) | Function bodies |
+| Dependencies between components | Step-by-step instructions |
+| "Done when" verification criteria | Test code |
+
+**Exception: Contracts get full specification.** When a component exposes an interface that other systems depend on, specify the contract fully:
+
+- API endpoints with request/response shapes
+- Inter-service interfaces (types, method signatures)
+- Database schemas that other systems read
+- Message formats for queues/events
+
+Contracts can include code blocks showing types and interfaces. This is different from implementation code -- contracts define boundaries, not behavior.
+
+**Example -- Contract specification (OK):**
+```typescript
+interface TokenService {
+  generate(claims: TokenClaims): Promise<string>;
+  validate(token: string): Promise<TokenClaims | null>;
+}
+
+interface TokenClaims {
+  sub: string;      // service identifier
+  aud: string[];    // allowed audiences
+  exp: number;      // expiration timestamp
+}
+```
+
+**Example -- Implementation code (NOT OK for design plans):**
+```typescript
+async function generate(claims: TokenClaims): Promise<string> {
+  const payload = { ...claims, iat: Date.now() };
+  return jwt.sign(payload, config.secret, { algorithm: 'RS256' });
+}
+```
+
+The first defines what the boundary looks like. The second implements behavior -- that belongs in implementation plans.
+
+## File Location and Naming
+
+**File location:** `doc/design/YYYY-MM-DD-<topic>.md`
+
+The file is created by start-design-plan Phase 3. This skill appends to that file.
+
+**Expected naming convention:**
+- Good: `doc/design/2025-01-18-oauth2-svc-authn.md`
+- Good: `doc/design/2025-01-18-user-prof-redesign.md`
+- Bad: `doc/design/design.md`
+- Bad: `doc/design/new-feature.md`
+
+## Document Structure
+
+**The design document already exists** from Phase 3 of start-design-plan with this structure:
+
+```markdown
+# [Feature Name] Design
+
+## Summary
+<!-- TO BE GENERATED after body is written -->
+
+## Definition of Done
+[Already written - confirmed in Phase 3]
+
+## Acceptance Criteria
+<!-- TO BE GENERATED and validated before glossary -->
+
+## Glossary
+<!-- TO BE GENERATED after body is written -->
+```
+
+**This skill appends the body sections:**
+
+```markdown
+## Architecture
+[Approach selected in brainstorming Phase 2]
+
+[Key components and how they interact]
+
+[Data flow and system boundaries]
+
+## Existing Patterns
+[Document codebase patterns discovered by investigator that this design follows]
+
+[If introducing new patterns, explain why and note divergence from existing code]
+
+[If no existing patterns found, state that explicitly]
+
+## Implementation Phases
+
+Break implementation into discrete phases (<=8 recommended).
+
+**REQUIRED: Wrap each phase in HTML comment markers:**
+
+<!-- START_PHASE_1 -->
+### Phase 1: [Name]
+**Goal:** What this phase achieves
+
+**Components:** What gets built/modified (exact paths from investigator)
+
+**Dependencies:** What must exist first
+
+**Done when:** How to verify this phase is complete (see Phase Verification below)
+<!-- END_PHASE_1 -->
+
+<!-- START_PHASE_2 -->
+### Phase 2: [Name]
+[Same structure]
+<!-- END_PHASE_2 -->
+
+...continue for each phase...
+
+**Why markers:** These enable structured reference to specific phases during plan mode and implementation. Markers survive context compaction, ensuring phases remain navigable in long conversations.
+
+## Additional Considerations
+[Error handling, edge cases, future extensibility - only if relevant]
+
+[Don't include hypothetical "nice to have" features]
+```
+
+**Then this skill:**
+1. Generates Acceptance Criteria (inline) and gets human validation
+2. Generates Summary and Glossary to replace the placeholders
+
+## Legibility Header
+
+The first three sections (Summary, Definition of Done, Glossary) form the **legibility header**. These sections help human reviewers quickly understand what the document is about before diving into technical details.
+
+**Definition of Done is already written** -- it was captured in Phase 3 immediately after user confirmation, preserving full fidelity.
+
+**Summary and Glossary are generated AFTER writing the body.** This avoids summarizing something that hasn't been written yet and ensures they accurately reflect the full document.
+
+See "After Writing: Generating Summary and Glossary" below for the extraction process.
+
+## Implementation Phases: Critical Requirements
+
+**YOU MUST break design into discrete, sequential phases.**
+
+**Each phase should:**
+- Achieve one cohesive goal
+- Build on previous phases (explicit dependencies)
+- End with a working build and clear "done" criteria
+- Use exact file paths and component names from codebase investigation
+
+## Phase Verification
+
+**Verification depends on what the phase delivers:**
+
+| Phase Type | Done When | Examples |
+|------------|-----------|----------|
+| Infrastructure/scaffolding | Operational success | Project installs, builds, runs, deploys |
+| Functionality/behavior | Tests pass that verify the ACs this phase covers | Unit tests, integration tests, E2E tests |
+
+**The rule:** If a phase implements functionality, it must include tests that verify the specific acceptance criteria it claims to cover. Tests are a deliverable of the phase, not a separate "testing phase" later.
+
+**Tying tests to ACs:** A functionality phase lists which ACs it covers (e.g., `oauth2-svc-authn.AC1.1`, `oauth2-svc-authn.AC1.3`). The phase is not "done" until tests exist that verify each of those specific cases. This creates traceability: AC -> phase -> test.
+
+**Don't over-engineer infrastructure verification.** You don't need unit tests for package.json. "npm install succeeds" is sufficient verification for a dependency setup phase. Infrastructure phases typically don't list ACs -- their verification is operational.
+
+**Do require tests for functionality.** Any code that does something needs tests that prove it does that thing. These tests must map to specific ACs, not just "test the code." If a phase covers `oauth2-svc-authn.AC1.3` ("Invalid password returns 401"), a test must verify exactly that.
+
+**Tests can evolve.** A test written in Phase 2 may be modified in Phase 4 as requirements expand. This is expected. The constraint is that Phase 2 ends with passing tests for the ACs Phase 2 claims to cover.
+
+**Structure phases as subcomponents.** A phase may contain multiple logical subcomponents. List them at the component level -- the implementation plan will break these into tasks.
+
+Good structure (component-level):
+```
+<!-- START_PHASE_2 -->
+### Phase 2: Core Services
+**Goal:** Token generation and session management
+
+**Components:**
+- TokenService in `src/services/auth/` -- generates and validates JWT tokens
+- SessionManager in `src/services/auth/` -- creates, validates, and invalidates sessions
+- Types in `src/types/auth.ts` -- TokenClaims, SessionData interfaces
+
+**Dependencies:** Phase 1 (project setup)
+
+**Done when:** Token generation/validation works, sessions can be created/invalidated, all tests pass
+<!-- END_PHASE_2 -->
+```
+
+Bad structure (task-level -- this belongs in implementation plans):
+```
+Phase 2: Core Services
+- Task 1: TokenPayload type and TokenConfig
+- Task 2: TokenService implementation
+- Task 3: TokenService tests
+- Task 4: SessionManager implementation
+- Task 5: SessionManager tests
+```
+
+Design plans describe WHAT gets built. Implementation plans describe HOW to build it step-by-step.
+
+**Phase count:**
+- Recommended: 2-8 phases
+- If >8 phases seem necessary, the design is likely too large for a single document. Split into smaller designs that can be implemented independently.
+
+**Why keep phases bounded:**
+- Large phase counts signal the design needs decomposition
+- Each phase should be implementable in a focused session
+- Smaller designs are easier to review, implement, and test
+
+## Using Codebase Investigation Findings
+
+**Include paths and component descriptions from investigation. Do NOT include implementation details.**
+
+Good Phase definitions:
+
+**Infrastructure phase example:**
+```markdown
+<!-- START_PHASE_1 -->
+### Phase 1: Project Setup
+**Goal:** Initialize project structure and dependencies
+
+**Components:**
+- `package.json` with auth dependencies (jsonwebtoken, bcrypt)
+- `tsconfig.json` with strict mode
+- `src/index.ts` entry point
+
+**Dependencies:** None (first phase)
+
+**Done when:** `npm install` succeeds, `npm run build` succeeds
+<!-- END_PHASE_1 -->
+```
+
+**Functionality phase example:**
+```markdown
+<!-- START_PHASE_2 -->
+### Phase 2: Token Generation Service
+**Goal:** JWT token generation and validation for service-to-service auth
+
+**Components:**
+- TokenService in `src/services/auth/` -- generates signed JWTs, validates signatures and expiration
+- TokenValidator in `src/services/auth/` -- middleware-friendly validation that returns claims or rejects
+
+**Dependencies:** Phase 1 (project setup)
+
+**Done when:** Tokens can be generated, validated, and rejected when invalid/expired
+<!-- END_PHASE_2 -->
+```
+
+Bad Phase definitions:
+
+**Too vague:**
+```markdown
+### Phase 1: Authentication
+**Goal:** Add auth stuff
+**Components:** Auth files
+**Dependencies:** Database maybe
+```
+
+**Too detailed (task-level):**
+```markdown
+### Phase 2: Token Service
+**Components:**
+- Create `src/types/token.ts` with TokenClaims interface
+- Create `src/services/auth/token-service.ts` with generate() and validate()
+- Create `tests/services/auth/token-service.test.ts`
+- Step 1: Write failing test for generate()
+- Step 2: Implement generate()
+- Step 3: Write failing test for validate()
+...
+```
+
+The second example is doing implementation planning's job. Design plans stay at component level.
+
+## Writing Style
+
+Follow these guidelines:
+
+**Be concise:**
+- Remove throat-clearing
+- State facts directly
+- Skip obvious explanations
+
+**Be specific:**
+- Use exact component names
+- Reference actual file paths
+- Include concrete examples
+
+**Be honest:**
+- Acknowledge unknowns
+- State assumptions explicitly
+- Don't over-promise
+
+**Example - Good:**
+```markdown
+## Architecture
+
+Service-to-service authentication using OAuth2 client credentials flow.
+
+Auth service (`src/services/auth/`) generates and validates JWT tokens. API middleware (`src/api/middleware/auth.ts`) validates tokens on incoming requests. Token store (`src/data/token-store.ts`) maintains revocation list in PostgreSQL.
+
+Tokens expire after 1 hour. Refresh not needed for service accounts (can request new token).
+```
+
+**Example - Bad:**
+```markdown
+## Architecture
+
+In this exciting new architecture, we'll be implementing a robust and scalable authentication system that leverages the power of OAuth2! The system will be designed with best practices in mind, ensuring security and performance at every level. We'll use industry-standard JWT tokens that provide excellent flexibility and are widely supported across the ecosystem. This will integrate seamlessly with our existing infrastructure and provide a solid foundation for future enhancements!
+```
+
+## Existing Patterns Section
+
+**Purpose:** Document what codebase investigation revealed.
+
+**Include:**
+- Patterns this design follows from existing code
+- Why those patterns were chosen (if known)
+- Any divergence from existing patterns with justification
+
+**If following existing patterns:**
+```markdown
+## Existing Patterns
+
+Investigation found existing authentication in `src/services/legacy-auth/`. This design follows the same service structure:
+- Service classes in `src/services/<domain>/`
+- Middleware in `src/api/middleware/`
+- Data access in `src/data/`
+
+Token storage follows pattern from `src/data/session-store.ts` (PostgreSQL with TTL).
+```
+
+**If no existing patterns:**
+```markdown
+## Existing Patterns
+
+Investigation found no existing authentication implementation. This design introduces new patterns:
+- Service layer for business logic (`src/services/`)
+- Middleware for request interception (`src/api/middleware/`)
+
+These patterns align with functional core, imperative shell separation.
+```
+
+**If diverging from existing patterns:**
+```markdown
+## Existing Patterns
+
+Investigation found legacy authentication in `src/auth/`. This design diverges:
+- OLD: Monolithic `src/auth/auth.js` (600 lines, mixed concerns)
+- NEW: Separate services (`token-service.ts`, `validator.ts`) following FCIS
+
+Divergence justified by: Legacy code violates FCIS pattern, difficult to test, high coupling.
+```
+
+## Additional Considerations
+
+**Only include if genuinely relevant:**
+
+**Error handling** - if not obvious:
+```markdown
+## Additional Considerations
+
+**Error handling:** Token validation failures return 401 with generic message (don't leak token details). Service-to-service communication failures retry 3x with exponential backoff before returning 503.
+```
+
+**Edge cases** - if non-obvious:
+```markdown
+**Edge cases:** Clock skew handled by 5-minute token validation window. Revoked tokens remain in database for 7 days for audit trail.
+```
+
+**Future extensibility** - if architectural decision enables future features:
+```markdown
+**Future extensibility:** Token claims structure supports adding user metadata (currently unused). Enables future human user authentication without architecture change.
+```
+
+**Do NOT include:**
+- "Nice to have" features not in current design
+- Hypothetical future requirements
+- Generic platitudes ("should be secure", "needs good testing")
+
+## After Body: Generating and Validating Acceptance Criteria
+
+After appending the body, generate Acceptance Criteria and get human validation BEFORE Summary/Glossary.
+
+Acceptance Criteria translate the Definition of Done into specific, verifiable items that become the basis for test requirements during implementation. You have full context from just writing the phases -- do this inline, no subagent needed.
+
+### What Acceptance Criteria Must Cover
+
+For **each Definition of Done item**, think through:
+
+1. **Success cases**: What are all the ways this can succeed? List each distinctly.
+   - Happy path: the normal, expected flow
+   - Variations: different valid inputs, configurations, user types
+   - Edge cases: boundary values, empty inputs, maximum sizes
+
+2. **Important failure cases**: What should the system reject or handle gracefully?
+   - Invalid inputs (malformed, out of range, wrong type)
+   - Unauthorized access attempts
+   - Resource exhaustion or unavailability
+   - Concurrent access conflicts
+
+Then look at the **Implementation Phases and brainstorming details** for additional cases:
+- Integration points between phases (data flows correctly between components)
+- Behavior implied by architectural decisions (caching, retries, timeouts)
+- Edge cases surfaced during design discussion
+
+### Writing Criteria
+
+Each criterion must be **observable and testable**:
+
+**Good:** "API returns 401 when token is expired"
+**Good:** "User sees error message when password is less than 8 characters"
+**Good:** "System processes 100 concurrent requests within 2 seconds"
+
+**Bad:** "System is secure" (vague)
+**Bad:** "Code is clean" (subjective)
+**Bad:** "Performance is acceptable" (unmeasurable)
+
+### Structure
+
+**Scoped AC format:** `{slug}.AC{N}.{M}` where `{slug}` is extracted from the design plan filename (everything after `YYYY-MM-DD-`, excluding `.md`).
+
+For design plan `2025-01-18-oauth2-svc-authn.md`, the slug is `oauth2-svc-authn`. All AC identifiers use this prefix:
+
+```markdown
+## Acceptance Criteria
+
+### oauth2-svc-authn.AC1: Users can authenticate
+- **oauth2-svc-authn.AC1.1 Success:** User with valid credentials receives auth token
+- **oauth2-svc-authn.AC1.2 Success:** Token contains correct user ID and permissions
+- **oauth2-svc-authn.AC1.3 Failure:** Invalid password returns 401 with generic error (no password hint)
+- **oauth2-svc-authn.AC1.4 Failure:** Locked account returns 403 with lockout duration
+- **oauth2-svc-authn.AC1.5 Edge:** Empty password field shows validation error before submission
+
+### oauth2-svc-authn.AC2: Sessions persist across page refresh
+- **oauth2-svc-authn.AC2.1 Success:** ...
+- **oauth2-svc-authn.AC2.2 Failure:** ...
+...
+
+### oauth2-svc-authn.AC[N]: Cross-Cutting Behaviors
+- **oauth2-svc-authn.AC[N].1:** Token expiration triggers re-authentication prompt (not silent failure)
+- **oauth2-svc-authn.AC[N].2:** All API errors include correlation ID for debugging
+- ...
+```
+
+**Why scoped:** Multiple design rounds accumulate tests in the same codebase. Scoped identifiers prevent collision -- `oauth2-svc-authn.AC2.1` and `user-prof.AC2.1` are unambiguous. Implementation phases, task specs, and test names all use the full scoped identifier.
+
+### Validation
+
+Present generated criteria to the user. Use AskUserQuestion: "Review the acceptance criteria. Approve to continue, or describe what's missing or needs revision."
+
+Loop until approved. Then replace the placeholder in the document and proceed to Summary/Glossary.
+
+## After Writing: Generating Summary and Glossary
+
+After appending the body (Architecture through Additional Considerations), generate Summary and Glossary using a subagent with fresh context.
+
+**Why a subagent?**
+- Fresh context avoids "context rot" from the long brainstorming/writing session
+- Acts as a forcing function: if the subagent can't extract a coherent summary, the document is unclear
+- Mirrors the experience of a human reviewer seeing the document for the first time
+
+**Step 1: At this point the document looks like:**
+
+The body has been appended and Acceptance Criteria validated:
+
+```markdown
+# [Feature Name] Design
+
+## Summary
+<!-- TO BE GENERATED after body is written -->
+
+## Definition of Done
+[Already written from Phase 3]
+
+## Acceptance Criteria
+[Validated in previous step]
+
+## Glossary
+<!-- TO BE GENERATED after body is written -->
+
+## Architecture
+[... body content ...]
+
+## Existing Patterns
+[... body content ...]
+
+## Implementation Phases
+[... body content ...]
+
+## Additional Considerations
+[... body content ...]
+```
+
+**Step 2: Dispatch extraction subagent**
+
+Use the Task tool to generate Summary and Glossary:
+
+```
+<invoke name="Task">
+<parameter name="subagent_type">general-purpose</parameter>
+<parameter name="description">Generating Summary and Glossary for design document</parameter>
+<parameter name="prompt">
+Read the design document at [file path].
+
+Generate two sections to replace the placeholders in the document:
+
+1. **Summary**: Write 1-2 paragraphs summarizing what is being built and the
+   high-level approach. This should be understandable to someone unfamiliar
+   with the codebase. The Definition of Done section already exists -- your
+   summary should complement it by explaining the "how" rather than restating
+   the "what."
+
+2. **Glossary**: List domain terms from the application and third-party concepts
+   (libraries, frameworks, patterns) that a reviewer needs to understand this
+   document. Format as:
+   - **[Term]**: [Brief explanation]
+
+   Include only terms that appear in the document and would benefit from
+   explanation.
+
+3. **Omitted Terms**: List terms you considered but skipped as too obvious or
+   generic. Only include borderline cases -- terms that a less technical reviewer
+   might not know. Format as a simple comma-separated list.
+
+Return all three sections. The first two are markdown ready to insert; the
+third is for transparency about what was excluded.
+</parameter>
+</invoke>
+```
+
+**Step 3: Review omitted terms with user**
+
+Before inserting the extracted sections, briefly mention the omitted terms to the user:
+
+"Glossary includes [X terms]. Omitted as likely obvious: [list from subagent]. Let me know if any of those should be included."
+
+Don't wait for approval -- proceed to insert the sections. The user can hit escape and ask for adjustments if needed.
+
+**Step 4: Replace placeholders**
+
+Replace the Summary and Glossary placeholder comments with the subagent's output. Do not insert the Omitted Terms section -- that was for your transparency message only.
+
+**Step 5: Review and adjust**
+
+Briefly review the generated sections for accuracy. The subagent may miss nuance from the conversation -- adjust if needed, but prefer the subagent's version when it's accurate (it reflects what the document actually says, not what you remember).
+
+## After Summary and Glossary: Commit
+
+**Commit the design document:**
+
+```bash
+git add doc/design/YYYY-MM-DD-<topic>.md
+git commit -m "$(cat <<'EOF'
+doc: add [feature name] design plan
+
+Completed brainstorming session. Design includes:
+- [Key architectural decision 1]
+- [Key architectural decision 2]
+- [N] implementation phases
+EOF
+)"
+```
+
+**Announce completion:**
+
+"Design plan documented in `doc/design/YYYY-MM-DD-<topic>.md` and committed."
+
+## Common Rationalizations - STOP
+
+| Excuse | Reality |
+|--------|---------|
+| "I'll write the summary first since I know what I'm building" | Write body first. Summarize what you wrote, not what you planned. |
+| "I can write Summary and Glossary myself, don't need subagent" | Subagent has fresh context and acts as forcing function. Use it. |
+| "Glossary isn't needed, terms are obvious" | Obvious to you after brainstorming. Not to fresh reviewer. Include it. |
+| "Design is simple, don't need phases" | Phases make implementation manageable. Always include. |
+| "Phases are obvious, don't need detail" | Plan mode needs component descriptions to generate good implementation plans. Provide them. |
+| "Can have 12 phases if needed" | Recommended max is 8. If you need more, split the design. |
+| "I'll include the code so implementation is easier" | No. Implementation generates code fresh from current codebase state. Design provides direction only. |
+| "Breaking into tasks helps the reader" | Task breakdown is implementation planning's job. Design stays at component level. |
+| "I'll just show how the function works" | Implementation code doesn't belong in design. Show contracts/interfaces if needed, not function bodies. |
+| "Additional considerations should be comprehensive" | Only include if relevant. YAGNI applies. |
+| "Should document all future possibilities" | Document current design only. No hypotheticals. |
+| "Existing patterns section can be skipped" | Shows investigation happened. Always include. |
+| "Can use generic file paths" | Exact paths from investigation. No handwaving. |
+| "Tests can be a separate phase at the end" | No. Tests for functionality belong in the phase that creates that functionality. |
+| "We'll add tests after the code works" | Phase isn't done until its tests pass. Tests are deliverables, not afterthoughts. |
+| "Infrastructure needs unit tests too" | No. Infrastructure verified operationally. Don't over-engineer. |
+| "Phase 3 tests will cover Phase 2 code" | Each phase tests its own deliverables. Later phases may extend tests, but don't defer. |
+| "Phase markers are just noise" | Markers enable structured phase references. Always include. |
+| "Acceptance criteria are just the Definition of Done restated" | Criteria must be specific and verifiable. "System is secure" becomes "API rejects invalid tokens with 401." |
+| "User approved DoD, don't need to validate criteria" | Criteria translate DoD into testable items. User must confirm this translation is correct. |
+| "I'll skip criteria validation to save time" | Implementation depends on validated criteria. Skipping creates downstream confusion. |
+| "Criteria are obvious from the phases" | Obvious to you. User must confirm they agree on what 'done' means before proceeding. |
+
+**All of these mean: STOP. Follow the structure exactly.**
+
+## Integration with Workflow
+
+This skill completes the design document started in Phase 3:
+
+```
+Phase 3 (Definition of Done) completes
+  -> User confirms Definition of Done
+  -> File created with Title, Summary placeholder, DoD, AC placeholder, Glossary placeholder
+  -> DoD captured at full fidelity
+
+Brainstorming (Phase 4) completes
+  -> Validated design exists in conversation
+  -> User approved incrementally
+
+Writing Design Plans (this skill)
+  -> Append body: Architecture, Existing Patterns, Implementation Phases, Additional Considerations
+  -> Add exact paths from investigation
+  -> Create discrete phases (<=8 recommended)
+  -> Generate Acceptance Criteria inline (success + failure cases for each DoD item)
+  -> USER VALIDATES Acceptance Criteria
+  -> Replace AC placeholder with validated criteria
+  -> Dispatch subagent to generate Summary and Glossary
+  -> Replace Summary/Glossary placeholders with generated content
+  -> Commit to git
+
+Implementation (next step, in fresh context)
+  -> User references design document via @doc/design/[filename].md
+  -> Enters plan mode to create implementation plan
+  -> Uses phases as basis for planning
+  -> After plan approval and implementation, creates PR
+  -> Runs /address-feedback-github for iterative review
+```
+
+**Purpose:** The design document serves as the contract for implementation. The legibility header (Summary, DoD, Acceptance Criteria, Glossary) ensures human reviewers can quickly understand the document. Acceptance Criteria provide traceability for tests.


### PR DESCRIPTION
## Summary

- Ports the design phase from the upstream ed3d-plan-and-execute plugin as five checked-in skills under `.claude/skills/`
- Adapts the workflow to use Claude Code's built-in plan mode for implementation planning and `/address-feedback-github` for code review
- Decouples all design-doc content from dropped upstream implementation skills (phase markers, phase count limits, workflow integration)
- Adds `verification-before-completion` as a lightweight quality gate

## Test plan

- [x] All five SKILL.md files have valid YAML frontmatter
- [x] `/start-design-plan` appears in Claude Code's available skills list
- [x] Zero matches for banned patterns: `docs/design-plans`, `ed3d-plan-and-execute:`, `writing-plans`, `writing-implementation-plans`, upstream agent types, model pinning
- [x] Pre-commit hooks pass