### PR TITLE
engine: rebuild stdlib model when user override is removed

### DIFF
--- a/src/simlin-engine/src/db.rs
+++ b/src/simlin-engine/src/db.rs
@@ -2099,6 +2099,7 @@ pub struct SyncedModel<'db> {
     pub id: ModelId<'db>,
     pub source: SourceModel,
     pub variables: HashMap<String, SyncedVariable<'db>>,
+    pub is_stdlib: bool,
 }
 
 pub struct SyncedVariable<'db> {
@@ -2170,6 +2171,7 @@ impl PersistentSyncState {
                             id: ModelId::from_id(pm.model_interned_id),
                             source: pm.source_model,
                             variables,
+                            is_stdlib: pm.is_stdlib,
                         },
                     )
                 })
@@ -2203,7 +2205,7 @@ impl PersistentSyncState {
                             model_interned_id: sm.id.as_id(),
                             source_model: sm.source,
                             variables,
-                            is_stdlib: false,
+                            is_stdlib: sm.is_stdlib,
                         },
                     )
                 })
@@ -2271,6 +2273,7 @@ pub fn sync_from_datamodel<'db>(
                 id: model_id,
                 source: source_model,
                 variables,
+                is_stdlib: false,
             },
         );
     }
@@ -2285,11 +2288,21 @@ pub fn sync_from_datamodel<'db>(
             continue;
         }
         let dm_model = crate::stdlib::get(stdlib_name).unwrap();
+        let model_id = ModelId::new(db, canonical.clone());
+        let mut variables = HashMap::new();
         let mut source_var_map = HashMap::new();
         for dm_var in &dm_model.variables {
             let canonical_var_name = canonicalize(dm_var.get_ident()).into_owned();
+            let var_id = VariableId::new(db, canonical_var_name.clone());
             let source_var = source_variable_from_datamodel(db, dm_var);
-            source_var_map.insert(canonical_var_name, source_var);
+            source_var_map.insert(canonical_var_name.clone(), source_var);
+            variables.insert(
+                canonical_var_name,
+                SyncedVariable {
+                    id: var_id,
+                    source: source_var,
+                },
+            );
         }
         let mut variable_names: Vec<String> = source_var_map.keys().cloned().collect();
         variable_names.sort();
@@ -2300,7 +2313,16 @@ pub fn sync_from_datamodel<'db>(
             source_var_map,
             dm_model.sim_specs.as_ref().map(SourceSimSpecs::from),
         );
-        source_model_map.insert(canonical, source_model);
+        source_model_map.insert(canonical.clone(), source_model);
+        models.insert(
+            canonical,
+            SyncedModel {
+                id: model_id,
+                source: source_model,
+                variables,
+                is_stdlib: true,
+            },
+        );
         model_names.push(full_name);
     }
 

--- a/src/simlin-engine/src/db_tests.rs
+++ b/src/simlin-engine/src/db_tests.rs
@@ -185,7 +185,7 @@ fn test_sync_multi_model() {
     };
 
     let result = sync_from_datamodel(&db, &project);
-    assert_eq!(result.models.len(), 2);
+    assert_eq!(result.models.len(), 2 + crate::stdlib::MODEL_NAMES.len(),);
     assert!(result.models.contains_key("main"));
     assert!(result.models.contains_key("submodel"));
 
@@ -4298,4 +4298,27 @@ fn test_incremental_stdlib_restored_after_user_override_removed() {
         expected_vars, actual_vars,
         "restored stdlib model should have exactly the real stdlib variables"
     );
+}
+
+/// After a fresh sync (prev_state=None), stdlib models in the resulting
+/// PersistentSyncState should be marked is_stdlib=true so that subsequent
+/// incremental syncs can reuse their salsa inputs without rebuilding.
+#[test]
+fn test_initial_sync_marks_stdlib_models() {
+    let mut db = SimlinDb::default();
+    let project = simple_project();
+
+    let state = sync_from_datamodel_incremental(&mut db, &project, None);
+
+    for stdlib_name in crate::stdlib::MODEL_NAMES {
+        let canonical = canonicalize(&format!("stdlib\u{205A}{stdlib_name}")).into_owned();
+        let pm = state
+            .models
+            .get(&canonical)
+            .unwrap_or_else(|| panic!("stdlib model {stdlib_name} missing from sync state"));
+        assert!(
+            pm.is_stdlib,
+            "stdlib model {stdlib_name} should have is_stdlib=true after initial sync"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

- Add `is_stdlib` flag to `PersistentModelState` to distinguish stdlib-origin from user-origin entries
- Filter the stdlib reuse check in `sync_from_datamodel_incremental` so stale user overrides are not mistaken for real stdlib definitions
- When a user model that shadows a stdlib name is removed, the stdlib model is now correctly rebuilt from scratch

Fixes #315

## Test plan

- [x] New test `test_incremental_stdlib_restored_after_user_override_removed` verifies the fix:
  1. Creates a project with a user model shadowing `stdlib⁚delay1`
  2. Syncs incrementally so the override lands in `PersistentSyncState`
  3. Removes the shadowing model and syncs again
  4. Asserts the restored model is `is_stdlib: true` with the real stdlib variables
- [x] All existing engine tests pass (`cargo test -p simlin-engine`)