### PR TITLE
engine: fold stdlib-name gating into stdlib_args lookup

### DIFF
--- a/src/simlin-engine/src/builtins_visitor.rs
+++ b/src/simlin-engine/src/builtins_visitor.rs
@@ -452,12 +452,15 @@ impl<'a> BuiltinVisitor<'a> {
                     return Ok(App(UntypedBuiltinFn(func, args), loc));
                 }
 
-                // TODO: make this a function call/hash lookup
-                if !crate::stdlib::MODEL_NAMES.contains(&func.as_str()) {
+                // `stdlib_args` is the authoritative per-name lookup: it both
+                // rejects unknown names and returns the input-port spec used
+                // below to wire the synthesized module. Folding the two
+                // lookups into one match also avoids a panic path for
+                // MODEL_NAMES entries without a `stdlib_args` spec (e.g.
+                // `systems_*`) if a user equation ever references them.
+                let Some(stdlib_model_inputs) = stdlib_args(&func) else {
                     return eqn_err!(UnknownBuiltin, loc.start, loc.end);
-                }
-
-                let stdlib_model_inputs = stdlib_args(&func).unwrap();
+                };
 
                 // In A2A context, add subscript suffix to module name for uniqueness
                 let subscript_suffix = self.subscript_suffix();


### PR DESCRIPTION
The stdlib-module dispatch in the builtin visitor did a linear
`MODEL_NAMES.contains()` scan and then called `stdlib_args(&func).unwrap()`
on the next line. Replace the two lookups with a single `let Some(...) =
stdlib_args(&func) else { ... }` match. This addresses the existing
TODO to use a function/hash lookup, and also removes a latent panic
path: MODEL_NAMES entries without a `stdlib_args` spec (currently the
`systems_*` stdlib modules used internally by the systems-format
importer) would have tripped the `.unwrap()` if ever referenced from a
user equation.