### PR TITLE
build: enforce no-explicit-any in typescript

### DIFF
--- a/.eslintrc.root.js
+++ b/.eslintrc.root.js
@@ -18,7 +18,7 @@ module.exports = {
     "@typescript-eslint/explicit-function-return-type": "off",
     "@typescript-eslint/no-empty-function": "off",
     "@typescript-eslint/no-use-before-define": "off",
-    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-explicit-any": "error",
     "@typescript-eslint/restrict-template-expressions": "off",
     "@typescript-eslint/no-unsafe-member-access": "off",
     "@typescript-eslint/no-unused-vars": [

--- a/eslint.config.shared.js
+++ b/eslint.config.shared.js
@@ -45,7 +45,7 @@ const baseConfig = {
     '@typescript-eslint/explicit-function-return-type': 'off',
     '@typescript-eslint/no-empty-function': 'off',
     '@typescript-eslint/no-use-before-define': 'off',
-    '@typescript-eslint/no-explicit-any': 'off',
+    '@typescript-eslint/no-explicit-any': 'error',
     '@typescript-eslint/restrict-template-expressions': 'off',
     '@typescript-eslint/no-unsafe-member-access': 'off',
     '@typescript-eslint/no-unused-vars': [

--- a/src/app/NewProject.tsx
+++ b/src/app/NewProject.tsx
@@ -82,7 +82,12 @@ export class NewProject extends React.Component<NewProjectProps, NewProjectState
   };
 
   setProjectName = async (): Promise<void> => {
-    const bodyContents: any = {
+    const bodyContents: {
+      projectName: string;
+      description: string;
+      projectPB?: string;
+      isPublic?: boolean;
+    } = {
       projectName: this.state.projectNameField,
       description: this.state.descriptionField,
     };

--- a/src/core/tests/datamodel.test.ts
+++ b/src/core/tests/datamodel.test.ts
@@ -59,6 +59,12 @@ import type {
   Project,
   Variable,
 } from '../datamodel';
+import type {
+  JsonStockViewElement,
+  JsonFlowViewElement,
+  JsonLinkViewElement,
+  JsonCloudViewElement,
+} from '@simlin/engine';
 
 describe('GraphicalFunctionScale', () => {
   it('should roundtrip correctly', () => {
@@ -311,14 +317,14 @@ describe('View Elements', () => {
       zoom: -1,
       useLetteredPolarity: false,
     });
-    const stockJson = json.elements[0];
+    const stockJson = json.elements[0] as JsonStockViewElement;
     expect(stockJson.type).toBe('stock');
-    expect((stockJson as any).name).toBe('Population');
-    expect((stockJson as any).x).toBe(100);
-    expect((stockJson as any).y).toBe(200);
-    expect((stockJson as any).labelSide).toBe('top');
+    expect(stockJson.name).toBe('Population');
+    expect(stockJson.x).toBe(100);
+    expect(stockJson.y).toBe(200);
+    expect(stockJson.labelSide).toBe('top');
 
-    const restored = stockViewElementFromJson(stockJson as any);
+    const restored = stockViewElementFromJson(stockJson);
     expect(restored.uid).toBe(1);
     expect(restored.name).toBe('Population');
     expect(restored.x).toBe(100);
@@ -349,7 +355,7 @@ describe('View Elements', () => {
       zoom: -1,
       useLetteredPolarity: false,
     });
-    const flowJson = json.elements[0] as any;
+    const flowJson = json.elements[0] as JsonFlowViewElement;
     expect(flowJson.type).toBe('flow');
     expect(flowJson.points).toHaveLength(2);
     expect(flowJson.points[1].attachedToUid).toBe(1);
@@ -382,7 +388,7 @@ describe('View Elements', () => {
       zoom: -1,
       useLetteredPolarity: false,
     });
-    const linkJson = json.elements[0] as any;
+    const linkJson = json.elements[0] as JsonLinkViewElement;
     expect(linkJson.type).toBe('link');
     expect(linkJson.arc).toBe(30);
     expect(linkJson.multiPoints).toBeUndefined();
@@ -415,7 +421,7 @@ describe('View Elements', () => {
       zoom: -1,
       useLetteredPolarity: false,
     });
-    const linkJson = json.elements[0] as any;
+    const linkJson = json.elements[0] as JsonLinkViewElement;
     expect(linkJson.type).toBe('link');
     expect(linkJson.arc).toBeUndefined();
 
@@ -442,7 +448,7 @@ describe('View Elements', () => {
       zoom: -1,
       useLetteredPolarity: false,
     });
-    const cloudJson = json.elements[0] as any;
+    const cloudJson = json.elements[0] as JsonCloudViewElement;
     expect(cloudJson.type).toBe('cloud');
     expect(cloudJson.flowUid).toBe(2);
 
@@ -764,11 +770,12 @@ describe('LinkViewElement multiPoint', () => {
       zoom: -1,
       useLetteredPolarity: false,
     });
-    const linkJson = json.elements[0] as any;
+    const linkJson = json.elements[0] as JsonLinkViewElement;
     expect(linkJson.type).toBe('link');
     expect(linkJson.arc).toBeUndefined();
-    expect(linkJson.multiPoints).toHaveLength(3);
-    expect(linkJson.multiPoints[1]).toEqual({ x: 150, y: 75 });
+    const multiPoints = linkJson.multiPoints;
+    expect(multiPoints).toHaveLength(3);
+    expect(multiPoints?.[1]).toEqual({ x: 150, y: 75 });
 
     const restored = linkViewElementFromJson(linkJson);
     expect(restored.arc).toBeUndefined();

--- a/src/diagram/Editor.tsx
+++ b/src/diagram/Editor.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 import clsx from 'clsx';
 import IconButton from './components/IconButton';
 import TextField from './components/TextField';
-import Autocomplete from './components/Autocomplete';
+import Autocomplete, { type AutocompleteRenderInputParams } from './components/Autocomplete';
 import Snackbar from './components/Snackbar';
 import { ClearIcon, EditIcon, MenuIcon } from './components/icons';
 import SpeedDial, { CloseReason, SpeedDialAction, SpeedDialIcon } from './components/SpeedDial';
@@ -139,6 +139,27 @@ class EditorError implements Error {
   constructor(msg: string) {
     this.message = msg;
   }
+}
+
+interface ErrorDetailsLike {
+  code?: unknown;
+  message?: string;
+  details?: unknown;
+}
+
+function getErrorDetails(error: unknown): ErrorDetailsLike {
+  if (typeof error === 'object' && error !== null) {
+    const maybeError = error as Record<string, unknown>;
+    return {
+      code: maybeError.code,
+      message: typeof maybeError.message === 'string' ? maybeError.message : undefined,
+      details: maybeError.details,
+    };
+  }
+  if (typeof error === 'string') {
+    return { message: error };
+  }
+  return {};
 }
 
 interface CachedErrorDetails {
@@ -493,9 +514,10 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
 
     try {
       await engine.applyPatch(patch, { allowErrors: true });
-    } catch (e: any) {
-      console.error('applyPatch error (rename):', e?.code, e?.message, e?.details);
-      const msg = e?.message ?? 'Unknown error during rename';
+    } catch (e: unknown) {
+      const err = getErrorDetails(e);
+      console.error('applyPatch error (rename):', err.code, err.message, err.details);
+      const msg = err.message ?? 'Unknown error during rename';
       this.appendModelError(msg);
       return;
     }
@@ -594,9 +616,10 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       };
       try {
         await engine.applyPatch(patch, { allowErrors: true });
-      } catch (e: any) {
-        console.error('applyPatch error (delete):', e?.code, e?.message, e?.details);
-        this.appendModelError(e?.message ?? 'Unknown error during delete');
+      } catch (e: unknown) {
+        const err = getErrorDetails(e);
+        console.error('applyPatch error (delete):', err.code, err.message, err.details);
+        this.appendModelError(err.message ?? 'Unknown error during delete');
       }
     }
 
@@ -990,9 +1013,10 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       };
       try {
         await engine.applyPatch(patch, { allowErrors: true });
-      } catch (e: any) {
-        console.error('applyPatch error (flow attach):', e?.code, e?.message, e?.details);
-        this.appendModelError(e?.message ?? 'Unknown error during flow attach');
+      } catch (e: unknown) {
+        const err = getErrorDetails(e);
+        console.error('applyPatch error (flow attach):', err.code, err.message, err.details);
+        this.appendModelError(err.message ?? 'Unknown error during flow attach');
         this.setState({ selection, flowStillBeingCreated: inCreation });
         return;
       }
@@ -1096,9 +1120,10 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       };
       try {
         await engine.applyPatch(patch, { allowErrors: true });
-      } catch (e: any) {
-        console.error('applyPatch error (view update):', e?.code, e?.message, e?.details);
-        const msg = e?.message ?? 'Unknown error during view update';
+      } catch (e: unknown) {
+        const err = getErrorDetails(e);
+        console.error('applyPatch error (view update):', err.code, err.message, err.details);
+        const msg = err.message ?? 'Unknown error during view update';
         this.appendModelError(msg);
         return;
       }
@@ -1159,9 +1184,10 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
 
     try {
       await engine.applyPatch(patch, { allowErrors: true });
-    } catch (e: any) {
-      console.error('applyPatch error (variable creation):', e?.code, e?.message, e?.details);
-      this.appendModelError(e?.message ?? 'Unknown error during variable creation');
+    } catch (e: unknown) {
+      const err = getErrorDetails(e);
+      console.error('applyPatch error (variable creation):', err.code, err.message, err.details);
+      this.appendModelError(err.message ?? 'Unknown error during variable creation');
     }
 
     await this.updateView({ ...view, nextUid, elements });
@@ -1242,9 +1268,10 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
 
     try {
       await engine.applyPatch(patch, { allowErrors: true });
-    } catch (e: any) {
-      console.error('applyPatch error (sim specs):', e?.code, e?.message, e?.details);
-      this.appendModelError(e?.message ?? 'Unknown error updating sim specs');
+    } catch (e: unknown) {
+      const err = getErrorDetails(e);
+      console.error('applyPatch error (sim specs):', err.code, err.message, err.details);
+      this.appendModelError(err.message ?? 'Unknown error updating sim specs');
       return;
     }
 
@@ -1288,7 +1315,7 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       const a = document.createElement('a');
       document.body.appendChild(a);
       try {
-        (a as unknown as any).style = 'display: none';
+        a.style.display = 'none';
       } catch {
         // oh well
       }
@@ -1296,9 +1323,10 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       a.download = `${this.props.name}-${this.state.projectVersion | 0}.stmx`;
       a.click();
       window.URL.revokeObjectURL(url);
-    } catch (err: any) {
-      if (err && err.message) {
-        this.appendModelError(err.message);
+    } catch (err: unknown) {
+      const details = getErrorDetails(err);
+      if (details.message) {
+        this.appendModelError(details.message);
       }
     }
   };
@@ -1382,9 +1410,10 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       };
       try {
         await engine.applyPatch(patch, { allowErrors: true });
-      } catch (e: any) {
-        console.error('applyPatch error (queue view update):', e?.code, e?.message, e?.details);
-        const msg = e?.message ?? 'Unknown error during view update';
+      } catch (e: unknown) {
+        const err = getErrorDetails(e);
+        console.error('applyPatch error (queue view update):', err.code, err.message, err.details);
+        const msg = err.message ?? 'Unknown error during view update';
         this.appendModelError(msg);
         return;
       }
@@ -1578,7 +1607,7 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     });
   };
 
-  handleSearchChange = async (_event: any, newValue: string | null) => {
+  handleSearchChange = async (_event: React.SyntheticEvent | null, newValue: string | null) => {
     if (!newValue) {
       this.handleSelection(new Set());
       return;
@@ -1637,7 +1666,7 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
             clearOnEscape={true}
             defaultValue={name}
             options={autocompleteOptions}
-            renderInput={(params: any) => {
+            renderInput={(params: AutocompleteRenderInputParams) => {
               if (params.InputProps) {
                 params.InputProps.disableUnderline = true;
               }
@@ -1778,9 +1807,10 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
 
     try {
       await engine.applyPatch(patch, { allowErrors: true });
-    } catch (e: any) {
-      console.error('applyPatch error (equation update):', e?.code, e?.message, e?.details);
-      this.appendModelError(e?.message ?? 'Unknown error during equation update');
+    } catch (e: unknown) {
+      const err = getErrorDetails(e);
+      console.error('applyPatch error (equation update):', err.code, err.message, err.details);
+      this.appendModelError(err.message ?? 'Unknown error during equation update');
       return;
     }
 
@@ -1854,9 +1884,10 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
 
     try {
       await engine.applyPatch(patch, { allowErrors: true });
-    } catch (e: any) {
-      console.error('applyPatch error (table update):', e?.code, e?.message, e?.details);
-      this.appendModelError(e?.message ?? 'Unknown error during table update');
+    } catch (e: unknown) {
+      const err = getErrorDetails(e);
+      console.error('applyPatch error (table update):', err.code, err.message, err.details);
+      this.appendModelError(err.message ?? 'Unknown error during table update');
       return;
     }
 
@@ -2074,8 +2105,9 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       } else {
         engine = await EngineProject.openProtobuf(this.props.initialProjectBinary as Uint8Array);
       }
-    } catch (e: any) {
-      this.appendModelError(`opening the project in the engine failed: ${e?.message ?? 'Unknown error'}`);
+    } catch (e: unknown) {
+      const err = getErrorDetails(e);
+      this.appendModelError(`opening the project in the engine failed: ${err.message ?? 'Unknown error'}`);
       return;
     }
 
@@ -2099,8 +2131,9 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     let engine: EngineProject;
     try {
       engine = await EngineProject.openProtobuf(serializedProject as Uint8Array);
-    } catch (e: any) {
-      this.appendModelError(`opening the project in the engine failed: ${e?.message ?? 'Unknown error'}`);
+    } catch (e: unknown) {
+      const err = getErrorDetails(e);
+      this.appendModelError(`opening the project in the engine failed: ${err.message ?? 'Unknown error'}`);
       return;
     }
     this.engineProject = engine;

--- a/src/diagram/VariableDetails.tsx
+++ b/src/diagram/VariableDetails.tsx
@@ -251,8 +251,9 @@ export class VariableDetails extends React.PureComponent<VariableDetailsProps, V
   };
 
   renderLeaf = (props: RenderLeafProps) => {
-    const isError = !!(props.leaf as unknown as any).error;
-    const isWarning = !!(props.leaf as unknown as any).warning;
+    const leaf = props.leaf as FormattedText;
+    const isError = !!leaf.error;
+    const isWarning = !!leaf.warning;
     const className = isError ? styles.eqnError : isWarning ? styles.eqnWarning : undefined;
     return (
       <span {...props.attributes} className={className}>
@@ -472,12 +473,12 @@ export class VariableDetails extends React.PureComponent<VariableDetailsProps, V
         try {
           const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
           while (walker.nextNode()) {
-            const tn = walker.currentNode as any;
-            const text: string = (tn && (tn as any).nodeValue) || '';
+            const tn = walker.currentNode;
+            const text: string = tn?.nodeValue ?? '';
             for (let i = 0; i < text.length; i++) {
               const rng = document.createRange();
-              rng.setStart(tn as Node, i);
-              rng.setEnd(tn as Node, i + 1);
+              rng.setStart(tn, i);
+              rng.setEnd(tn, i + 1);
               const r = rng.getBoundingClientRect();
               if (!r || r.width <= 0 || r.height <= 0) continue;
               const raw = text[i];

--- a/src/diagram/components/Autocomplete.tsx
+++ b/src/diagram/components/Autocomplete.tsx
@@ -10,14 +10,22 @@ import clsx from 'clsx';
 
 import styles from './Autocomplete.module.css';
 
+export interface AutocompleteRenderInputParams {
+  InputProps: {
+    disableUnderline: boolean;
+    ref: React.Ref<HTMLDivElement>;
+  };
+  inputProps: React.InputHTMLAttributes<HTMLInputElement>;
+}
+
 interface AutocompleteProps {
   key?: string;
   value?: string | null;
   defaultValue?: string;
-  onChange: (event: any, newValue: string | null) => void;
+  onChange: (event: React.SyntheticEvent | null, newValue: string | null) => void;
   clearOnEscape?: boolean;
   options: string[];
-  renderInput: (params: any) => React.ReactNode;
+  renderInput: (params: AutocompleteRenderInputParams) => React.ReactNode;
 }
 
 function itemToString(item: string | null): string {
@@ -81,8 +89,8 @@ export default function Autocomplete(props: AutocompleteProps) {
     }
   }, [isOpen]);
 
-  const inputProps = getInputProps();
-  const params = {
+  const inputProps = getInputProps() as React.InputHTMLAttributes<HTMLInputElement>;
+  const params: AutocompleteRenderInputParams = {
     InputProps: {
       disableUnderline: false,
       ref: wrapperRef,

--- a/src/diagram/drawing/Canvas.tsx
+++ b/src/diagram/drawing/Canvas.tsx
@@ -1743,7 +1743,7 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
       this.pointerId = e.pointerId;
       this.selectionCenterOffset = client;
 
-      (e.target as any).setPointerCapture(e.pointerId);
+      (e.target as Element).setPointerCapture(e.pointerId);
 
       this.setState({
         isEditingName: false,
@@ -1872,7 +1872,7 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
     this.selectionCenterOffset = this.getCanvasPoint(e.clientX, e.clientY);
 
     if (!isEditingName) {
-      (e.target as any).setPointerCapture(e.pointerId);
+      (e.target as Element).setPointerCapture(e.pointerId);
     }
 
     const { selectedTool } = this.props;
@@ -2044,10 +2044,10 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
     // an SVG element can't actually be focused.  Instead, blur any _other_
     // focused element.
     if (typeof document !== 'undefined' && document && document.activeElement) {
-      const e: any = document.activeElement;
-      // blur doesn't exist on "Element" but it definitely is a real thing
-
-      e.blur();
+      const activeElement = document.activeElement;
+      if ('blur' in activeElement && typeof activeElement.blur === 'function') {
+        activeElement.blur();
+      }
     }
   }
 

--- a/src/diagram/drawing/Label.tsx
+++ b/src/diagram/drawing/Label.tsx
@@ -169,7 +169,7 @@ export class Label extends React.PureComponent<LabelPropsFull> {
     }
     this.inMove = true;
 
-    (e.target as any).setPointerCapture(e.pointerId);
+    (e.target as Element).setPointerCapture(e.pointerId);
     this.props.onLabelDrag?.(this.props.uid, e);
   };
 

--- a/src/diagram/tests/line-chart.test.tsx
+++ b/src/diagram/tests/line-chart.test.tsx
@@ -8,7 +8,7 @@ import { LineChart, ChartSeries } from '../LineChart';
 
 // Polyfill PointerEvent for jsdom (which doesn't provide it)
 if (typeof PointerEvent === 'undefined') {
-  (global as any).PointerEvent = class PointerEvent extends MouseEvent {
+  class PointerEventPolyfill extends MouseEvent {
     readonly pointerId: number;
     readonly width: number;
     readonly height: number;
@@ -29,7 +29,12 @@ if (typeof PointerEvent === 'undefined') {
       this.pointerType = params.pointerType ?? '';
       this.isPrimary = params.isPrimary ?? false;
     }
-  };
+  }
+  Object.defineProperty(globalThis, 'PointerEvent', {
+    value: PointerEventPolyfill,
+    configurable: true,
+    writable: true,
+  });
 }
 
 // Mock ResizeObserver
@@ -58,11 +63,15 @@ class MockResizeObserver {
 }
 
 beforeAll(() => {
-  (global as any).ResizeObserver = MockResizeObserver;
+  Object.defineProperty(globalThis, 'ResizeObserver', {
+    value: MockResizeObserver,
+    configurable: true,
+    writable: true,
+  });
 });
 
 afterAll(() => {
-  delete (global as any).ResizeObserver;
+  Reflect.deleteProperty(globalThis, 'ResizeObserver');
 });
 
 // Mock setPointerCapture / releasePointerCapture on elements

--- a/src/diagram/view-conversion.ts
+++ b/src/diagram/view-conversion.ts
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the Apache License,
 // Version 2.0, that can be found in the LICENSE file.
 
-import type { JsonView, JsonViewElement, JsonRect, JsonFlowPoint, JsonLinkPoint } from '@simlin/engine';
+import type { JsonView, JsonViewElement, JsonRect, JsonFlowPoint, JsonLinkPoint, JsonLinkViewElement } from '@simlin/engine';
 
 import {
   ViewElement,
@@ -78,7 +78,7 @@ function elementToJson(element: ViewElement): JsonViewElement {
       };
 
     case 'link': {
-      const result: JsonViewElement = {
+      const result: JsonLinkViewElement = {
         type: 'link',
         uid: element.uid,
         fromUid: element.fromUid,
@@ -86,11 +86,11 @@ function elementToJson(element: ViewElement): JsonViewElement {
       };
 
       if (element.arc !== undefined) {
-        (result as any).arc = element.arc;
+        result.arc = element.arc;
       }
 
       if (element.multiPoint) {
-        (result as any).multiPoints = element.multiPoint.map(pointToLinkPoint);
+        result.multiPoints = element.multiPoint.map(pointToLinkPoint);
       }
 
       return result;

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -16,6 +16,32 @@ import { Project as ProjectPb } from './schemas/project_pb';
 import { User as UserPb } from './schemas/user_pb';
 import { UsernameDenylist } from './usernames';
 
+function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+  if (typeof error === 'string') {
+    return error;
+  }
+  if (typeof error === 'object' && error !== null) {
+    const message = (error as Record<string, unknown>).message;
+    if (typeof message === 'string') {
+      return message;
+    }
+  }
+  return String(error);
+}
+
+function getErrorCode(error: unknown): string | undefined {
+  if (typeof error === 'object' && error !== null) {
+    const code = (error as Record<string, unknown>).code;
+    if (typeof code === 'string') {
+      return code;
+    }
+  }
+  return undefined;
+}
+
 export async function updatePreview(db: Database, project: ProjectPb): Promise<PreviewPb> {
   const fileDoc = await db.file.findOne(project.getFileId());
   if (!fileDoc) {
@@ -26,8 +52,7 @@ export async function updatePreview(db: Database, project: ProjectPb): Promise<P
   try {
     png = await renderToPNG(fileDoc);
   } catch (error) {
-    const err = error as any;
-    throw new Error(`renderToPNG: ${err.message}`);
+    throw new Error(`renderToPNG: ${getErrorMessage(error)}`);
   }
 
   const created = new Timestamp();
@@ -101,14 +126,13 @@ export const apiRouter = (app: Application): Router => {
 
       res.status(200).json(project.toObject());
     } catch (error) {
-      const err = error as any;
-      if (err.code === 'wut') {
+      if (getErrorCode(error) === 'wut') {
         res.status(400).json({ error: 'project name already taken' });
         return;
       }
       logger.error(':ohno:');
-      logger.error(err);
-      throw err;
+      logger.error(error);
+      throw error;
     }
   });
 
@@ -319,8 +343,7 @@ export const apiRouter = (app: Application): Router => {
       await app.db.user.deleteOne(origUserId);
       logger.error(`done deleting old user ${origUserId}`);
     } catch (error) {
-      const err = error as any;
-      if (err.code === 'wut') {
+      if (getErrorCode(error) === 'wut') {
         res.status(400).json({ error: 'username already taken' });
         return;
       } else {

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -41,6 +41,17 @@ interface ContentSecurityPolicyDirectives {
   [directiveName: string]: Iterable<ContentSecurityPolicyDirectiveValue>;
 }
 
+type SessionCallback = (err?: Error) => void;
+
+type SessionWithCompat = Record<string, unknown> & {
+  regenerate?: (cb: SessionCallback) => void;
+  save?: (cb: SessionCallback) => void;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 export async function createApp(): Promise<App> {
   const app = new App();
   await app.setup();
@@ -53,7 +64,7 @@ class App {
   private readonly authn: admin.auth.Auth;
 
   constructor() {
-    this.app = express() as any as Application;
+    this.app = express() as unknown as Application;
 
     // initialize firebase
     admin.initializeApp();
@@ -97,13 +108,13 @@ class App {
       } else {
         let component = defined(path[0]);
         path = path.slice(1);
-        let obj: any = this.app.get(component);
-        while (obj && path.length > 1) {
+        let obj: unknown = this.app.get(component);
+        while (isRecord(obj) && path.length > 1) {
           component = defined(path[0]);
           path = path.slice(1);
           obj = obj[component];
         }
-        if (obj) {
+        if (isRecord(obj)) {
           obj[defined(path[0])] = value;
         }
       }
@@ -137,17 +148,20 @@ class App {
     // Passport 0.7.0 requires session.regenerate() and session.save()
     // that seshcookie's plain-object sessions don't provide.
     this.app.use((req: express.Request, _res: express.Response, next: express.NextFunction) => {
-      const addSessionMethods = (session: Record<string, any>): void => {
-        session.regenerate = (cb: (err?: any) => void) => {
+      const addSessionMethods = (session: SessionWithCompat): void => {
+        session.regenerate = (cb: SessionCallback) => {
           req.session = {};
-          addSessionMethods(req.session);
+          addSessionMethods(req.session as SessionWithCompat);
           cb();
         };
-        session.save = (cb: (err?: any) => void) => {
+        session.save = (cb: SessionCallback) => {
           cb();
         };
       };
-      addSessionMethods(req.session);
+      if (!isRecord(req.session)) {
+        req.session = {};
+      }
+      addSessionMethods(req.session as SessionWithCompat);
       next();
     });
 

--- a/src/server/authn.ts
+++ b/src/server/authn.ts
@@ -16,8 +16,38 @@ import { User } from './schemas/user_pb';
 
 interface StrategyOptions {}
 
+interface SerializedSessionUser {
+  id: string;
+}
+
+type VerifyDone = (error: Error | null, user?: unknown) => void;
+
 interface VerifyFunction {
-  (firestoreIdToken: string, done: (error: any, user?: any) => void): Promise<void>;
+  (firestoreIdToken: string, done: VerifyDone): Promise<void>;
+}
+
+function toError(error: unknown): Error {
+  if (error instanceof Error) {
+    return error;
+  }
+  if (typeof error === 'string') {
+    return new Error(error);
+  }
+  if (typeof error === 'object' && error !== null) {
+    const message = (error as Record<string, unknown>).message;
+    if (typeof message === 'string') {
+      return new Error(message);
+    }
+  }
+  return new Error(String(error));
+}
+
+function isSerializedSessionUser(value: unknown): value is SerializedSessionUser {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as Record<string, unknown>).id === 'string'
+  );
 }
 
 class FirestoreAuthStrategy extends BaseStrategy implements passport.Strategy {
@@ -30,7 +60,7 @@ class FirestoreAuthStrategy extends BaseStrategy implements passport.Strategy {
     this.verify = verify;
   }
 
-  authenticate(req: Request, _options?: any): void {
+  authenticate(req: Request, _options?: unknown): void {
     if (!req.body || !req.body.idToken) {
       this.error(new Error('no idToken in body'));
       return;
@@ -38,20 +68,20 @@ class FirestoreAuthStrategy extends BaseStrategy implements passport.Strategy {
 
     const idToken = req.body.idToken as string;
 
-    const verified = (error: any, user?: any): void => {
+    const verified: VerifyDone = (error, user): void => {
       if (error) {
         return this.error(error);
       }
       if (!user) {
         return this.fail(401);
       }
-      this.success(user);
+      this.success(user as User);
     };
 
     this.verify(idToken, verified)
       .then(() => {})
       .catch((err) => {
-        this.error(err);
+        this.error(toError(err));
       });
   }
 }
@@ -157,41 +187,45 @@ export const authn = (app: Application, firebaseAuthn: admin.auth.Auth): void =>
   // const config = app.get('authentication');
 
   passport.use(
-    new FirestoreAuthStrategy({}, async (firestoreIdToken: string, done: (error: any, user?: any) => void) => {
+    new FirestoreAuthStrategy({}, async (firestoreIdToken: string, done: VerifyDone) => {
       const [user, err] = await getOrCreateUserFromProfile(app.db.user, firebaseAuthn, firestoreIdToken);
       if (err !== undefined) {
         logger.error(err);
         done(err);
       } else if (user) {
-        done(undefined, user);
+        done(null, user);
       } else {
         throw new Error('unreachable');
       }
     }),
   );
 
-  passport.serializeUser((rawUser: any, done: (error: any, user?: any) => void) => {
-    const user = rawUser as User;
+  passport.serializeUser((rawUser, done) => {
+    if (!(rawUser instanceof User)) {
+      done(new Error('serializeUser expected a User instance'));
+      return;
+    }
+    const user = rawUser;
     console.log(`serialize user: ${user.getId()}`);
-    const serializedUser: any = {
+    const serializedUser: SerializedSessionUser = {
       id: user.getId(),
     };
-    done(undefined, serializedUser);
+    done(null, serializedUser);
   });
 
-  passport.deserializeUser(async (user: any, done: (error: any, user?: any) => void) => {
-    if (!user || !user.id) {
-      done(new Error(`no or incorrectly serialized User: ${user}`));
+  passport.deserializeUser(async (user, done) => {
+    if (!isSerializedSessionUser(user)) {
+      done(new Error(`no or incorrectly serialized User: ${String(user)}`));
       return;
     }
 
     const userModel = await app.db.user.findOne(user.id);
     if (!userModel) {
       logger.info(`couldn't find user '${user.id}' in DB`);
-      done(undefined, null);
+      done(null, null);
       return;
     }
-    done(undefined, userModel);
+    done(null, userModel);
   });
 
   app.use(passport.initialize());

--- a/src/server/headers.ts
+++ b/src/server/headers.ts
@@ -8,6 +8,7 @@ import { Response } from 'express';
 
 export function interceptWriteHeaders(res: Response, callback: (statusCode: number) => void): void {
   const realWriteHead = res.writeHead;
+  const writeHead = realWriteHead.bind(res);
 
   // eslint-disable-next-line
   // @ts-ignore
@@ -18,21 +19,17 @@ export function interceptWriteHeaders(res: Response, callback: (statusCode: numb
   ): ServerResponse => {
     callback(statusCode);
 
-    // ensure arguments.length is right
-    const args: [number, (string | OutgoingHttpHeaders | undefined)?, (OutgoingHttpHeaders | undefined)?] = [
-      statusCode,
-    ];
-    if (reasonOrHeaders !== undefined) {
-      args.push(reasonOrHeaders);
+    if (typeof reasonOrHeaders === 'string') {
       if (headers !== undefined) {
-        args.push(headers);
+        writeHead(statusCode, reasonOrHeaders, headers);
+      } else {
+        writeHead(statusCode, reasonOrHeaders);
       }
+    } else if (reasonOrHeaders !== undefined) {
+      writeHead(statusCode, reasonOrHeaders);
+    } else {
+      writeHead(statusCode);
     }
-
-    // TODO: remove this any cast in the future -- for now,
-    // typescript can't quite handle the insanity of Node's
-    // writeHead's signature
-    realWriteHead.apply(res, args as any);
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     // @ts-ignore

--- a/src/server/models/table-firestore.ts
+++ b/src/server/models/table-firestore.ts
@@ -5,7 +5,7 @@
 import { CollectionReference, FieldPath, Firestore } from '@google-cloud/firestore';
 import { Message } from 'google-protobuf';
 
-import { SerializableClass, Table } from './table';
+import { Query, SerializableClass, Table } from './table';
 
 interface FirestoreTableOptions {
   readonly db: Firestore;
@@ -17,7 +17,7 @@ interface Schema {
   // with Firestore, you specify the document name separately from the contents
   // _id: string;
   // additional stuff
-  [x: string]: any;
+  [x: string]: unknown;
 }
 
 export class FirestoreTable<T extends Message> implements Table<T> {
@@ -55,7 +55,7 @@ export class FirestoreTable<T extends Message> implements Table<T> {
     return this.deserialize(docSnapshot.get('value'));
   }
 
-  async findOneByScan(query: any): Promise<T | undefined> {
+  async findOneByScan(query: Query): Promise<T | undefined> {
     const docs = await this.findByScan(query);
     if (docs === undefined) {
       return undefined;
@@ -66,7 +66,7 @@ export class FirestoreTable<T extends Message> implements Table<T> {
     return docs[0];
   }
 
-  async findByScan(query: any): Promise<T[] | undefined> {
+  async findByScan(query: Query): Promise<T[] | undefined> {
     const keys = Object.keys(query);
     if (keys.length !== 1) {
       throw new Error('findByScan: expected single query key');
@@ -97,7 +97,7 @@ export class FirestoreTable<T extends Message> implements Table<T> {
 
   private doc(_id: string, pb: T): Schema {
     const serializedPb = pb.serializeBinary();
-    const doc: { [key: string]: any } = pb.toObject();
+    const doc = pb.toObject() as Record<string, unknown>;
 
     if (doc.hasOwnProperty('value')) {
       throw new Error('we expect document to not have "value" property');
@@ -112,7 +112,7 @@ export class FirestoreTable<T extends Message> implements Table<T> {
       if (key === 'jsonContents') {
         const contents = value;
         // if the JSON is too big, don't expose it (as its only for debugging info anyway)
-        if (contents.length > 100 * 1024) {
+        if (typeof contents === 'string' && contents.length > 100 * 1024) {
           doc[key] = null;
         }
       }
@@ -137,7 +137,7 @@ export class FirestoreTable<T extends Message> implements Table<T> {
     await docRef.create(this.doc(id, pb));
   }
 
-  async update(id: string, cond: any, pb: T): Promise<T | null> {
+  async update(id: string, cond: Query, pb: T): Promise<T | null> {
     try {
       await this.db.runTransaction(async (tx) => {
         const docRef = this.docRef(id);

--- a/src/server/models/table.ts
+++ b/src/server/models/table.ts
@@ -4,6 +4,8 @@
 
 import { Message } from 'google-protobuf';
 
+export type Query = Readonly<Record<string, unknown>>;
+
 export interface SerializableClass<T extends Message> {
   new (): T;
   deserializeBinary(bytes: Uint8Array): T;
@@ -13,10 +15,10 @@ export interface Table<T extends Message> {
   init(): Promise<void>;
 
   findOne(id: string): Promise<T | undefined>;
-  findOneByScan(query: any): Promise<T | undefined>;
-  findByScan(query: any): Promise<T[] | undefined>;
+  findOneByScan(query: Query): Promise<T | undefined>;
+  findByScan(query: Query): Promise<T[] | undefined>;
   find(idPrefix: string): Promise<T[]>;
   create(id: string, pb: T): Promise<void>;
-  update(id: string, cond: any, pb: T): Promise<T | null>;
+  update(id: string, cond: Query, pb: T): Promise<T | null>;
   deleteOne(id: string): Promise<void>;
 }

--- a/src/server/tests/session-passport-compat.test.ts
+++ b/src/server/tests/session-passport-compat.test.ts
@@ -9,12 +9,22 @@ import { Strategy as BaseStrategy } from 'passport-strategy';
 import { seshcookie } from 'seshcookie';
 import http from 'http';
 
+type SessionCallback = (err?: Error) => void;
+type SessionWithCompat = Record<string, unknown> & {
+  regenerate?: (cb: SessionCallback) => void;
+  save?: (cb: SessionCallback) => void;
+};
+
+interface TestSessionUser {
+  id: string;
+}
+
 // Minimal passport strategy that always succeeds with a test user.
 class TestStrategy extends BaseStrategy implements passport.Strategy {
   readonly name = 'test';
 
   authenticate(_req: express.Request): void {
-    this.success({ id: 'test-user' });
+    this.success({ id: 'test-user' } as TestSessionUser);
   }
 }
 
@@ -34,24 +44,24 @@ function createTestApp(options?: { addSessionCompat?: boolean }): express.Expres
 
   if (options?.addSessionCompat) {
     app.use((req: express.Request, _res: express.Response, next: express.NextFunction) => {
-      const addSessionMethods = (session: Record<string, any>): void => {
-        session.regenerate = (cb: (err?: any) => void) => {
+      const addSessionMethods = (session: SessionWithCompat): void => {
+        session.regenerate = (cb: SessionCallback) => {
           req.session = {};
-          addSessionMethods(req.session);
+          addSessionMethods(req.session as SessionWithCompat);
           cb();
         };
-        session.save = (cb: (err?: any) => void) => {
+        session.save = (cb: SessionCallback) => {
           cb();
         };
       };
-      addSessionMethods(req.session);
+      addSessionMethods(req.session as SessionWithCompat);
       next();
     });
   }
 
   passport.use(new TestStrategy());
-  passport.serializeUser((user: any, done) => done(undefined, user));
-  passport.deserializeUser((user: any, done) => done(undefined, user));
+  passport.serializeUser((user, done) => done(undefined, user as TestSessionUser));
+  passport.deserializeUser((user, done) => done(undefined, user as TestSessionUser));
 
   app.use(passport.initialize());
   app.use(passport.session());
@@ -76,7 +86,7 @@ function request(
   method: string,
   path: string,
   headers?: Record<string, string>,
-): Promise<{ status: number; body: any; headers: http.IncomingHttpHeaders }> {
+): Promise<{ status: number; body: unknown; headers: http.IncomingHttpHeaders }> {
   return new Promise((resolve, reject) => {
     const addr = server.address();
     if (!addr || typeof addr === 'string') {
@@ -94,9 +104,9 @@ function request(
         let data = '';
         res.on('data', (chunk) => (data += chunk));
         res.on('end', () => {
-          let body: any;
+          let body: unknown;
           try {
-            body = JSON.parse(data);
+            body = JSON.parse(data) as unknown;
           } catch {
             body = data;
           }
@@ -136,7 +146,7 @@ describe('seshcookie + passport session compatibility', () => {
 
       const checkRes = await request(server, 'GET', '/check', { cookie: cookieHeader });
       expect(checkRes.status).toBe(200);
-      expect(checkRes.body.user).toEqual({ id: 'test-user' });
+      expect((checkRes.body as { user?: TestSessionUser }).user).toEqual({ id: 'test-user' });
     } finally {
       server.close();
     }


### PR DESCRIPTION
Replace all explicit : any annotations and as any assertions across the TypeScript codebase with concrete types or unknown plus narrowing. This keeps existing runtime behavior while restoring compiler and lint guarantees around API boundaries, errors, and event/session handling.

Enable @typescript-eslint/no-explicit-any as an error in shared and legacy ESLint configs so future regressions are blocked.
