### PR TITLE
engine: fix nested array-producing builtin reductions in A2A

### DIFF
--- a/src/simlin-engine/src/compiler/mod.rs
+++ b/src/simlin-engine/src/compiler/mod.rs
@@ -995,6 +995,15 @@ fn builtin_contains_array_producing(builtin: &BuiltinFn) -> bool {
 /// handling the case where nested builtins operate on different dimensions.
 /// On the first call (element 0), collects the hoisted AssignTemp expressions.
 /// On subsequent calls, only performs the replacement using the same temp IDs.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum NestedBuiltinArgMode {
+    /// Expression is consumed as a scalar for the current A2A element.
+    ScalarElement,
+    /// Expression is consumed as an array value (e.g., SUM arg) and must keep
+    /// full-array semantics.
+    ArrayValue,
+}
+
 fn replace_nested_builtins_for_element(
     expr: Expr,
     var_idx: usize,
@@ -1002,17 +1011,23 @@ fn replace_nested_builtins_for_element(
     temp_id: &mut u32,
     hoisted: &mut Vec<Expr>,
     collect_hoisted: bool,
+    arg_mode: NestedBuiltinArgMode,
 ) -> Expr {
     if is_array_producing_builtin(&expr) {
         let id = *temp_id;
         *temp_id += 1;
         let loc = expr.get_loc();
         let builtin_view = find_expr_array_view(&expr).unwrap_or_else(|| var_view.clone());
-        let element_idx = project_var_index_to_temp(var_idx, var_view, &builtin_view);
         if collect_hoisted {
             hoisted.push(Expr::AssignTemp(id, Box::new(expr), builtin_view.clone()));
         }
-        return Expr::TempArrayElement(id, builtin_view, element_idx, loc);
+        return match arg_mode {
+            NestedBuiltinArgMode::ScalarElement => {
+                let element_idx = project_var_index_to_temp(var_idx, var_view, &builtin_view);
+                Expr::TempArrayElement(id, builtin_view, element_idx, loc)
+            }
+            NestedBuiltinArgMode::ArrayValue => Expr::TempArray(id, builtin_view, loc),
+        };
     }
     match expr {
         Expr::Op2(op, lhs, rhs, loc) => Expr::Op2(
@@ -1024,6 +1039,7 @@ fn replace_nested_builtins_for_element(
                 temp_id,
                 hoisted,
                 collect_hoisted,
+                arg_mode,
             )),
             Box::new(replace_nested_builtins_for_element(
                 *rhs,
@@ -1032,6 +1048,7 @@ fn replace_nested_builtins_for_element(
                 temp_id,
                 hoisted,
                 collect_hoisted,
+                arg_mode,
             )),
             loc,
         ),
@@ -1044,6 +1061,7 @@ fn replace_nested_builtins_for_element(
                 temp_id,
                 hoisted,
                 collect_hoisted,
+                arg_mode,
             )),
             loc,
         ),
@@ -1055,6 +1073,7 @@ fn replace_nested_builtins_for_element(
                 temp_id,
                 hoisted,
                 collect_hoisted,
+                arg_mode,
             )),
             Box::new(replace_nested_builtins_for_element(
                 *t,
@@ -1063,6 +1082,7 @@ fn replace_nested_builtins_for_element(
                 temp_id,
                 hoisted,
                 collect_hoisted,
+                arg_mode,
             )),
             Box::new(replace_nested_builtins_for_element(
                 *f,
@@ -1071,26 +1091,255 @@ fn replace_nested_builtins_for_element(
                 temp_id,
                 hoisted,
                 collect_hoisted,
+                arg_mode,
             )),
             loc,
         ),
-        // Descend into builtin arguments so that patterns like ABS(VECTOR_ELM_MAP(...))
-        // are correctly hoisted -- the array-producing builtin inside gets replaced with
-        // a TempArrayElement reference, and the outer non-array-producing builtin is
-        // preserved with its sub-expressions updated.
-        Expr::App(builtin, loc) => Expr::App(
-            builtin.map(|sub_expr| {
-                replace_nested_builtins_for_element(
-                    sub_expr,
-                    var_idx,
-                    var_view,
-                    temp_id,
-                    hoisted,
-                    collect_hoisted,
-                )
-            }),
-            loc,
-        ),
+        // Descend into builtin arguments while preserving whether each argument
+        // expects a scalar element or a full array value.
+        Expr::App(builtin, loc) => {
+            let rewritten = match builtin {
+                BuiltinFn::Sum(arg) => {
+                    BuiltinFn::Sum(Box::new(replace_nested_builtins_for_element(
+                        *arg,
+                        var_idx,
+                        var_view,
+                        temp_id,
+                        hoisted,
+                        collect_hoisted,
+                        NestedBuiltinArgMode::ArrayValue,
+                    )))
+                }
+                BuiltinFn::Stddev(arg) => {
+                    BuiltinFn::Stddev(Box::new(replace_nested_builtins_for_element(
+                        *arg,
+                        var_idx,
+                        var_view,
+                        temp_id,
+                        hoisted,
+                        collect_hoisted,
+                        NestedBuiltinArgMode::ArrayValue,
+                    )))
+                }
+                BuiltinFn::Size(arg) => {
+                    BuiltinFn::Size(Box::new(replace_nested_builtins_for_element(
+                        *arg,
+                        var_idx,
+                        var_view,
+                        temp_id,
+                        hoisted,
+                        collect_hoisted,
+                        NestedBuiltinArgMode::ArrayValue,
+                    )))
+                }
+                BuiltinFn::Max(arg, None) => BuiltinFn::Max(
+                    Box::new(replace_nested_builtins_for_element(
+                        *arg,
+                        var_idx,
+                        var_view,
+                        temp_id,
+                        hoisted,
+                        collect_hoisted,
+                        NestedBuiltinArgMode::ArrayValue,
+                    )),
+                    None,
+                ),
+                BuiltinFn::Min(arg, None) => BuiltinFn::Min(
+                    Box::new(replace_nested_builtins_for_element(
+                        *arg,
+                        var_idx,
+                        var_view,
+                        temp_id,
+                        hoisted,
+                        collect_hoisted,
+                        NestedBuiltinArgMode::ArrayValue,
+                    )),
+                    None,
+                ),
+                BuiltinFn::Mean(args) if args.len() == 1 => {
+                    let mut it = args.into_iter();
+                    let arg = it.next().expect("Mean(args) len checked");
+                    BuiltinFn::Mean(vec![replace_nested_builtins_for_element(
+                        arg,
+                        var_idx,
+                        var_view,
+                        temp_id,
+                        hoisted,
+                        collect_hoisted,
+                        NestedBuiltinArgMode::ArrayValue,
+                    )])
+                }
+                BuiltinFn::Rank(arg, opt) => BuiltinFn::Rank(
+                    Box::new(replace_nested_builtins_for_element(
+                        *arg,
+                        var_idx,
+                        var_view,
+                        temp_id,
+                        hoisted,
+                        collect_hoisted,
+                        NestedBuiltinArgMode::ArrayValue,
+                    )),
+                    opt.map(|(a, b)| {
+                        (
+                            Box::new(replace_nested_builtins_for_element(
+                                *a,
+                                var_idx,
+                                var_view,
+                                temp_id,
+                                hoisted,
+                                collect_hoisted,
+                                NestedBuiltinArgMode::ScalarElement,
+                            )),
+                            b.map(|c| {
+                                Box::new(replace_nested_builtins_for_element(
+                                    *c,
+                                    var_idx,
+                                    var_view,
+                                    temp_id,
+                                    hoisted,
+                                    collect_hoisted,
+                                    NestedBuiltinArgMode::ScalarElement,
+                                ))
+                            }),
+                        )
+                    }),
+                ),
+                BuiltinFn::VectorSelect(selection, expr, max_value, action, error_handling) => {
+                    BuiltinFn::VectorSelect(
+                        Box::new(replace_nested_builtins_for_element(
+                            *selection,
+                            var_idx,
+                            var_view,
+                            temp_id,
+                            hoisted,
+                            collect_hoisted,
+                            NestedBuiltinArgMode::ArrayValue,
+                        )),
+                        Box::new(replace_nested_builtins_for_element(
+                            *expr,
+                            var_idx,
+                            var_view,
+                            temp_id,
+                            hoisted,
+                            collect_hoisted,
+                            NestedBuiltinArgMode::ArrayValue,
+                        )),
+                        Box::new(replace_nested_builtins_for_element(
+                            *max_value,
+                            var_idx,
+                            var_view,
+                            temp_id,
+                            hoisted,
+                            collect_hoisted,
+                            NestedBuiltinArgMode::ScalarElement,
+                        )),
+                        Box::new(replace_nested_builtins_for_element(
+                            *action,
+                            var_idx,
+                            var_view,
+                            temp_id,
+                            hoisted,
+                            collect_hoisted,
+                            NestedBuiltinArgMode::ScalarElement,
+                        )),
+                        Box::new(replace_nested_builtins_for_element(
+                            *error_handling,
+                            var_idx,
+                            var_view,
+                            temp_id,
+                            hoisted,
+                            collect_hoisted,
+                            NestedBuiltinArgMode::ScalarElement,
+                        )),
+                    )
+                }
+                BuiltinFn::VectorElmMap(source, offsets) => BuiltinFn::VectorElmMap(
+                    Box::new(replace_nested_builtins_for_element(
+                        *source,
+                        var_idx,
+                        var_view,
+                        temp_id,
+                        hoisted,
+                        collect_hoisted,
+                        NestedBuiltinArgMode::ArrayValue,
+                    )),
+                    Box::new(replace_nested_builtins_for_element(
+                        *offsets,
+                        var_idx,
+                        var_view,
+                        temp_id,
+                        hoisted,
+                        collect_hoisted,
+                        NestedBuiltinArgMode::ArrayValue,
+                    )),
+                ),
+                BuiltinFn::VectorSortOrder(array_expr, direction_expr) => {
+                    BuiltinFn::VectorSortOrder(
+                        Box::new(replace_nested_builtins_for_element(
+                            *array_expr,
+                            var_idx,
+                            var_view,
+                            temp_id,
+                            hoisted,
+                            collect_hoisted,
+                            NestedBuiltinArgMode::ArrayValue,
+                        )),
+                        Box::new(replace_nested_builtins_for_element(
+                            *direction_expr,
+                            var_idx,
+                            var_view,
+                            temp_id,
+                            hoisted,
+                            collect_hoisted,
+                            NestedBuiltinArgMode::ScalarElement,
+                        )),
+                    )
+                }
+                BuiltinFn::AllocateAvailable(requests, profile, avail) => {
+                    BuiltinFn::AllocateAvailable(
+                        Box::new(replace_nested_builtins_for_element(
+                            *requests,
+                            var_idx,
+                            var_view,
+                            temp_id,
+                            hoisted,
+                            collect_hoisted,
+                            NestedBuiltinArgMode::ArrayValue,
+                        )),
+                        Box::new(replace_nested_builtins_for_element(
+                            *profile,
+                            var_idx,
+                            var_view,
+                            temp_id,
+                            hoisted,
+                            collect_hoisted,
+                            NestedBuiltinArgMode::ArrayValue,
+                        )),
+                        Box::new(replace_nested_builtins_for_element(
+                            *avail,
+                            var_idx,
+                            var_view,
+                            temp_id,
+                            hoisted,
+                            collect_hoisted,
+                            NestedBuiltinArgMode::ScalarElement,
+                        )),
+                    )
+                }
+                other => other.map(|sub_expr| {
+                    replace_nested_builtins_for_element(
+                        sub_expr,
+                        var_idx,
+                        var_view,
+                        temp_id,
+                        hoisted,
+                        collect_hoisted,
+                        arg_mode,
+                    )
+                }),
+            };
+            Expr::App(rewritten, loc)
+        }
         other => other,
     }
 }
@@ -1378,6 +1627,7 @@ fn expand_a2a_hoisted(
                     &mut temp_id,
                     &mut hoisted,
                     true,
+                    NestedBuiltinArgMode::ScalarElement,
                 );
                 result.extend(hoisted);
                 result.push(Expr::AssignCurr(off + i, Box::new(elem_rewritten)));
@@ -1394,6 +1644,7 @@ fn expand_a2a_hoisted(
                 &mut temp_id,
                 &mut hoisted,
                 true,
+                NestedBuiltinArgMode::ScalarElement,
             );
             result.extend(hoisted);
             result.push(Expr::AssignCurr(off, Box::new(rewritten)));
@@ -1412,6 +1663,7 @@ fn expand_a2a_hoisted(
                     &mut tid,
                     &mut unused,
                     false,
+                    NestedBuiltinArgMode::ScalarElement,
                 );
                 result.push(Expr::AssignCurr(off + i, Box::new(elem_rewritten)));
             }
@@ -1540,6 +1792,7 @@ fn expand_arrayed_hoisted(
                 &mut temp_id,
                 &mut hoisted,
                 true,
+                NestedBuiltinArgMode::ScalarElement,
             );
             result.extend(hoisted);
             ast_temp_bases.insert(hoisting_ast as *const _, base_temp_id);
@@ -1620,6 +1873,7 @@ fn expand_arrayed_hoisted(
                         &mut temp_id,
                         &mut hoisted,
                         true,
+                        NestedBuiltinArgMode::ScalarElement,
                     );
                     result.extend(hoisted);
                     result.push(Expr::AssignCurr(off + i, Box::new(elem_rewritten)));
@@ -1663,6 +1917,7 @@ fn expand_arrayed_hoisted(
                         &mut temp_id,
                         &mut new_hoisted,
                         true,
+                        NestedBuiltinArgMode::ScalarElement,
                     );
                     result.extend(new_hoisted);
                     ast_temp_bases.insert(ast_ptr, new_base);
@@ -1681,6 +1936,7 @@ fn expand_arrayed_hoisted(
                     &mut tid,
                     &mut unused,
                     false,
+                    NestedBuiltinArgMode::ScalarElement,
                 );
                 result.push(Expr::AssignCurr(off + i, Box::new(elem_rewritten)));
             } else if let Some(ast) = elem_ast {

--- a/src/simlin-engine/tests/compiler_vector.rs
+++ b/src/simlin-engine/tests/compiler_vector.rs
@@ -96,6 +96,73 @@ fn vector_elm_map_a2a_produces_correct_values_vm() {
     project.assert_vm_result("result", &[10.0, 30.0, 20.0]);
 }
 
+#[test]
+fn nested_vector_elm_map_inside_max_interpreter() {
+    // source = [10, 20, 30], offsets = [2, 0, 1] => VEM = [30, 10, 20]
+    // MAX(VEM, 15) should be element-wise: [30, 15, 20]
+    let project = TestProject::new("vem_nested_max_interp")
+        .indexed_dimension("D", 3)
+        .array_with_ranges("source[D]", vec![("1", "10"), ("2", "20"), ("3", "30")])
+        .array_with_ranges("offsets[D]", vec![("1", "2"), ("2", "0"), ("3", "1")])
+        .array_aux(
+            "result[D]",
+            "max(vector_elm_map(source[*], offsets[*]), 15)",
+        );
+
+    project.assert_interpreter_result("result", &[30.0, 15.0, 20.0]);
+}
+
+#[test]
+fn nested_vector_elm_map_inside_max_vm() {
+    let project = TestProject::new("vem_nested_max_vm")
+        .indexed_dimension("D", 3)
+        .array_with_ranges("source[D]", vec![("1", "10"), ("2", "20"), ("3", "30")])
+        .array_with_ranges("offsets[D]", vec![("1", "2"), ("2", "0"), ("3", "1")])
+        .array_aux(
+            "result[D]",
+            "max(vector_elm_map(source[*], offsets[*]), 15)",
+        );
+
+    project.assert_vm_result("result", &[30.0, 15.0, 20.0]);
+}
+
+#[test]
+fn nested_vector_elm_map_inside_sum_interpreter() {
+    // source = [10, 20, 30], offsets = [2, 0, 1] => VEM = [30, 10, 20]
+    // SUM(VEM) = 60
+    let project = TestProject::new("vem_nested_sum_interp")
+        .indexed_dimension("D", 3)
+        .array_with_ranges("source[D]", vec![("1", "10"), ("2", "20"), ("3", "30")])
+        .array_with_ranges("offsets[D]", vec![("1", "2"), ("2", "0"), ("3", "1")])
+        .scalar_aux("result", "sum(vector_elm_map(source[*], offsets[*]))");
+
+    project.assert_interpreter_result("result", &[60.0, 60.0]);
+}
+
+#[test]
+fn nested_vector_elm_map_inside_sum_in_array_context_interpreter() {
+    // In array context, SUM(VEM(...)) should still evaluate VEM as an array,
+    // not as an element-local scalar.
+    let project = TestProject::new("vem_nested_sum_array_context_interp")
+        .indexed_dimension("D", 3)
+        .array_with_ranges("source[D]", vec![("1", "10"), ("2", "20"), ("3", "30")])
+        .array_with_ranges("offsets[D]", vec![("1", "2"), ("2", "0"), ("3", "1")])
+        .array_aux("result[D]", "sum(vector_elm_map(source[*], offsets[*]))");
+
+    project.assert_interpreter_result("result", &[60.0, 60.0, 60.0]);
+}
+
+#[test]
+fn nested_vector_sort_order_inside_sum_in_array_context_interpreter() {
+    // vals = [30, 10, 20], vector_sort_order(vals, 1) = [2, 3, 1], SUM = 6
+    let project = TestProject::new("vso_nested_sum_array_context_interp")
+        .indexed_dimension("D", 3)
+        .array_with_ranges("vals[D]", vec![("1", "30"), ("2", "10"), ("3", "20")])
+        .array_aux("result[D]", "sum(vector_sort_order(vals[*], 1))");
+
+    project.assert_interpreter_result("result", &[6.0, 6.0, 6.0]);
+}
+
 // ---------------------------------------------------------------------------
 // AC4.3 - AllocateAvailable: AssignTemp hoisting in array context
 // ---------------------------------------------------------------------------
@@ -164,4 +231,39 @@ fn allocate_available_a2a_sums_to_supply_interpreter() {
 fn allocate_available_a2a_sums_to_supply_vm() {
     let project = make_alloc_project("alloc_a2a_sum_vm");
     project.assert_scalar_result("total_alloc", 40.0);
+}
+
+#[test]
+fn nested_allocate_available_inside_sum_in_array_context_interpreter() {
+    // allocate_available(request, pp, supply) returns a D-array whose total is supply.
+    // SUM(...) should therefore be 40, and in array context each element should
+    // receive that same scalar reduction result.
+    let project = TestProject::new("alloc_nested_sum_array_context_interp")
+        .indexed_dimension("D", 3)
+        .indexed_dimension("XP", 4)
+        .array_with_ranges("request[D]", vec![("1", "10"), ("2", "20"), ("3", "30")])
+        .scalar_const("supply", 40.0)
+        .array_with_ranges(
+            "pp[D,XP]",
+            vec![
+                ("1,1", "3"),
+                ("1,2", "1"),
+                ("1,3", "1"),
+                ("1,4", "0"),
+                ("2,1", "3"),
+                ("2,2", "1"),
+                ("2,3", "1"),
+                ("2,4", "0"),
+                ("3,1", "3"),
+                ("3,2", "1"),
+                ("3,3", "1"),
+                ("3,4", "0"),
+            ],
+        )
+        .array_aux(
+            "result[D]",
+            "sum(allocate_available(request[*], pp[*,1], supply))",
+        );
+
+    project.assert_interpreter_result("result", &[40.0, 40.0, 40.0]);
 }


### PR DESCRIPTION
## Summary
This PR fixes incorrect interpreter behavior when array-producing builtins are nested inside other builtins in A2A contexts.

The root cause was nested hoisting always rewriting array-producing builtins to `TempArrayElement`, even when the parent builtin expected an array argument (for example `SUM(...)`). That collapsed full-array semantics into element-local reads.

## Changes
- Made nested builtin rewriting argument-mode aware (`ScalarElement` vs `ArrayValue`).
- Keep `TempArray` for array-consuming argument positions and `TempArrayElement` for scalar-consuming positions.
- Added regression tests for nested:
  - `SUM(VECTOR ELM MAP(...))` in array context
  - `SUM(VECTOR SORT ORDER(...))` in array context
  - `SUM(ALLOCATE AVAILABLE(...))` in array context

## Validation
- `cargo test -p simlin-engine --test compiler_vector`
