### PR TITLE
Add regression coverage for XMILE right-nested non-commutative operators

### DIFF
--- a/src/simlin-engine/src/ast/mod.rs
+++ b/src/simlin-engine/src/ast/mod.rs
@@ -416,6 +416,48 @@ fn test_print_eqn() {
         ))
     );
     assert_eq!(
+        "a - (b - c)",
+        print_eqn(&Expr0::Op2(
+            BinaryOp::Sub,
+            Box::new(Expr0::Var(RawIdent::new_from_str("a"), Loc::new(1, 2))),
+            Box::new(Expr0::Op2(
+                BinaryOp::Sub,
+                Box::new(Expr0::Var(RawIdent::new_from_str("b"), Loc::default())),
+                Box::new(Expr0::Var(RawIdent::new_from_str("c"), Loc::default())),
+                Loc::default()
+            )),
+            Loc::new(0, 11),
+        ))
+    );
+    assert_eq!(
+        "a / (b / c)",
+        print_eqn(&Expr0::Op2(
+            BinaryOp::Div,
+            Box::new(Expr0::Var(RawIdent::new_from_str("a"), Loc::new(1, 2))),
+            Box::new(Expr0::Op2(
+                BinaryOp::Div,
+                Box::new(Expr0::Var(RawIdent::new_from_str("b"), Loc::default())),
+                Box::new(Expr0::Var(RawIdent::new_from_str("c"), Loc::default())),
+                Loc::default()
+            )),
+            Loc::new(0, 11),
+        ))
+    );
+    assert_eq!(
+        "a mod (b mod c)",
+        print_eqn(&Expr0::Op2(
+            BinaryOp::Mod,
+            Box::new(Expr0::Var(RawIdent::new_from_str("a"), Loc::new(1, 2))),
+            Box::new(Expr0::Op2(
+                BinaryOp::Mod,
+                Box::new(Expr0::Var(RawIdent::new_from_str("b"), Loc::default())),
+                Box::new(Expr0::Var(RawIdent::new_from_str("c"), Loc::default())),
+                Loc::default()
+            )),
+            Loc::new(0, 15),
+        ))
+    );
+    assert_eq!(
         "-a",
         print_eqn(&Expr0::Op1(
             UnaryOp::Negative,


### PR DESCRIPTION
### Motivation

- The XMILE equation printer must preserve grouping for right-nested non-commutative operators so that expressions like `a - (b - c)` do not lose their parentheses and change semantics. 
- This patch hardens the existing parenthesization fix by adding focused regression tests to prevent regressions in future edits.

### Description

- Added assertions to `test_print_eqn` in `src/simlin-engine/src/ast/mod.rs` that verify `print_eqn` emits `a - (b - c)`, `a / (b / c)`, and `a mod (b mod c)`. 
- The change only adds test coverage and does not alter the printer logic which is already handling right-child parenthesization for non-commutative operators.

### Testing

- Ran the targeted Rust unit test with `cargo test -p simlin-engine test_print_eqn`, which completed successfully. 
- The project pre-commit pipeline (Rust, TypeScript, and Python checks) was executed during the commit and passed, confirming the tests and workspace checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f73fa36208328b112999fbee33138)