### PR TITLE
engine: reduce LTM circuit-enumeration memory and time on dense graphs

### DIFF
--- a/docs/design-plans/2026-04-17-ltm-mem-reduction.md
+++ b/docs/design-plans/2026-04-17-ltm-mem-reduction.md
@@ -1,0 +1,115 @@
+# LTM Circuit-Enumeration Memory Reduction
+
+Status: in progress on branch `reduce-ltm-mem`.
+Baseline captured 2026-04-17.
+
+## Problem
+
+`CausalGraph::find_circuit_node_lists` enumerates elementary circuits via
+lexicographic-small-start DFS over the causal graph. On dense SD models this
+blows up in both time and memory:
+
+* test/metasd/WRLD3-03/wrld3-03.mdl has **1,863,803** deduplicated elementary
+  circuits (mean length 47 nodes, max 80).
+* Full enumeration consumes **8.45 GiB peak RSS** and **27 s wall-clock** on
+  reduce-ltm-mem@d1870d2e (baseline commit for this work). WASM's 4 GiB linear
+  memory limit forces the existing `MAX_LTM_CIRCUITS = 100_000` budget, which
+  itself already consumes ~322 MiB.
+* Per-circuit cost: ~4.5 KiB (Vec<Ident<Canonical>> with ~47 heap-allocated
+  String clones per circuit, plus the dedup HashSet<String> key which is
+  string-joined node names).
+
+## Graph Characterization (wrld3-03)
+
+* 302 nodes with outgoing edges, 313 nodes overall
+* 483 total out-edges
+* 1 weakly-connected component (size 313)
+* **148 strongly-connected components. Largest = 166 nodes.**
+* **Exactly 1 non-trivial SCC (size > 1).** 147 trivial SCCs carry zero cycles.
+* 15 stocks, all in the single non-trivial SCC.
+
+The `166`-node SCC is where every loop lives. Enumeration across all 302
+start-nodes spends the majority of its work inside this SCC; the 147 nodes
+outside it never close a cycle but are still explored when their successor
+edges lead into the SCC.
+
+## System-Dynamics Domain Notes
+
+* Directed edges: flow→stock (structural), stock→flow / aux→aux / stock→aux
+  / aux→flow (from equation dependencies). Stock init-value dependencies are
+  intentionally excluded from the cycle graph.
+* A well-formed SD cycle contains at least one stock: stocks provide the
+  DT-delay that makes the feedback solvable. A pure auxiliary cycle would
+  be an unsolvable algebraic loop and is rejected elsewhere.
+* The DT delay is a semantic property of how the simulator integrates the
+  stock, not a structural property of the graph. For the purposes of cycle
+  enumeration the directed graph is the complete ground truth; Johnson's
+  algorithm on it is both necessary and sufficient.
+* SD models tend to have long cycles (many auxes between stocks). wrld3's
+  mean cycle length is 47 nodes -- the per-circuit memory cost is dominated
+  by path length.
+
+## Hypotheses (in priority order)
+
+### H1 -- SCC-restricted enumeration
+
+Compute strongly-connected components of the full graph once. For each
+non-trivial SCC, enumerate circuits using only intra-SCC edges, starting
+only from nodes in that SCC. Cross-SCC edges are never traversed (they
+cannot close any cycle). Trivial SCCs are skipped outright.
+
+Expected savings: modest on wrld3 (most of the work already happens inside
+the big SCC because of the small-start invariant) but significant for time
+on graphs with many trivial feeders. Mainly a correctness-preserving
+structural improvement that composes well with H2/H3.
+
+### H3 -- integer node IDs throughout the DFS
+
+Replace `Vec<Ident<Canonical>>` paths and visited sets with `Vec<NodeId>`
+(NodeId = u32) plus a bitset. Each Ident clone is a heap String clone; each
+NodeId is 4 bytes no-alloc.
+
+Expected savings:
+* Per-circuit memory: ~14x reduction (~120 B for a 30-node circuit vs. ~1660 B)
+* Dedup key: ~8x reduction (sorted Vec<u32> vs. joined string)
+* Projected wrld3 peak: 8.45 GiB -> ~500 MiB.
+
+### H5 -- indexed dedup key
+
+Follows directly from H3. Dedup via `HashSet<SmallVec<[u32; 48]>>` of sorted
+node indices rather than `HashSet<String>` of joined names.
+
+### H2 -- true Johnson's with blocking (deferred)
+
+If time at `usize::MAX` budget remains unacceptable after H1+H3+H5, adopt
+Johnson's full algorithm using block-map unblocking. Johnson's is O((V+E)(C+1))
+worst case; the current small-start DFS can degrade badly on dense SCCs.
+
+### H11 -- eliminate defensive dedup (deferred / investigative)
+
+The small-start invariant already guarantees each circuit is found exactly
+once (from its lex-smallest node). The current `HashSet` dedup is defensive.
+Confirm empirically on a few models that the dedup is a no-op, then either
+remove it or keep a cheap indexed version from H5.
+
+## Success Criteria
+
+* Full wrld3 enumeration (budget = usize::MAX) fits in **<= 500 MiB** peak RSS.
+* Stretch: **<= 200 MiB** peak RSS.
+* No regression on simulate_ltm integration tests.
+* New unit tests cover SCC decomposition and indexed-graph invariants.
+* `wrld3_ltm_compilation_finishes_in_time` continues to pass.
+
+## Measurement Harness
+
+`src/simlin-engine/examples/ltm_mem_bench.rs` reports, given an `.mdl` path
+and a circuit budget:
+
+* graph shape (nodes / edges / stocks / SCC sizes)
+* elapsed wall-clock for `find_circuit_node_lists_with_limit`
+* VmPeak / VmHWM / VmRSS from /proc/self/status at each phase
+
+Invocation:
+```
+cargo run --release --example ltm_mem_bench -- test/metasd/WRLD3-03/wrld3-03.mdl <budget>
+```

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -168,3 +168,108 @@ Known debt items consolidated from CLAUDE.md files and codebase analysis. Each e
 - **Count**: 3 affected tests (as of 2026-02-24)
 - **Owner**: unassigned
 - **Last reviewed**: 2026-02-24
+
+### 20. LTM FixedIndex References Expand to N-squared Edges
+
+- **Component**: simlin-engine (src/simlin-engine/src/db_analysis.rs)
+- **Severity**: high
+- **Description**: `classify_element_dependency` lumps both wildcard reducers (`population[*]`) and fixed-index references (`population[NYC]`) under `CrossElement`, which `expand_edge_to_elements` then expands to the full N-by-N element cross-product. For a pattern like `relative_pop[R] = population / population[NYC]` the true element structure is two N-edge patterns (same-element and broadcast from NYC), not N-squared. On arrays with tens of elements the spurious edges trigger combinatorial loop-enumeration blow-ups even though their runtime link scores are effectively zero. Fix: add a `FixedIndex(element)` classification and emit `source[element] -> target[d]` edges instead of the all-to-all expansion.
+- **Measure**: Build a test model with explicit subscript references and count element-level edges vs. `N + N` expected.
+- **Owner**: unassigned
+- **Last reviewed**: 2026-04-17
+
+### 21. LTM Polarity Analysis Has Reducer Blind Spots
+
+- **Component**: simlin-engine (src/simlin-engine/src/ltm.rs `analyze_expr_polarity_with_context`)
+- **Severity**: medium
+- **Description**: Only the scalar two-arg forms of `Max(a, Some(b))` / `Min(a, Some(b))` are handled; the array reducer forms (`Sum`, `Mean`, `Max(_, None)`, `Min(_, None)`, `Stddev`, `Rank`) fall through to `App(_, _, _) => Unknown`. Any variable computed via `SUM(x[*])` or `MEAN(x[*])` therefore contributes `Unknown` polarity, and every loop through it is classified `Undetermined`. For `Sum` and `Mean` polarity is trivially the argument's polarity (monotone in every element). Graphical-function monotonicity also uses a strict EPSILON=1e-10 check that flags numeric import noise as `Unknown`. Fix: add reducer cases (pass through for SUM/MEAN, Unknown for STDDEV/RANK) and consider a plateau-tolerant GF monotonicity check.
+- **Owner**: unassigned
+- **Last reviewed**: 2026-04-17
+
+### 22. LTM Dedup Keys Fold Distinct Directed Cycles with Matching Node Sets
+
+- **Component**: simlin-engine (src/simlin-engine/src/ltm.rs `IndexedGraph::dedup_circuits`, `CausalGraph::deduplicate_loops`)
+- **Severity**: medium
+- **Description**: Dedup hashes the sorted node-index vector. In a multidigraph a cycle A->B->C->A and the distinct cycle A->C->B->A share a node set and are silently merged into a single `Loop`. `test_layout_arms_race` exercises this today. For scalar SD models with asymmetric dependency structure the merge happens to be benign, but the semantics are wrong: the two cycles have distinct edge sequences and potentially distinct polarity products. Fix: key dedup by a canonical edge-sequence rotation (rotate so the lex-smallest node starts the cycle, then compare the ordered edge list) instead of the sorted node set.
+- **Owner**: unassigned
+- **Last reviewed**: 2026-04-17
+
+### 23. LTM Circuit Enumeration Is Tiernan-Style, Not Johnson's
+
+- **Component**: simlin-engine (src/simlin-engine/src/ltm.rs `IndexedGraph::enumerate_circuits_in_scc`)
+- **Severity**: low
+- **Description**: The DFS uses Tiernan (1970) lexicographic-restart with a per-start visited set; the comment labelling it "Johnson-style" is inaccurate. Real Johnson (1975) maintains a blocked set and B[w] unblock lists to achieve O((V+E)(C+1)) time; Tiernan can repeat exploration of the same subtree from multiple starts when those subtrees yield no cycle back to the start. On wrld3 with a dense 166-node SCC the current MAX_LTM_CIRCUITS=100_000 path is already fast (~26 ms) because cycles close early, but pathological graphs with long non-cyclic branches could benefit meaningfully from the switch (~50 lines of added code). Fix: either rename the comment to "Tiernan-style" or implement the blocked-set mechanism.
+- **Owner**: unassigned
+- **Last reviewed**: 2026-04-17
+
+### 24. LTM SearchGraph Uses String-Backed Idents in Hot Path
+
+- **Component**: simlin-engine (src/simlin-engine/src/ltm_finding.rs `SearchGraph::check_outbound_uses`)
+- **Severity**: medium
+- **Description**: The per-timestep strongest-path DFS keys `best_score` and `visiting` on `Ident<Canonical>` (String-backed), cloning identifiers into hash maps on every recursive call. For a 1000-variable model with 500 saved timesteps this is ~5x10^7 map operations per run; element-level expansion makes it far worse. Apply the same NodeId indexing pattern that `IndexedGraph` uses in the exhaustive path: per-timestep `Vec<u32>`-indexed `SearchGraph`, dense `Vec<f64>` for `best_score`, `Vec<bool>` for `visiting`. Expected 5-10x speedup on large discovery runs.
+- **Owner**: unassigned
+- **Last reviewed**: 2026-04-17
+
+### 25. LTM Element-Level Loop Enumeration Runs at Wrong Granularity
+
+- **Component**: simlin-engine (src/simlin-engine/src/db_analysis.rs `model_element_loop_circuits`)
+- **Severity**: medium
+- **Description**: `model_element_loop_circuits` enumerates circuits on the element graph. For a pure-A2A model with 20 variables over a 100-element dimension, every variable-level circuit produces 100 element-level circuits that `build_element_level_loops` then collapses into one A2A loop. The multiplication hits MAX_LTM_CIRCUITS=100_000 far sooner than variable-level enumeration would. Fix: enumerate at the variable level first, tag each loop's edges by same-element / cross-element / scalar, and only element-level-enumerate the cross-element subgraph. Cost becomes additive in N for pure-A2A loops instead of multiplicative.
+- **Owner**: unassigned
+- **Last reviewed**: 2026-04-17
+
+### 26. LTM A2A Partial Equation Is Wrong When Target Mixes Same-Element and Cross-Element References
+
+- **Component**: simlin-engine (src/simlin-engine/src/ltm_augment.rs `build_partial_equation`)
+- **Severity**: medium
+- **Description**: For a target like `share[R] = population / SUM(population[*])` the source `population` appears both as a bare (same-element) reference and inside a wildcard reducer. The A2A ceteris-paribus wrapper leaves all `population` references unchanged, so when `share[nyc]` is evaluated in the partial, `SUM(population[*])` uses CURRENT populations for every element instead of PREV for the non-target elements. The partial equals the full expression, link-score magnitude is always 1, and dominance is misattributed. Fix: detect dual-mode references during AST analysis and either split into separate same-element and cross-element link scores or fall back to explicit per-element scalar scores for the edge.
+- **Owner**: unassigned
+- **Last reviewed**: 2026-04-17
+
+### 27. LTM STDDEV/RANK Fallback Scores Are Silently Wrong
+
+- **Component**: simlin-engine (src/simlin-engine/src/ltm_augment.rs `generate_nonlinear_partial`)
+- **Severity**: medium
+- **Description**: For STDDEV and RANK the "nonlinear" reducer path returns the target variable itself, yielding a delta-ratio `(target - PREV(target)) / (source[d] - PREV(source[d]))` instead of a ceteris-paribus partial. Under uniform scaling of all elements, STDDEV does not change, but the delta-ratio still reports nonzero per-element attributions. Fix: unroll STDDEV element-by-element with the standard formula `sqrt(((s[d] - mean_p)^2 + sum_{i!=d}(PREV(s[i]) - mean_p)^2) / N)` where `mean_p = (s[d] + sum_{i!=d}PREV(s[i]))/N`. Similar unroll applies to RANK.
+- **Owner**: unassigned
+- **Last reviewed**: 2026-04-17
+
+### 28. LTM Discovery Truncates Before Partition-Scoped Filtering
+
+- **Component**: simlin-engine (src/simlin-engine/src/ltm_finding.rs `rank_and_filter`)
+- **Severity**: low
+- **Description**: `rank_and_filter` sorts loops by average absolute score, truncates to MAX_LOOPS=200, and then applies MIN_CONTRIBUTION filtering per-partition. A loop that is dominant in a small partition but globally ranked below 200 is lost before the partition scope sees it. In practice MAX_LOOPS is generous enough that the case is rare; the comment already acknowledges the concern. Fix: filter first, truncate second.
+- **Owner**: unassigned
+- **Last reviewed**: 2026-04-17
+
+### 29. LTM LOOPSCORE / PATHSCORE Builtins Not Implemented
+
+- **Component**: simlin-engine (LTM augmentation layer)
+- **Severity**: low
+- **Description**: The reference treats `LOOPSCORE(path...)` and `PATHSCORE(path...)` as primitives users invoke to track loops the heuristic discovery may have missed. Simlin does not implement them. Given discovery is heuristic, users currently have no way to pin a specific loop and compare it across runs or parameter sweeps. Fix: generate one synthetic variable per user-named loop that computes the product of its constituent link scores; coexists cleanly with discovery.
+- **Owner**: unassigned
+- **Last reviewed**: 2026-04-17
+
+### 30. LTM Polarity Confidence Metric Missing
+
+- **Component**: simlin-engine (src/simlin-engine/src/ltm.rs `LoopPolarity::from_runtime_scores`)
+- **Severity**: low
+- **Description**: The paper's polarity-confidence metric `|r - |b|| / (r + |b|)` classifies loops as Rux/Bux when mostly one polarity. Simlin collapses any sign change to Undetermined, losing information on mostly-reinforcing loops that briefly dip balancing (or vice versa). Fix: retain the ratio alongside the categorical polarity and surface it in `DetectedLoopsResult`.
+- **Owner**: unassigned
+- **Last reviewed**: 2026-04-17
+
+### 31. RK4 + LTM Combination Has No Hard-Error Guard
+
+- **Component**: simlin-engine (src/simlin-engine/src/ltm_augment.rs flow-to-stock path)
+- **Severity**: medium
+- **Description**: The 2023 flow-to-stock link-score formula assumes Euler integration: `PREVIOUS(flow) - PREVIOUS(PREVIOUS(flow))` aligns the numerator to the causal interval that drove the stock change from t-1 to t. Under RK2/RK4 this alignment breaks and link scores become mathematically nonsensical. Nothing currently prevents a user from setting `integration_method = RK4` and `ltm_enabled = true`; they'd get numbers that look plausible but are wrong. Fix: emit a compile-time diagnostic (preferably an Error) when LTM is enabled on a model whose sim specs select a non-Euler integrator.
+- **Owner**: unassigned
+- **Last reviewed**: 2026-04-17
+
+### 32. LTM Unused `_is_affecting_stock` Flag
+
+- **Component**: simlin-engine (src/simlin-engine/src/ltm_augment.rs:374)
+- **Severity**: low
+- **Description**: `generate_stock_to_flow_equation` computes `_is_affecting_stock` and discards it. Either use it (e.g., zero out scores for non-connected stock->flow pairs) or delete. Trivial cleanup.
+- **Owner**: unassigned
+- **Last reviewed**: 2026-04-17

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -197,10 +197,10 @@ Known debt items consolidated from CLAUDE.md files and codebase analysis. Each e
 ### 23. LTM Circuit Enumeration Is Tiernan-Style, Not Johnson's
 
 - **Component**: simlin-engine (src/simlin-engine/src/ltm.rs `IndexedGraph::enumerate_circuits_in_scc`)
-- **Severity**: low
-- **Description**: The DFS uses Tiernan (1970) lexicographic-restart with a per-start visited set; the comment labelling it "Johnson-style" is inaccurate. Real Johnson (1975) maintains a blocked set and B[w] unblock lists to achieve O((V+E)(C+1)) time; Tiernan can repeat exploration of the same subtree from multiple starts when those subtrees yield no cycle back to the start. On wrld3 with a dense 166-node SCC the current MAX_LTM_CIRCUITS=100_000 path is already fast (~26 ms) because cycles close early, but pathological graphs with long non-cyclic branches could benefit meaningfully from the switch (~50 lines of added code). Fix: either rename the comment to "Tiernan-style" or implement the blocked-set mechanism.
+- **Severity**: RESOLVED
+- **Description**: (**Resolved** in commit aa56c5a1 on the reduce-ltm-mem branch.) Production code now implements Johnson 1975 with the blocked-set + B[w] unblock-list mechanism; the misnamed "Johnson-style" Tiernan variant is retained only under `#[cfg(test)]` as a test oracle for a Johnson-vs-Tiernan equivalence proptest.  Keeping the entry as a historical pointer to the commit that fixed it.
 - **Owner**: unassigned
-- **Last reviewed**: 2026-04-17
+- **Last reviewed**: 2026-04-18
 
 ### 24. LTM SearchGraph Uses String-Backed Idents in Hot Path
 

--- a/src/simlin-engine/Cargo.toml
+++ b/src/simlin-engine/Cargo.toml
@@ -100,4 +100,8 @@ harness = false
 name = "compiler"
 harness = false
 
+[[bench]]
+name = "rapidhash_bench"
+harness = false
+
 [build-dependencies]

--- a/src/simlin-engine/benches/rapidhash_bench.rs
+++ b/src/simlin-engine/benches/rapidhash_bench.rs
@@ -1,0 +1,105 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+//! Throughput benchmark for the LTM circuit fingerprint hash.
+//!
+//! Compares the current `rapidhash::hash_u32_slice` (rapidhash V3
+//! `HashMicro`) against the original FNV-1a baseline at a range of input
+//! sizes covering the LTM call site's observed distribution
+//! (8..=320 bytes, ~188 bytes mean, ~47 u32 elements) and one large
+//! size (1 KiB) to sanity-check behavior outside the hot range.
+//!
+//! Run with `cargo bench -p simlin-engine --bench rapidhash_bench`.
+
+use std::hint::black_box;
+
+use criterion::{BenchmarkId, Criterion, Throughput, criterion_group, criterion_main};
+use simlin_engine::rapidhash::{hash_bytes, hash_u32_slice};
+
+/// Reference FNV-1a 64-bit hash, u32-at-a-time.
+///
+/// This is a verbatim copy of the pre-rapidhash implementation that
+/// lived in `src/simlin-engine/src/ltm.rs` -- keep it here as the apples-
+/// to-apples baseline so the criterion diff reflects a real replacement
+/// and not a comparison against some other hash crate's tuning.
+fn fnv1a_u32_slice(vals: &[u32]) -> u64 {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x100000001b3;
+    let mut h: u64 = FNV_OFFSET_BASIS;
+    for &v in vals {
+        h ^= v as u64;
+        h = h.wrapping_mul(FNV_PRIME);
+    }
+    h
+}
+
+/// Input sizes in bytes.  Spans the 8..=320 byte sweet spot plus an
+/// outlier size so we can tell if `HashMicro` loses ground for large
+/// keys (it shouldn't for these sizes, but it's a cheap guardrail).
+const SIZES_BYTES: &[usize] = &[8, 32, 64, 128, 188, 256, 320, 1024];
+
+/// Build a `Vec<u32>` of the requested byte length by striding a simple
+/// pseudo-random sequence -- realistic enough that the optimizer can't
+/// fold it to a constant, deterministic enough that benchmark runs are
+/// comparable.
+fn make_u32_input(size_bytes: usize) -> Vec<u32> {
+    assert!(size_bytes.is_multiple_of(4), "u32 input must be 4-aligned");
+    let n = size_bytes / 4;
+    let mut out = Vec::with_capacity(n);
+    let mut state: u64 = 0xdeadbeef_cafebabe;
+    for _ in 0..n {
+        // Xorshift64 -- two xors and two shifts, cheap and good enough
+        // to defeat loop-invariant code motion.
+        state ^= state << 13;
+        state ^= state >> 7;
+        state ^= state << 17;
+        out.push(state as u32);
+    }
+    out
+}
+
+fn bench_hashes(c: &mut Criterion) {
+    let seed = 0xabcdef0123456789u64;
+
+    // rapidhash_bench vs fnv1a_bench as separate groups so criterion's
+    // throughput display is unambiguous.
+    let mut rapid_group = c.benchmark_group("rapidhash_micro");
+    for &size in SIZES_BYTES {
+        let input = make_u32_input(size);
+        rapid_group.throughput(Throughput::Bytes(size as u64));
+        rapid_group.bench_with_input(BenchmarkId::from_parameter(size), &input, |b, input| {
+            b.iter(|| black_box(hash_u32_slice(black_box(input), seed)));
+        });
+    }
+    rapid_group.finish();
+
+    let mut fnv_group = c.benchmark_group("fnv1a_u32");
+    for &size in SIZES_BYTES {
+        let input = make_u32_input(size);
+        fnv_group.throughput(Throughput::Bytes(size as u64));
+        fnv_group.bench_with_input(BenchmarkId::from_parameter(size), &input, |b, input| {
+            b.iter(|| black_box(fnv1a_u32_slice(black_box(input))));
+        });
+    }
+    fnv_group.finish();
+
+    // Byte-level hash: also relevant since the `hash_u32_slice` wrapper
+    // adds a single `from_raw_parts` call that we want to verify has
+    // zero measurable cost.
+    let mut raw_group = c.benchmark_group("rapidhash_micro_bytes");
+    for &size in SIZES_BYTES {
+        let input: Vec<u8> = make_u32_input(size)
+            .iter()
+            .flat_map(|v| v.to_le_bytes())
+            .collect();
+        raw_group.throughput(Throughput::Bytes(size as u64));
+        raw_group.bench_with_input(BenchmarkId::from_parameter(size), &input, |b, input| {
+            b.iter(|| black_box(hash_bytes(black_box(input), seed)));
+        });
+    }
+    raw_group.finish();
+}
+
+criterion_group!(benches, bench_hashes);
+criterion_main!(benches);

--- a/src/simlin-engine/examples/ltm_mem_bench.rs
+++ b/src/simlin-engine/examples/ltm_mem_bench.rs
@@ -1,0 +1,317 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+//! Memory and timing benchmark for LTM circuit enumeration.
+//!
+//! Usage: `cargo run --release --example ltm_mem_bench -- [mdl] [budget]`
+//!
+//! Example:
+//!   cargo run --release --example ltm_mem_bench -- \
+//!       test/metasd/WRLD3-03/wrld3-03.mdl 10000000
+//!
+//! Reports nodes, edges, stocks, wall-clock time, circuits found, and peak
+//! RSS as reported by `/proc/self/status` (VmPeak / VmHWM).  Designed as a
+//! repeatable measurement harness for iterating on the LTM enumeration
+//! algorithm without having to reason about the full salsa pipeline.
+
+use std::collections::HashMap;
+use std::fs;
+use std::time::Instant;
+
+use simlin_engine::common::{Canonical, Ident};
+use simlin_engine::db::{
+    SimlinDb, causal_graph_from_edges, model_causal_edges, sync_from_datamodel,
+};
+use simlin_engine::ltm::CausalGraph;
+use simlin_engine::open_vensim;
+
+fn read_proc_status_kb(key: &str) -> Option<u64> {
+    let status = fs::read_to_string("/proc/self/status").ok()?;
+    for line in status.lines() {
+        if let Some(rest) = line.strip_prefix(key) {
+            // lines look like: "VmPeak:\t  12345 kB"
+            let rest = rest.trim_start_matches(':').trim();
+            let value = rest.trim_end_matches(" kB").trim();
+            return value.parse().ok();
+        }
+    }
+    None
+}
+
+fn print_mem(label: &str) {
+    let peak = read_proc_status_kb("VmPeak").unwrap_or(0);
+    let hwm = read_proc_status_kb("VmHWM").unwrap_or(0);
+    let rss = read_proc_status_kb("VmRSS").unwrap_or(0);
+    eprintln!(
+        "[mem {label:>8}] VmPeak={:>9.3} MiB  VmHWM={:>9.3} MiB  VmRSS={:>9.3} MiB",
+        peak as f64 / 1024.0,
+        hwm as f64 / 1024.0,
+        rss as f64 / 1024.0,
+    );
+}
+
+fn scc_stats(
+    edges: &HashMap<Ident<Canonical>, Vec<Ident<Canonical>>>,
+) -> (usize, Vec<usize>, Vec<Vec<Ident<Canonical>>>) {
+    // Tarjan's SCC iteratively, so we don't blow the stack on big graphs.
+    // Returns (num_sccs, sorted_desc_sizes, non_trivial_sccs).
+    let mut all_nodes: std::collections::HashSet<&Ident<Canonical>> =
+        std::collections::HashSet::new();
+    for (from, tos) in edges {
+        all_nodes.insert(from);
+        for to in tos {
+            all_nodes.insert(to);
+        }
+    }
+    let mut nodes: Vec<&Ident<Canonical>> = all_nodes.into_iter().collect();
+    nodes.sort_by_key(|n| n.as_str());
+    let index_of: HashMap<&Ident<Canonical>, usize> =
+        nodes.iter().enumerate().map(|(i, n)| (*n, i)).collect();
+
+    // Build per-index successor lists
+    let mut succ: Vec<Vec<usize>> = vec![Vec::new(); nodes.len()];
+    for (from, tos) in edges {
+        if let Some(&fi) = index_of.get(from) {
+            for to in tos {
+                if let Some(&ti) = index_of.get(to) {
+                    succ[fi].push(ti);
+                }
+            }
+        }
+    }
+
+    let mut index = 0usize;
+    let mut indices: Vec<i64> = vec![-1; nodes.len()];
+    let mut lowlinks: Vec<i64> = vec![-1; nodes.len()];
+    let mut on_stack: Vec<bool> = vec![false; nodes.len()];
+    let mut stack: Vec<usize> = Vec::new();
+    let mut sccs: Vec<Vec<usize>> = Vec::new();
+
+    enum Frame {
+        Enter(usize),
+        Resume { v: usize, next_child: usize },
+    }
+
+    for start in 0..nodes.len() {
+        if indices[start] != -1 {
+            continue;
+        }
+        let mut frames: Vec<Frame> = vec![Frame::Enter(start)];
+        while let Some(frame) = frames.pop() {
+            match frame {
+                Frame::Enter(v) => {
+                    indices[v] = index as i64;
+                    lowlinks[v] = index as i64;
+                    index += 1;
+                    stack.push(v);
+                    on_stack[v] = true;
+                    frames.push(Frame::Resume { v, next_child: 0 });
+                }
+                Frame::Resume { v, next_child } => {
+                    if next_child < succ[v].len() {
+                        let w = succ[v][next_child];
+                        frames.push(Frame::Resume {
+                            v,
+                            next_child: next_child + 1,
+                        });
+                        if indices[w] == -1 {
+                            frames.push(Frame::Enter(w));
+                        } else if on_stack[w] && indices[w] < lowlinks[v] {
+                            lowlinks[v] = indices[w];
+                        }
+                    } else {
+                        // child iteration done; propagate lowlink to parent
+                        if let Some(Frame::Resume {
+                            v: parent,
+                            next_child: _,
+                        }) = frames.last_mut()
+                            && lowlinks[v] < lowlinks[*parent]
+                        {
+                            lowlinks[*parent] = lowlinks[v];
+                        }
+                        if lowlinks[v] == indices[v] {
+                            let mut scc = Vec::new();
+                            loop {
+                                let w = stack.pop().unwrap();
+                                on_stack[w] = false;
+                                scc.push(w);
+                                if w == v {
+                                    break;
+                                }
+                            }
+                            sccs.push(scc);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    let mut sizes: Vec<usize> = sccs.iter().map(|s| s.len()).collect();
+    sizes.sort_unstable_by(|a, b| b.cmp(a));
+
+    // Non-trivial SCCs = size > 1 OR (size == 1 AND has self-loop)
+    let mut non_trivial: Vec<Vec<Ident<Canonical>>> = Vec::new();
+    for scc in &sccs {
+        if scc.len() > 1 {
+            non_trivial.push(scc.iter().map(|&i| nodes[i].clone()).collect());
+        } else {
+            let v = scc[0];
+            if succ[v].contains(&v) {
+                non_trivial.push(vec![nodes[v].clone()]);
+            }
+        }
+    }
+
+    (sccs.len(), sizes, non_trivial)
+}
+
+fn connected_component_stats(
+    edges: &HashMap<Ident<Canonical>, Vec<Ident<Canonical>>>,
+) -> (usize, Vec<usize>) {
+    // Undirected connected components: for quick structural sanity check.
+    let mut undir: HashMap<&Ident<Canonical>, Vec<&Ident<Canonical>>> = HashMap::new();
+    for (from, tos) in edges {
+        undir.entry(from).or_default();
+        for to in tos {
+            undir.entry(from).or_default().push(to);
+            undir.entry(to).or_default().push(from);
+        }
+    }
+    let all_nodes: std::collections::HashSet<&Ident<Canonical>> = undir.keys().copied().collect();
+    let mut seen: std::collections::HashSet<&Ident<Canonical>> = std::collections::HashSet::new();
+    let mut sizes = Vec::new();
+    for start in &all_nodes {
+        if seen.contains(start) {
+            continue;
+        }
+        let mut stack = vec![*start];
+        let mut size = 0;
+        while let Some(node) = stack.pop() {
+            if !seen.insert(node) {
+                continue;
+            }
+            size += 1;
+            if let Some(neighbors) = undir.get(node) {
+                for n in neighbors {
+                    if !seen.contains(n) {
+                        stack.push(*n);
+                    }
+                }
+            }
+        }
+        sizes.push(size);
+    }
+    sizes.sort_unstable_by(|a, b| b.cmp(a));
+    (all_nodes.len(), sizes)
+}
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let mdl_path = args
+        .get(1)
+        .cloned()
+        .unwrap_or_else(|| "test/metasd/WRLD3-03/wrld3-03.mdl".to_string());
+    let budget: usize = args
+        .get(2)
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(usize::MAX);
+
+    eprintln!("=== LTM memory/time benchmark ===");
+    eprintln!("model:  {mdl_path}");
+    eprintln!("budget: {budget}");
+    print_mem("startup");
+
+    let mdl = fs::read_to_string(&mdl_path).expect("read model file");
+    let datamodel = open_vensim(&mdl).expect("parse MDL");
+    eprintln!(
+        "parsed: {} models, root variables = {}",
+        datamodel.models.len(),
+        datamodel
+            .models
+            .first()
+            .map(|m| m.variables.len())
+            .unwrap_or(0)
+    );
+    print_mem("parsed");
+
+    let db = SimlinDb::default();
+    let sync = sync_from_datamodel(&db, &datamodel);
+    // Identify the root model (Vensim has a single unnamed / "main" model).
+    let (model_name, synced) = sync
+        .models
+        .iter()
+        .find(|(n, m)| {
+            !m.is_stdlib && (n.as_str() == "main" || n.is_empty() || m.source.name(&db) != "main")
+        })
+        .or_else(|| sync.models.iter().find(|(_, m)| !m.is_stdlib))
+        .expect("root model");
+    eprintln!("root model: '{model_name}'");
+    print_mem("synced");
+
+    let t0 = Instant::now();
+    let edges_result = model_causal_edges(&db, synced.source, sync.project);
+    let edges_dur = t0.elapsed();
+    eprintln!(
+        "model_causal_edges: {:?}  ({} source nodes, {} stocks)",
+        edges_dur,
+        edges_result.edges.len(),
+        edges_result.stocks.len(),
+    );
+
+    let graph: CausalGraph = causal_graph_from_edges(edges_result);
+    let n_nodes_with_outedges = graph.edges().len();
+    let total_outedges: usize = graph.edges().values().map(|v| v.len()).sum();
+    let (n_total_nodes, cc_sizes) = connected_component_stats(graph.edges());
+    eprintln!(
+        "graph:  nodes-with-outedges={n_nodes_with_outedges}  all-nodes(by edges)={n_total_nodes}  \
+         total-outedges={total_outedges}  stocks={}",
+        graph.stocks().len()
+    );
+    eprintln!(
+        "weakly-connected components: {} (largest = {})",
+        cc_sizes.len(),
+        cc_sizes.first().copied().unwrap_or(0)
+    );
+    eprintln!("cc sizes: {:?}", &cc_sizes[..cc_sizes.len().min(10)]);
+
+    let (n_sccs, scc_sizes, non_trivial) = scc_stats(graph.edges());
+    eprintln!(
+        "strongly-connected components: {n_sccs} (largest = {})",
+        scc_sizes.first().copied().unwrap_or(0)
+    );
+    eprintln!("scc sizes: {:?}", &scc_sizes[..scc_sizes.len().min(15)]);
+    let loop_carrying: usize = non_trivial.iter().map(|s| s.len()).sum();
+    eprintln!(
+        "non-trivial SCCs (size>1 or self-loop): {}  loop-carrying nodes: {loop_carrying}",
+        non_trivial.len()
+    );
+    print_mem("graph");
+
+    eprintln!("\n--- enumerating circuits ---");
+    let t0 = Instant::now();
+    let result = graph.find_circuit_node_lists_with_limit(budget);
+    let elapsed = t0.elapsed();
+
+    match result {
+        Ok(circuits) => {
+            eprintln!("circuits (deduplicated): {}", circuits.len());
+            let lens: Vec<usize> = circuits.iter().map(|c| c.len()).collect();
+            if !lens.is_empty() {
+                let min = *lens.iter().min().unwrap();
+                let max = *lens.iter().max().unwrap();
+                let sum: usize = lens.iter().sum();
+                eprintln!(
+                    "circuit lengths: min={min}  max={max}  mean={:.1}",
+                    sum as f64 / lens.len() as f64
+                );
+            }
+        }
+        Err(_) => {
+            eprintln!("TRUNCATED at budget {budget} (caller should treat as 'too many')");
+        }
+    }
+    eprintln!("elapsed: {elapsed:?}");
+    print_mem("done");
+}

--- a/src/simlin-engine/examples/ltm_mem_bench.rs
+++ b/src/simlin-engine/examples/ltm_mem_bench.rs
@@ -238,16 +238,20 @@ fn main() {
 
     let db = SimlinDb::default();
     let sync = sync_from_datamodel(&db, &datamodel);
-    // Identify the root model (Vensim has a single unnamed / "main" model).
-    let (model_name, synced) = sync
+    // The root model is always the first entry of `datamodel.models`;
+    // looking it up by that exact name avoids the trap of "any non-stdlib
+    // model" which would match arbitrary submodels on projects that have
+    // them (sync.models is a HashMap, so .iter().find() is not stable).
+    let root_name = datamodel
         .models
-        .iter()
-        .find(|(n, m)| {
-            !m.is_stdlib && (n.as_str() == "main" || n.is_empty() || m.source.name(&db) != "main")
-        })
-        .or_else(|| sync.models.iter().find(|(_, m)| !m.is_stdlib))
-        .expect("root model");
-    eprintln!("root model: '{model_name}'");
+        .first()
+        .map(|m| m.name.as_str())
+        .expect("datamodel must contain at least one model");
+    let synced = sync
+        .models
+        .get(root_name)
+        .expect("root model must be present in sync result");
+    eprintln!("root model: '{root_name}'");
     print_mem("synced");
 
     let t0 = Instant::now();

--- a/src/simlin-engine/examples/ltm_mem_bench.rs
+++ b/src/simlin-engine/examples/ltm_mem_bench.rs
@@ -291,12 +291,21 @@ fn main() {
 
     eprintln!("\n--- enumerating circuits ---");
     let t0 = Instant::now();
-    let result = graph.find_circuit_node_lists_with_limit(budget);
+    // Use the indexed API (names table + u32 paths) so the benchmark
+    // reflects the post-H13 memory profile -- the legacy
+    // `Vec<Vec<Ident<Canonical>>>` path still exists for callers that
+    // need owned idents, but production LTM flows through the indexed
+    // view exclusively.
+    let result = graph.find_indexed_circuits_with_limit(budget);
     let elapsed = t0.elapsed();
 
     match result {
-        Ok(circuits) => {
-            eprintln!("circuits (deduplicated): {}", circuits.len());
+        Ok((names, circuits)) => {
+            eprintln!(
+                "circuits (deduplicated): {}  unique node names: {}",
+                circuits.len(),
+                names.len(),
+            );
             let lens: Vec<usize> = circuits.iter().map(|c| c.len()).collect();
             if !lens.is_empty() {
                 let min = *lens.iter().min().unwrap();

--- a/src/simlin-engine/proptest-regressions/ltm.txt
+++ b/src/simlin-engine/proptest-regressions/ltm.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc aad5c5bd10ca677b11c57fa6bc9142d7fa3799c3878b948d032e8f07171c2147 # shrinks to n = 2, edges = [(30, 61), (103, 138), (20, 12)]
+cc a1eea11f004d2fd257c93cee2c4aa965d9be18f6a94d5ce533f2113eb1f5f117 # shrinks to n = 4, edges = [(88, 217), (142, 19), (20, 202), (193, 26), (181, 123), (62, 37), (3, 192)]

--- a/src/simlin-engine/proptest-regressions/ltm.txt
+++ b/src/simlin-engine/proptest-regressions/ltm.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc aad5c5bd10ca677b11c57fa6bc9142d7fa3799c3878b948d032e8f07171c2147 # shrinks to n = 2, edges = [(30, 61), (103, 138), (20, 12)]

--- a/src/simlin-engine/src/db.rs
+++ b/src/simlin-engine/src/db.rs
@@ -20,7 +20,9 @@ pub use db_ltm::{
 
 #[path = "db_analysis.rs"]
 mod db_analysis;
+pub use db_analysis::causal_graph_from_edges;
 pub use db_analysis::causal_graph_from_element_edges;
+pub(crate) use db_analysis::reconstruct_model_variables;
 use db_analysis::*;
 pub use db_analysis::{
     CausalEdgesResult, CyclePartitionsResult, DetectedLoop, DetectedLoopPolarity,
@@ -28,7 +30,6 @@ pub use db_analysis::{
     model_causal_edges, model_cycle_partitions, model_detected_loops, model_element_causal_edges,
     model_element_cycle_partitions, model_element_loop_circuits, model_loop_circuits,
 };
-pub(crate) use db_analysis::{causal_graph_from_edges, reconstruct_model_variables};
 
 #[path = "db_implicit_deps.rs"]
 mod db_implicit_deps;

--- a/src/simlin-engine/src/db_analysis.rs
+++ b/src/simlin-engine/src/db_analysis.rs
@@ -636,7 +636,7 @@ pub(super) fn normalize_module_ref_str(s: &str) -> String {
 /// Construct a lightweight CausalGraph from a CausalEdgesResult.
 /// Variables and module_graphs are empty -- suitable for graph algorithms
 /// (circuit finding, SCC computation) but not for polarity analysis.
-pub(crate) fn causal_graph_from_edges(result: &CausalEdgesResult) -> crate::ltm::CausalGraph {
+pub fn causal_graph_from_edges(result: &CausalEdgesResult) -> crate::ltm::CausalGraph {
     use crate::common::{Canonical, Ident};
     use std::collections::HashSet;
 

--- a/src/simlin-engine/src/db_analysis.rs
+++ b/src/simlin-engine/src/db_analysis.rs
@@ -1608,11 +1608,11 @@ mod loop_circuits_result_tests {
         );
     }
 
-    /// A pure DAG produces zero circuits.  The `names` table still
-    /// reflects every node in the causal graph (the enumerator builds
-    /// the indexed graph before pruning SCCs), so we assert non-empty
-    /// -- callers that compare `names` to a legacy variable list should
-    /// use `to_named_circuits` for an exact match.
+    /// A pure DAG produces zero circuits and an empty names table.
+    /// Trimming names to cycle-participating nodes is what keeps the
+    /// salsa LoopCircuitsResult stable under renames of acyclic
+    /// variables -- see the `find_indexed_circuits_trims_names_to_cycle_participants`
+    /// regression test in `ltm.rs::tests` for the positive-side invariant.
     #[test]
     fn test_loop_circuits_result_empty_on_dag() {
         let project = TestProject::new("dag_only")
@@ -1624,6 +1624,10 @@ mod loop_circuits_result_tests {
         assert!(result.is_empty(), "pure DAG must produce zero circuits");
         assert_eq!(result.len(), 0);
         assert_eq!(result.to_named_circuits().len(), 0);
+        assert!(
+            result.names.is_empty(),
+            "empty circuits must produce empty names table so salsa stays stable under acyclic-variable renames"
+        );
     }
 }
 

--- a/src/simlin-engine/src/db_analysis.rs
+++ b/src/simlin-engine/src/db_analysis.rs
@@ -581,10 +581,65 @@ fn expand_same_element(
     }
 }
 
-/// Deduplicated loop circuits as node name lists.
+/// Deduplicated loop circuits in an indexed form.
+///
+/// Flat `Vec<Vec<String>>` was O(circuits × path_len) in owned-string
+/// allocations, which dominated RSS on dense graphs like WRLD3 where a
+/// single 166-node SCC produced ~1.86M circuits × 47 nodes ≈ 87M strings
+/// over only ~166 distinct names.  The indexed form keeps a single shared
+/// `names` table (one `String` per unique node) plus `circuits` as
+/// `Vec<Vec<u32>>`; reconstructing named circuits is a one-liner lookup.
+///
+/// Consumers that need the legacy `Vec<Vec<String>>` view can call
+/// [`LoopCircuitsResult::to_named_circuits`].  Prefer
+/// [`LoopCircuitsResult::circuit_names`] or direct index iteration when
+/// you only need to read the names.
 #[derive(Clone, Debug, PartialEq, Eq, salsa::Update)]
 pub struct LoopCircuitsResult {
-    pub circuits: Vec<Vec<String>>,
+    /// Unique variable names referenced by any circuit.  The integer
+    /// values inside `circuits` index into this vector.  Names are in
+    /// the canonical (lex-sorted) node ordering produced by the indexed
+    /// enumerator so identical models deterministically produce identical
+    /// results -- a prerequisite for salsa's pointer-equal caching.
+    pub names: Vec<String>,
+    /// Each circuit is a deduplicated sequence of indices into `names`.
+    /// Circuits are emitted in the enumerator's deterministic order.
+    pub circuits: Vec<Vec<u32>>,
+}
+
+impl LoopCircuitsResult {
+    /// Number of circuits.  Convenience wrapper around `circuits.len()`.
+    pub fn len(&self) -> usize {
+        self.circuits.len()
+    }
+
+    /// True when no circuits were found (or the enumerator exhausted its
+    /// budget and returned an empty placeholder).
+    pub fn is_empty(&self) -> bool {
+        self.circuits.is_empty()
+    }
+
+    /// Iterate the variable names of circuit `idx` as `&str` slices
+    /// without allocating a per-node `String`.
+    ///
+    /// Panics if `idx >= self.len()`, matching the behavior of a direct
+    /// `self.circuits[idx]` index.
+    pub fn circuit_names(&self, idx: usize) -> impl Iterator<Item = &str> {
+        self.circuits[idx]
+            .iter()
+            .map(|&i| self.names[i as usize].as_str())
+    }
+
+    /// Materialize the legacy `Vec<Vec<String>>` view.  Allocates one
+    /// `String` per referenced node; only use in tests or at API
+    /// boundaries that require owned strings -- prefer `circuit_names`
+    /// or index-based iteration otherwise.
+    pub fn to_named_circuits(&self) -> Vec<Vec<String>> {
+        self.circuits
+            .iter()
+            .map(|c| c.iter().map(|&i| self.names[i as usize].clone()).collect())
+            .collect()
+    }
 }
 
 /// A detected feedback loop with polarity and deterministic ID.
@@ -1009,13 +1064,8 @@ pub fn model_loop_circuits(
 ) -> LoopCircuitsResult {
     let edges_result = model_causal_edges(db, model, project);
     let graph = causal_graph_from_edges(edges_result);
-    let circuits = graph.find_circuit_node_lists();
-    LoopCircuitsResult {
-        circuits: circuits
-            .into_iter()
-            .map(|c| c.into_iter().map(|n| n.to_string()).collect())
-            .collect(),
-    }
+    let (names, circuits) = graph.find_indexed_circuits();
+    LoopCircuitsResult { names, circuits }
 }
 
 /// Detect feedback loops with polarity analysis and deterministic IDs.
@@ -1152,13 +1202,8 @@ pub fn model_element_loop_circuits(
 ) -> LoopCircuitsResult {
     let element_edges = model_element_causal_edges(db, model, project);
     let graph = causal_graph_from_element_edges(element_edges);
-    let circuits = graph.find_circuit_node_lists();
-    LoopCircuitsResult {
-        circuits: circuits
-            .into_iter()
-            .map(|c| c.into_iter().map(|n| n.to_string()).collect())
-            .collect(),
-    }
+    let (names, circuits) = graph.find_indexed_circuits();
+    LoopCircuitsResult { names, circuits }
 }
 
 /// Compute stock-to-stock cycle partitions at element granularity.
@@ -1482,6 +1527,103 @@ mod classify_element_dependency_tests {
             classify(&project, "relative_pop", "population"),
             ElementDependencyKind::CrossElement
         );
+    }
+}
+
+#[cfg(test)]
+mod loop_circuits_result_tests {
+    use super::*;
+    use crate::db::{SimlinDb, sync_from_datamodel};
+    use crate::test_common::TestProject;
+
+    /// Small feedback-loop project: population -> births -> population.
+    fn feedback_project() -> TestProject {
+        TestProject::new("loop_result_test")
+            .stock("population", "100", &["births"], &[], None)
+            .flow("births", "population * 0.1", None)
+    }
+
+    fn compute_loop_circuits(project: &TestProject) -> LoopCircuitsResult {
+        let datamodel = project.build_datamodel();
+        let db = SimlinDb::default();
+        let sync = sync_from_datamodel(&db, &datamodel);
+        let source_model = sync.models["main"].source;
+        let source_project = sync.project;
+        model_loop_circuits(&db, source_model, source_project).clone()
+    }
+
+    /// `to_named_circuits` must reconstruct the same owned-string lists
+    /// that the legacy `Vec<Vec<String>>` shape would have produced.
+    #[test]
+    fn test_loop_circuits_result_lookup_matches_legacy() {
+        let result = compute_loop_circuits(&feedback_project());
+
+        let legacy: Vec<Vec<String>> = result.to_named_circuits();
+        assert_eq!(legacy.len(), result.len());
+
+        for (ci, circuit_idx) in result.circuits.iter().enumerate() {
+            let names: Vec<&str> = result.circuit_names(ci).collect();
+            let legacy_names: Vec<&str> = legacy[ci].iter().map(String::as_str).collect();
+            assert_eq!(names, legacy_names);
+
+            // And each index resolves to the same name.
+            for (slot, &ni) in circuit_idx.iter().enumerate() {
+                assert_eq!(result.names[ni as usize], legacy[ci][slot]);
+            }
+        }
+
+        // The legacy loop has two nodes: population and births, both in
+        // the name table exactly once.
+        assert!(result.names.iter().any(|n| n == "population"));
+        assert!(result.names.iter().any(|n| n == "births"));
+    }
+
+    /// The shared name table should contain no duplicates and be sorted
+    /// lexicographically -- the enumerator relies on lex-sorted indices
+    /// for its small-start dedup, so the exposed table must preserve
+    /// that invariant.
+    #[test]
+    fn test_loop_circuits_result_names_are_unique_and_sorted() {
+        let project = TestProject::new("multi_node_loop")
+            .stock("a", "10", &["f1"], &[], None)
+            .flow("f1", "a * 0.1", None)
+            .stock("b", "20", &["f2"], &[], None)
+            .flow("f2", "b * 0.2", None);
+        let result = compute_loop_circuits(&project);
+
+        let mut sorted = result.names.clone();
+        sorted.sort();
+        assert_eq!(
+            result.names, sorted,
+            "names should be in lex-sorted order (the enumerator's canonical ordering)"
+        );
+
+        let mut dedup = result.names.clone();
+        dedup.sort();
+        dedup.dedup();
+        assert_eq!(
+            dedup.len(),
+            result.names.len(),
+            "names should contain no duplicates"
+        );
+    }
+
+    /// A pure DAG produces zero circuits.  The `names` table still
+    /// reflects every node in the causal graph (the enumerator builds
+    /// the indexed graph before pruning SCCs), so we assert non-empty
+    /// -- callers that compare `names` to a legacy variable list should
+    /// use `to_named_circuits` for an exact match.
+    #[test]
+    fn test_loop_circuits_result_empty_on_dag() {
+        let project = TestProject::new("dag_only")
+            .scalar_const("a", 1.0)
+            .scalar_aux("b", "a + 1")
+            .scalar_aux("c", "b * 2");
+        let result = compute_loop_circuits(&project);
+
+        assert!(result.is_empty(), "pure DAG must produce zero circuits");
+        assert_eq!(result.len(), 0);
+        assert_eq!(result.to_named_circuits().len(), 0);
     }
 }
 

--- a/src/simlin-engine/src/db_element_graph_tests.rs
+++ b/src/simlin-engine/src/db_element_graph_tests.rs
@@ -369,14 +369,15 @@ fn normalize_circuit(mut circuit: Vec<String>) -> Vec<String> {
 }
 
 /// Check that `circuits` contains a circuit matching `expected_nodes`
-/// (after normalization of both).
-fn assert_has_circuit(circuits: &[Vec<String>], expected_nodes: &[&str]) {
+/// (after normalization of both).  Accepts the indexed `LoopCircuitsResult`
+/// directly; materializing the owned-string view only happens for the
+/// test assertion path.
+fn assert_has_circuit(circuits: &super::LoopCircuitsResult, expected_nodes: &[&str]) {
     let expected: Vec<String> = expected_nodes.iter().map(|s| s.to_string()).collect();
     let normalized_expected = normalize_circuit(expected);
 
-    let normalized_circuits: Vec<Vec<String>> = circuits
-        .iter()
-        .map(|c| normalize_circuit(c.clone()))
+    let normalized_circuits: Vec<Vec<String>> = (0..circuits.len())
+        .map(|i| normalize_circuit(circuits.circuit_names(i).map(String::from).collect()))
         .collect();
 
     assert!(
@@ -414,9 +415,9 @@ fn a2a_produces_n_element_identical_loops() {
     );
 
     // Each loop should be a 2-node circuit: [population[r], births[r]]
-    assert_has_circuit(&result.circuits, &["population[nyc]", "births[nyc]"]);
-    assert_has_circuit(&result.circuits, &["population[boston]", "births[boston]"]);
-    assert_has_circuit(&result.circuits, &["population[la]", "births[la]"]);
+    assert_has_circuit(&result, &["population[nyc]", "births[nyc]"]);
+    assert_has_circuit(&result, &["population[boston]", "births[boston]"]);
+    assert_has_circuit(&result, &["population[la]", "births[la]"]);
 }
 
 // ---- Test 9: AC3.2 (cross-element loop detection) ----
@@ -452,12 +453,12 @@ fn cross_element_loop_through_sum_reducer() {
     );
 
     // Same-element loops
-    assert_has_circuit(&result.circuits, &["population[nyc]", "births[nyc]"]);
-    assert_has_circuit(&result.circuits, &["population[boston]", "births[boston]"]);
+    assert_has_circuit(&result, &["population[nyc]", "births[nyc]"]);
+    assert_has_circuit(&result, &["population[boston]", "births[boston]"]);
 
     // Cross-element loop: 4-node circuit through both regions
     assert_has_circuit(
-        &result.circuits,
+        &result,
         &[
             "population[nyc]",
             "births[boston]",
@@ -594,15 +595,17 @@ fn scalar_model_loops_and_partitions_identical() {
     let var_circuits = var_loop_circuits(&project);
     let elem_circuits = element_loop_circuits(&project);
 
-    // Normalize both for comparison (circuit ordering may differ)
+    // Normalize both for comparison (circuit ordering may differ).  The
+    // indexed form doesn't produce owned strings, so materialize the
+    // legacy shape once for the normalization dance.
     let mut var_normalized: Vec<Vec<String>> = var_circuits
-        .circuits
+        .to_named_circuits()
         .into_iter()
         .map(normalize_circuit)
         .collect();
     var_normalized.sort();
     let mut elem_normalized: Vec<Vec<String>> = elem_circuits
-        .circuits
+        .to_named_circuits()
         .into_iter()
         .map(normalize_circuit)
         .collect();

--- a/src/simlin-engine/src/db_ltm.rs
+++ b/src/simlin-engine/src/db_ltm.rs
@@ -1779,7 +1779,7 @@ fn cartesian_subscripts(dim_element_lists: &[Vec<String>]) -> Vec<String> {
 /// circuits with different variable-level structures. Each gets its own
 /// scalar loop with a unique element-specific ID suffix.
 fn build_element_level_loops(
-    element_circuits: &[Vec<String>],
+    element_circuits: &super::LoopCircuitsResult,
     var_graph: &crate::ltm::CausalGraph,
     source_vars: &HashMap<String, super::SourceVariable>,
     db: &dyn Db,
@@ -1789,26 +1789,39 @@ fn build_element_level_loops(
     use crate::common::{Canonical, Ident};
     use crate::ltm::{Loop, assign_loop_ids};
 
+    // Materialize each circuit as a small `Vec<&str>` once so downstream
+    // grouping, name stripping, and node-wise comparisons don't pay the
+    // indexed-lookup cost repeatedly.  The backing storage stays in
+    // `element_circuits.names`, so these slices are all borrows into the
+    // existing name table rather than per-call allocations.
+    let circuit_strs: Vec<Vec<&str>> = (0..element_circuits.len())
+        .map(|i| element_circuits.circuit_names(i).collect())
+        .collect();
+
     // Group element-level circuits by their variable-level node sequence.
-    // The key is the joined stripped names; the value collects all circuits
-    // that share that variable-level structure.
-    let mut groups: HashMap<String, Vec<&Vec<String>>> = HashMap::new();
-    for circuit in element_circuits {
+    // The key is the joined stripped names; the value collects indices
+    // into `circuit_strs` that share that variable-level structure.
+    let mut groups: HashMap<String, Vec<usize>> = HashMap::new();
+    for (ci, circuit) in circuit_strs.iter().enumerate() {
         let var_level_key: String = circuit
             .iter()
             .map(|n| strip_subscript(n))
             .collect::<Vec<_>>()
             .join("\x00");
-        groups.entry(var_level_key).or_default().push(circuit);
+        groups.entry(var_level_key).or_default().push(ci);
     }
 
     // Sort groups deterministically by their key.
-    let mut sorted_groups: Vec<(String, Vec<&Vec<String>>)> = groups.into_iter().collect();
+    let mut sorted_groups: Vec<(String, Vec<usize>)> = groups.into_iter().collect();
     sorted_groups.sort_by(|a, b| a.0.cmp(&b.0));
 
     let mut all_loops: Vec<Loop> = Vec::new();
 
-    for (_group_key, circuits_in_group) in &sorted_groups {
+    for (_group_key, group_indices) in &sorted_groups {
+        let circuits_in_group: Vec<&[&str]> = group_indices
+            .iter()
+            .map(|&ci| circuit_strs[ci].as_slice())
+            .collect();
         // Determine if this is a pure-dimension group.
         //
         // A group is pure-dimension when:
@@ -1824,7 +1837,7 @@ fn build_element_level_loops(
         // When a model has no arrayed variables, circuits won't have
         // subscripts and each group has exactly one circuit -- they are
         // scalar loops.
-        let representative = circuits_in_group[0];
+        let representative: &[&str] = circuits_in_group[0];
         let all_subscripted = representative.iter().all(|n| n.contains('['));
 
         // Detect cross-element circuits that should NOT be collapsed
@@ -1893,7 +1906,7 @@ fn build_element_level_loops(
             // Look at the first subscripted node to find which dimensions
             // it carries, then map canonical dim names to original
             // datamodel names for equation parsing.
-            let first_var_name = strip_subscript(&representative[0]);
+            let first_var_name = strip_subscript(representative[0]);
             let dimensions = source_vars
                 .get(first_var_name)
                 .map(|sv| {
@@ -2097,7 +2110,7 @@ pub fn model_ltm_variables(
     // the element-level graph has no variable data populated.
     let loops: Option<Vec<Loop>> = if !is_discovery {
         let circuits_result = model_element_loop_circuits(db, model, project);
-        if circuits_result.circuits.is_empty() {
+        if circuits_result.is_empty() {
             if !has_input_ports {
                 return LtmVariablesResult { vars: vec![] };
             }
@@ -2108,7 +2121,7 @@ pub fn model_ltm_variables(
             let var_graph = causal_graph_with_modules(db, model, project);
 
             let detected = build_element_level_loops(
-                &circuits_result.circuits,
+                circuits_result,
                 &var_graph,
                 source_vars,
                 db,

--- a/src/simlin-engine/src/db_tests.rs
+++ b/src/simlin-engine/src/db_tests.rs
@@ -1723,14 +1723,11 @@ fn test_model_loop_circuits_finds_feedback() {
     let circuits = model_loop_circuits(&db, model, result.project);
 
     // population -> births -> population is the single feedback loop
-    assert!(
-        !circuits.circuits.is_empty(),
-        "should find at least one circuit"
-    );
-    let has_pop_births_loop = circuits
-        .circuits
-        .iter()
-        .any(|c| c.contains(&"population".to_string()) && c.contains(&"births".to_string()));
+    assert!(!circuits.is_empty(), "should find at least one circuit");
+    let has_pop_births_loop = (0..circuits.len()).any(|i| {
+        let names: Vec<&str> = circuits.circuit_names(i).collect();
+        names.contains(&"population") && names.contains(&"births")
+    });
     assert!(has_pop_births_loop, "should find population-births loop");
 }
 
@@ -1888,7 +1885,7 @@ fn test_ltm_caching_dep_change_recomputes_circuits() {
     // Prime the cache
     let circuits_before = model_loop_circuits(&db, source_model, source_project);
     assert!(
-        !circuits_before.circuits.is_empty(),
+        !circuits_before.is_empty(),
         "should have circuits initially"
     );
 
@@ -1899,7 +1896,7 @@ fn test_ltm_caching_dep_change_recomputes_circuits() {
 
     let circuits_after = model_loop_circuits(&db, source_model, source_project);
     assert!(
-        circuits_after.circuits.is_empty(),
+        circuits_after.is_empty(),
         "should have no circuits after breaking loop"
     );
 }

--- a/src/simlin-engine/src/lib.rs
+++ b/src/simlin-engine/src/lib.rs
@@ -52,6 +52,8 @@ mod project;
 #[allow(clippy::derive_partial_eq_without_eq)]
 #[path = "project_io.gen.rs"]
 pub mod project_io;
+#[doc(hidden)]
+pub mod rapidhash;
 mod results;
 #[cfg(test)]
 mod rk_integration_tests;

--- a/src/simlin-engine/src/ltm.rs
+++ b/src/simlin-engine/src/ltm.rs
@@ -645,16 +645,35 @@ impl IndexedGraph {
         false
     }
 
-    /// Deduplicate circuits by node-set.  Keys are sorted `Vec<u32>` so each
-    /// key is ~4 bytes per node rather than the per-character weight of the
-    /// old `String::join(",")` path.
+    /// Deduplicate circuits by node-set.
+    ///
+    /// Two distinct elementary circuits can share a node set when the same
+    /// nodes are visited in different rotations (e.g. `a->b->c->a` vs.
+    /// `a->c->b->a` in a graph with edges in both orientations); the LTM
+    /// semantics fold these into a single loop.  See
+    /// `test_layout_arms_race` for a graph where this actually fires.
+    ///
+    /// Keys are a 64-bit fingerprint of the sorted node-index vector via
+    /// the default SipHash-1-3 hasher seeded from process RNG.  This is
+    /// within-process deterministic (every circuit uses the same seed) and
+    /// the birthday-collision probability over wrld3's 1.86M circuits is
+    /// under 1e-7 -- well below any observable impact on loop counts.
+    /// Storing u64 fingerprints instead of full sorted `Vec<u32>` keys
+    /// drops the dedup footprint from ~440 MiB to ~30 MiB on wrld3 at
+    /// uncapped enumeration.
     fn dedup_circuits(circuits: Vec<Vec<u32>>) -> Vec<Vec<u32>> {
-        let mut seen: HashSet<Vec<u32>> = HashSet::with_capacity(circuits.len());
+        use std::collections::hash_map::RandomState;
+        use std::hash::BuildHasher;
+
+        let state = RandomState::new();
+        let mut seen: HashSet<u64> = HashSet::with_capacity(circuits.len());
         let mut unique = Vec::with_capacity(circuits.len());
+        let mut scratch: Vec<u32> = Vec::new();
         for c in circuits {
-            let mut key = c.clone();
-            key.sort_unstable();
-            if seen.insert(key) {
+            scratch.clear();
+            scratch.extend_from_slice(&c);
+            scratch.sort_unstable();
+            if seen.insert(state.hash_one(&scratch)) {
                 unique.push(c);
             }
         }

--- a/src/simlin-engine/src/ltm.rs
+++ b/src/simlin-engine/src/ltm.rs
@@ -13,20 +13,27 @@ use crate::project::Project;
 use crate::variable::{Variable, identifier_set};
 
 /// Safety cap on the number of elementary circuits the causal-graph DFS
-/// will enumerate before bailing out.  The circuit count in a dense SD
-/// model (e.g. World3, C-LEARN) can blow up exponentially; without this
-/// cap LTM compilation will consume tens of gigabytes of memory, which
-/// on WASM surfaces as `RuntimeError: unreachable` from the allocator.
+/// will enumerate before bailing out.
 ///
-/// 100_000 is deliberately generous: typical hand-built models have at
-/// most a few thousand loops, so this only trips on truly pathological
-/// graphs where LTM results would be illegible anyway.
+/// After the reduce-ltm-mem branch brought wrld3's uncapped enumeration
+/// memory from ~8.5 GiB down to ~490 MiB and cut wall time to ~1.2 s
+/// (Johnson's), the cap is no longer needed to keep enumeration itself
+/// inside WASM's 4 GiB linear memory.  It still serves a second
+/// purpose: preventing the *downstream* LTM variable-generation pipeline
+/// (~2 synthetic variables per loop) from blowing up when the circuit
+/// count is in the millions.  wrld3 has ~1.86M elementary circuits;
+/// generating ~3.7M synthetic variables OOMs the compiler even though
+/// enumeration itself is fast and small.
+///
+/// Removing this cap cleanly would require first capping the synthetic
+/// variable count inside `model_ltm_variables` (or switching very
+/// large models to discovery mode).  See tech-debt #31 for the plan.
 pub(crate) const MAX_LTM_CIRCUITS: usize = 100_000;
 
-/// Marker returned by circuit-enumeration helpers when the DFS bailed out
-/// because it would have exceeded the [`MAX_LTM_CIRCUITS`] budget.  The
-/// caller should treat this as "LTM analysis skipped for this model" and
-/// emit a user-visible diagnostic.
+/// Marker returned by circuit-enumeration helpers when the DFS bailed
+/// out because it would have exceeded the [`MAX_LTM_CIRCUITS`] budget.
+/// The caller should treat this as "LTM analysis skipped for this
+/// model" and emit a user-visible diagnostic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct TruncatedByBudget;
 
@@ -391,6 +398,7 @@ struct IndexedGraph {
 /// Marker that DFS exceeded the shared circuit budget.  Used internally by
 /// `enumerate_circuits_in_scc` to propagate bail-out without confusion with
 /// a successful empty-result enumeration.
+#[derive(Debug)]
 struct TruncatedByBudgetInternal;
 
 /// Result bundle from the shared indexed-circuit enumerator: the
@@ -402,14 +410,34 @@ struct IndexedCircuits {
     circuits: Vec<Vec<u32>>,
 }
 
-/// Shared mutable state for the per-SCC DFS, bundled to keep the recursive
-/// helper's argument list short and the per-call overhead low.  All four
-/// fields are reset between starts by the enclosing loop.
+/// State for the per-SCC Tiernan DFS (kept as a test oracle -- the
+/// production path now uses Johnson's, see [`JohnsonState`]).
+#[cfg(test)]
 struct DfsState {
     visited: Vec<bool>,
     path: Vec<u32>,
     circuits: Vec<Vec<u32>>,
     in_scc: Vec<bool>,
+}
+
+/// State for the per-SCC Johnson 1975 circuit enumerator.
+///
+/// The core difference from Tiernan: nodes are `blocked` when entered on
+/// the DFS stack and STAY blocked on backtrack if their subtree didn't
+/// close a cycle.  Only when a cycle is later discovered through them --
+/// or through something they were waiting on (tracked via `b_list`) --
+/// are they unblocked for re-exploration.  This avoids Tiernan's repeated
+/// traversal of dead-end subtrees from different parent branches.
+///
+/// `blocked` and `b_list` are reset for every start node within an SCC,
+/// but `in_scc` is fixed for the whole SCC.  `path` and `circuits` are
+/// reused across starts to amortize allocation.
+struct JohnsonState {
+    blocked: Vec<bool>,
+    b_list: Vec<Vec<u32>>,
+    path: Vec<u32>,
+    in_scc: Vec<bool>,
+    circuits: Vec<Vec<u32>>,
 }
 
 impl IndexedGraph {
@@ -548,14 +576,25 @@ impl IndexedGraph {
         sccs
     }
 
-    /// Enumerate elementary circuits inside a single SCC using small-start
-    /// DFS.  Only edges whose target is also in the SCC are followed (others
-    /// cannot close a cycle), and starts are restricted to SCC members in
-    /// ascending index order so each cycle is found exactly once from its
-    /// lex-smallest node.
+    /// Enumerate elementary circuits inside a single SCC using Johnson 1975.
     ///
-    /// `budget` is the **remaining** circuit budget; it is decremented each
-    /// time a circuit of length > 1 is emitted.  Returns
+    /// Only edges whose target is inside the current SCC with index >=
+    /// `start` are followed, preserving the "each cycle emitted from its
+    /// lex-smallest node" invariant that downstream code
+    /// (`enrich_with_module_stocks`, `assign_loop_ids`, deterministic
+    /// salsa caching) depends on.
+    ///
+    /// The algorithm's efficiency vs. Tiernan-style lexicographic restart
+    /// comes from the blocked-set mechanism: once a node is visited on
+    /// the DFS stack it is `blocked`, and stays blocked on backtrack
+    /// unless a cycle was discovered through it.  Nodes that fail to
+    /// close a cycle register themselves as waiters in their successors'
+    /// `b_list`s; they're unblocked transitively when any of those
+    /// successors later participates in a cycle.  This avoids repeated
+    /// exploration of dead-end subtrees that Tiernan can fall into.
+    ///
+    /// `budget` is the **remaining** circuit budget; it is decremented
+    /// each time a circuit is emitted.  Returns
     /// `Err(TruncatedByBudgetInternal)` the moment the budget would go
     /// negative so the caller can stop immediately.
     fn enumerate_circuits_in_scc(
@@ -567,10 +606,165 @@ impl IndexedGraph {
             return Ok(Vec::new());
         }
 
-        // Trivial 1-node SCC with no self-loop: no circuits possible.  We
-        // still accept the 1-node-with-self-loop case but then `circuit.len()
-        // > 1` below rejects it -- pure self-loops were excluded by the
-        // old implementation and we preserve that contract.
+        // Size-1 SCC: the only possible circuit is a pure self-loop, and
+        // those are excluded by the `path.len() > 1` contract (a circuit
+        // is encoded as the list of stack nodes without the closing edge,
+        // so a length-1 list represents a self-loop we do not emit).
+        if scc.len() == 1 {
+            return Ok(Vec::new());
+        }
+
+        let n = self.nodes.len();
+        let mut state = JohnsonState {
+            blocked: vec![false; n],
+            b_list: vec![Vec::new(); n],
+            path: Vec::with_capacity(scc.len()),
+            in_scc: vec![false; n],
+            circuits: Vec::new(),
+        };
+        for &v in scc {
+            state.in_scc[v as usize] = true;
+        }
+
+        for &start in scc {
+            // Reset blocked/B[] for this start's search.  Reusing the
+            // allocations across starts saves a per-start Vec<bool>/Vec<Vec>
+            // construction cost.  O(|SCC|) per start; wrld3's 166-node SCC
+            // and 166 starts is 27 K bool writes total -- trivial.
+            for &v in scc {
+                state.blocked[v as usize] = false;
+                state.b_list[v as usize].clear();
+            }
+
+            // Push start onto the DFS stack and block it before entering
+            // the recursive CIRCUIT() subroutine -- the subroutine assumes
+            // its caller has already done this.
+            state.blocked[start as usize] = true;
+            state.path.push(start);
+
+            let result = self.johnson_circuit(start, start, &mut state, budget);
+
+            // Always restore the path stack even on bail-out so nested
+            // state is coherent if we ever chose to retry; since we
+            // currently abort the full enumeration on budget exhaustion
+            // this is defense-in-depth.
+            state.path.pop();
+
+            result?;
+        }
+
+        Ok(state.circuits)
+    }
+
+    /// Recursive CIRCUIT() of Johnson 1975.  Caller must have already:
+    ///   * pushed `v` onto `state.path`
+    ///   * set `state.blocked[v] = true`
+    ///
+    /// Returns `Ok(true)` if any cycle was discovered through `v` (direct
+    /// or via a descendant's recursive call); `Ok(false)` otherwise.
+    /// The caller decides whether to unblock `v` based on this return
+    /// value -- callers typically only need to concern themselves with
+    /// that when `v == start` at the outermost frame, where unblocking
+    /// happens inside the function itself.
+    fn johnson_circuit(
+        &self,
+        v: u32,
+        start: u32,
+        state: &mut JohnsonState,
+        budget: &mut usize,
+    ) -> std::result::Result<bool, TruncatedByBudgetInternal> {
+        let mut found_cycle = false;
+
+        // Successor list is already sorted ascending by
+        // `IndexedGraph::from_edges`.  Index iteration avoids holding an
+        // immutable borrow on `self.succ` across the recursive call.
+        let succs_len = self.succ[v as usize].len();
+        for i in 0..succs_len {
+            let w = self.succ[v as usize][i];
+
+            // Induced-subgraph gate: only traverse targets that are
+            // inside the current SCC AND have index >= start.  Targets
+            // with index < start would re-find cycles that were already
+            // emitted when their lex-smallest node was the start.
+            // Targets outside the SCC can never close a cycle back to
+            // start.
+            if !state.in_scc[w as usize] || w < start {
+                continue;
+            }
+
+            if w == start && state.path.len() > 1 {
+                // Elementary cycle: `state.path` currently holds
+                // [start, ..., v] with v != start (because path.len() > 1
+                // rules out the self-loop-at-root case).  The closing
+                // edge v -> start is implicit -- downstream code
+                // (circuit_to_links) wraps from path[last] to path[0].
+                // Budget is checked before the push so zero budget bails
+                // cleanly.
+                if *budget == 0 {
+                    return Err(TruncatedByBudgetInternal);
+                }
+                *budget -= 1;
+                state.circuits.push(state.path.clone());
+                found_cycle = true;
+            } else if w == start {
+                // Pure self-loop at the DFS root (v == start).  Excluded
+                // from the public contract (`circuit.len() > 1`).  We
+                // deliberately do NOT set `found_cycle = true` here --
+                // treating a self-loop as a discovered cycle would be
+                // semantically misleading even though in this case
+                // unblocking v is harmless (we're about to return from
+                // the outermost frame anyway).
+            } else if !state.blocked[w as usize] {
+                // Recurse into w: caller contract is "block and push
+                // before call, pop after call, unblock only via the
+                // Johnson unblock machinery".
+                state.blocked[w as usize] = true;
+                state.path.push(w);
+                let sub_found = self.johnson_circuit(w, start, state, budget)?;
+                state.path.pop();
+                if sub_found {
+                    found_cycle = true;
+                }
+            }
+        }
+
+        if found_cycle {
+            // Cycle found through v: unblock v and everything waiting
+            // on v (transitively).  Next exploration from a different
+            // branch might close a cycle through v and those waiters.
+            johnson_unblock(v, state);
+        } else {
+            // No cycle through v on this branch.  Register v as a waiter
+            // in each successor w's b_list, so that if w is later
+            // unblocked (because another DFS branch found a cycle
+            // through w), v will also be unblocked and retried.
+            for i in 0..succs_len {
+                let w = self.succ[v as usize][i];
+                if !state.in_scc[w as usize] || w < start {
+                    continue;
+                }
+                if !state.b_list[w as usize].contains(&v) {
+                    state.b_list[w as usize].push(v);
+                }
+            }
+        }
+
+        Ok(found_cycle)
+    }
+
+    /// Tiernan 1970 enumeration kept as the test oracle for the
+    /// Johnson-vs-Tiernan equivalence test.  Compiled only under
+    /// `cfg(test)`; production code uses `enumerate_circuits_in_scc`
+    /// (Johnson's).
+    #[cfg(test)]
+    fn enumerate_circuits_in_scc_tiernan(
+        &self,
+        scc: &[u32],
+        budget: &mut usize,
+    ) -> std::result::Result<Vec<Vec<u32>>, TruncatedByBudgetInternal> {
+        if scc.is_empty() {
+            return Ok(Vec::new());
+        }
         if scc.len() == 1 {
             let v = scc[0];
             if !self.succ[v as usize].contains(&v) {
@@ -578,8 +772,6 @@ impl IndexedGraph {
             }
         }
 
-        // Membership as a dense bitset for O(1) intra-SCC checks.  Using a
-        // Vec<bool> avoids pulling in `fixedbitset` as a dep.
         let mut in_scc: Vec<bool> = vec![false; self.nodes.len()];
         for &v in scc {
             in_scc[v as usize] = true;
@@ -595,7 +787,7 @@ impl IndexedGraph {
         for &start in scc {
             state.visited[start as usize] = true;
             state.path.push(start);
-            let bailed = self.dfs_circuits_indexed(start, start, &mut state, budget);
+            let bailed = self.dfs_tiernan_indexed(start, start, &mut state, budget);
             state.path.pop();
             state.visited[start as usize] = false;
             if bailed {
@@ -606,12 +798,10 @@ impl IndexedGraph {
         Ok(state.circuits)
     }
 
-    /// Recursive DFS mirroring the old `CausalGraph::dfs_circuits` but on
-    /// integer indices.  Returns `true` if the search bailed out on budget
-    /// so the caller can propagate immediately.  The "neighbor >= start"
-    /// test relies on `nodes` being lex-sorted: then index ordering matches
-    /// string ordering and each circuit emerges from its lex-smallest node.
-    fn dfs_circuits_indexed(
+    /// Tiernan DFS body, retained as oracle for the equivalence test.
+    /// See `enumerate_circuits_in_scc_tiernan` for rationale.
+    #[cfg(test)]
+    fn dfs_tiernan_indexed(
         &self,
         start: u32,
         current: u32,
@@ -619,9 +809,6 @@ impl IndexedGraph {
         budget: &mut usize,
     ) -> bool {
         for &neighbor in &self.succ[current as usize] {
-            // Restrict traversal to the current SCC: cross-SCC edges never
-            // close a cycle back to `start`, so exploring them is wasted
-            // work (and was a significant portion of WRLD3's runtime).
             if !state.in_scc[neighbor as usize] {
                 continue;
             }
@@ -634,7 +821,7 @@ impl IndexedGraph {
             } else if !state.visited[neighbor as usize] && neighbor >= start {
                 state.visited[neighbor as usize] = true;
                 state.path.push(neighbor);
-                let bailed = self.dfs_circuits_indexed(start, neighbor, state, budget);
+                let bailed = self.dfs_tiernan_indexed(start, neighbor, state, budget);
                 state.path.pop();
                 state.visited[neighbor as usize] = false;
                 if bailed {
@@ -697,6 +884,32 @@ impl IndexedGraph {
     /// rather than O(unique_nodes × circuits × path_len).
     fn node_name_strings(&self) -> Vec<String> {
         self.nodes.iter().map(|i| i.as_str().to_string()).collect()
+    }
+}
+
+/// Johnson 1975 UNBLOCK(u).  Iterative implementation so deeply nested
+/// B[] chains cannot overflow the recursion stack.
+///
+/// Called from `johnson_circuit` when a cycle has been found through `u`.
+/// Sets `blocked[u] = false` and drains `b_list[u]`, cascading to unblock
+/// every waiter that is still blocked.  `std::mem::take` empties the B[]
+/// list so that if `u` is re-blocked later, its list is ready for a fresh
+/// round of waiters.
+fn johnson_unblock(u: u32, state: &mut JohnsonState) {
+    let mut stack: Vec<u32> = vec![u];
+    while let Some(v) = stack.pop() {
+        // A vertex can appear in multiple B[] lists; the first pop
+        // transitions it to unblocked and any subsequent pop is a no-op.
+        if !state.blocked[v as usize] {
+            continue;
+        }
+        state.blocked[v as usize] = false;
+        let waiters = std::mem::take(&mut state.b_list[v as usize]);
+        for w in waiters {
+            if state.blocked[w as usize] {
+                stack.push(w);
+            }
+        }
     }
 }
 
@@ -785,21 +998,18 @@ impl CausalGraph {
         })
     }
 
-    /// Find all elementary circuits (feedback loops) using DFS.
+    /// Find all elementary circuits (feedback loops).
     ///
-    /// Bounded by `MAX_LTM_CIRCUITS`.  On dense causal graphs (e.g. World3
-    /// with hundreds of nodes and interconnected feedbacks) the number of
-    /// elementary circuits can blow up into the millions, which would
-    /// exhaust WASM's 4 GiB linear-memory limit and surface as a
-    /// `RuntimeError: unreachable` in the UI.  When the budget is exceeded
-    /// we return an empty vector -- LTM compilation then short-circuits
-    /// to "no loops detected" and the simulation still runs without
-    /// annotation, giving callers a chance to render sparklines rather
-    /// than crash.
+    /// Bounded by [`MAX_LTM_CIRCUITS`] because the downstream LTM
+    /// variable-generation pipeline synthesizes ~2 variables per loop;
+    /// at wrld3's ~1.86M circuits that's too many variables for the
+    /// compiler to handle even though the enumeration itself now
+    /// finishes in ~1.2 s and uses under 500 MiB.  On budget exhaustion
+    /// the public API returns an empty vec -- LTM compilation short-
+    /// circuits to "no loops detected" and simulation proceeds normally.
     ///
-    /// Callers that care whether LTM analysis was skipped should use
-    /// [`Self::find_loops_with_limit`] to get an explicit `TruncatedByBudget`
-    /// signal.
+    /// Callers that need an explicit truncation signal should use
+    /// [`Self::find_loops_with_limit`].
     pub fn find_loops(&self) -> Vec<Loop> {
         self.find_loops_with_limit(MAX_LTM_CIRCUITS)
             .unwrap_or_default()
@@ -904,10 +1114,10 @@ impl CausalGraph {
     /// Find all elementary circuits as deduplicated node lists.
     /// Only needs edges -- does not compute polarity or assign IDs.
     ///
-    /// Same budget semantics as [`Self::find_loops`]: bounded by
-    /// `MAX_LTM_CIRCUITS`; empty result on budget exhaustion.  Use
-    /// [`Self::find_circuit_node_lists_with_limit`] when the caller needs
-    /// to distinguish "no loops" from "too many loops to enumerate".
+    /// Bounded by [`MAX_LTM_CIRCUITS`]; empty result on budget
+    /// exhaustion.  Use [`Self::find_circuit_node_lists_with_limit`]
+    /// when the caller needs to distinguish "no loops" from "too many
+    /// loops to enumerate".
     pub fn find_circuit_node_lists(&self) -> Vec<Vec<Ident<Canonical>>> {
         self.find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
             .unwrap_or_default()
@@ -946,10 +1156,9 @@ impl CausalGraph {
         Ok((names, indexed.circuits))
     }
 
-    /// Unbounded (default-budget) variant of
-    /// [`Self::find_indexed_circuits_with_limit`]; returns `(names, [])`
-    /// when the DFS budget is exhausted so callers have a uniform empty
-    /// response.
+    /// Default-budget variant of [`Self::find_indexed_circuits_with_limit`];
+    /// bounded by [`MAX_LTM_CIRCUITS`].  Returns `(names, [])` when the
+    /// DFS budget is exhausted so callers have a uniform empty response.
     pub fn find_indexed_circuits(&self) -> (Vec<String>, Vec<Vec<u32>>) {
         self.find_indexed_circuits_with_limit(MAX_LTM_CIRCUITS)
             .unwrap_or_else(|_| (Vec::new(), Vec::new()))
@@ -4339,7 +4548,7 @@ mod tests {
     fn find_circuit_node_lists_succeeds_within_budget() {
         let graph = tiny_cycle_graph();
         let circuits = graph
-            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .find_circuit_node_lists_with_limit(usize::MAX)
             .expect("one-circuit graph must not exhaust the budget");
         assert_eq!(
             circuits.len(),
@@ -4414,7 +4623,7 @@ mod tests {
             module_graphs: HashMap::new(),
         };
         let circuits = cg
-            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .find_circuit_node_lists_with_limit(usize::MAX)
             .expect("empty graph must not trip the budget");
         assert!(circuits.is_empty(), "empty graph has no circuits");
     }
@@ -4436,7 +4645,7 @@ mod tests {
         }
 
         let circuits = cg
-            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .find_circuit_node_lists_with_limit(usize::MAX)
             .expect("small graph must not exhaust budget");
         assert_eq!(
             circuits_as_sorted_name_sets(&circuits),
@@ -4449,7 +4658,7 @@ mod tests {
         // A -> B -> C -> A: exactly one elementary circuit.
         let cg = build_causal_graph(&[("a", &["b"]), ("b", &["c"]), ("c", &["a"])]);
         let circuits = cg
-            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .find_circuit_node_lists_with_limit(usize::MAX)
             .expect("tiny cycle must not exhaust budget");
         assert_eq!(
             circuits_as_sorted_name_sets(&circuits),
@@ -4470,7 +4679,7 @@ mod tests {
             ("z", &["x"]),
         ]);
         let circuits = cg
-            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .find_circuit_node_lists_with_limit(usize::MAX)
             .expect("small disjoint graphs must not exhaust budget");
         let sorted = circuits_as_sorted_name_sets(&circuits);
         assert_eq!(
@@ -4489,7 +4698,7 @@ mod tests {
         // so only the A<->B cycle is returned.
         let cg = build_causal_graph(&[("a", &["b"]), ("b", &["a"]), ("s", &["s"])]);
         let circuits = cg
-            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .find_circuit_node_lists_with_limit(usize::MAX)
             .expect("small graph must not exhaust budget");
         assert_eq!(
             circuits_as_sorted_name_sets(&circuits),
@@ -4514,9 +4723,7 @@ mod tests {
             );
         }
         // And `find_circuit_node_lists_with_limit` agrees: zero circuits.
-        let circuits = cg
-            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
-            .unwrap();
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
         assert!(circuits.is_empty());
     }
 
@@ -4573,7 +4780,7 @@ mod tests {
         // self-loops (circuit.len() == 1) are intentionally excluded.
         let cg = build_causal_graph(&[("a", &["a"])]);
         let circuits = cg
-            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .find_circuit_node_lists_with_limit(usize::MAX)
             .expect("tiny graph must not exhaust budget");
         assert!(
             circuits.is_empty(),
@@ -4597,8 +4804,431 @@ mod tests {
         // with an ample budget must succeed and return exactly one circuit.
         let cg = build_causal_graph(&[("a", &["b"]), ("b", &["a"])]);
         let circuits = cg
-            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .find_circuit_node_lists_with_limit(usize::MAX)
             .expect("ample budget must succeed");
         assert_eq!(circuits.len(), 1);
+    }
+
+    // ------------------------------------------------------------------
+    // Johnson 1975 circuit-enumeration tests
+    // ------------------------------------------------------------------
+    //
+    // The tests below exercise the production Johnson's enumerator on
+    // targeted graph shapes and cross-check it against the Tiernan oracle
+    // retained under cfg(test) in the main IndexedGraph impl.  The
+    // invariants we care about match the LTM public contract:
+    //
+    //   (1) exactly the same set of circuits as Tiernan (after
+    //       canonicalizing each circuit's rotation),
+    //   (2) each circuit emitted rotated to start at its lex-smallest
+    //       node,
+    //   (3) pure self-loops excluded (circuit.len() > 1 contract),
+    //   (4) budget semantics: TruncatedByBudget on exactly the
+    //       max_circuits + 1st circuit,
+    //   (5) cross-SCC edges never traversed.
+
+    /// Helper: canonicalize a list of circuits for comparison.  Rotates
+    /// each circuit so that its lex-smallest node comes first, then sorts
+    /// the outer list.  Used by the equivalence test to compare Johnson's
+    /// output against Tiernan's ignoring rotation differences (both
+    /// algorithms SHOULD produce identical rotations under our
+    /// small-start discipline, but being rotation-insensitive in the test
+    /// hardens against future refactors).
+    fn canonicalize_circuits(mut circuits: Vec<Vec<u32>>) -> Vec<Vec<u32>> {
+        for c in &mut circuits {
+            if c.is_empty() {
+                continue;
+            }
+            let min_idx = c.iter().enumerate().min_by_key(|(_, v)| **v).unwrap().0;
+            c.rotate_left(min_idx);
+        }
+        circuits.sort();
+        circuits
+    }
+
+    /// Run both Johnson's (production) and Tiernan (oracle) on a graph
+    /// and assert their canonicalized outputs are equal.
+    fn assert_johnson_matches_tiernan(cg: &CausalGraph) {
+        let graph = IndexedGraph::from_edges(cg.edges());
+        let sccs = graph.tarjan_scc();
+
+        let mut johnson_circuits: Vec<Vec<u32>> = Vec::new();
+        let mut budget_j = usize::MAX;
+        for scc in &sccs {
+            let mut part = graph.enumerate_circuits_in_scc(scc, &mut budget_j).unwrap();
+            johnson_circuits.append(&mut part);
+        }
+
+        let mut tiernan_circuits: Vec<Vec<u32>> = Vec::new();
+        let mut budget_t = usize::MAX;
+        for scc in &sccs {
+            let mut part = graph
+                .enumerate_circuits_in_scc_tiernan(scc, &mut budget_t)
+                .unwrap();
+            tiernan_circuits.append(&mut part);
+        }
+
+        // Both should emit each cycle exactly once with the same total
+        // count.  Dedup (at the IndexedGraph::dedup_circuits layer) would
+        // normally fold multidigraph duplicates, but here we compare the
+        // raw output of each algorithm to confirm they're on equal footing.
+        let johnson_canon = canonicalize_circuits(johnson_circuits);
+        let tiernan_canon = canonicalize_circuits(tiernan_circuits);
+        assert_eq!(
+            johnson_canon,
+            tiernan_canon,
+            "Johnson's and Tiernan enumerations disagree on edges {:?}",
+            cg.edges()
+        );
+    }
+
+    #[test]
+    fn johnson_empty_graph_no_circuits() {
+        let cg = CausalGraph {
+            edges: HashMap::new(),
+            stocks: HashSet::new(),
+            variables: HashMap::new(),
+            module_graphs: HashMap::new(),
+        };
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        assert!(circuits.is_empty(), "empty graph must have zero circuits");
+    }
+
+    #[test]
+    fn johnson_pure_dag_no_circuits() {
+        let cg = build_causal_graph(&[("a", &["b"]), ("b", &["c"]), ("a", &["c"])]);
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        assert!(circuits.is_empty(), "pure DAG has no circuits");
+    }
+
+    #[test]
+    fn johnson_single_self_loop_excluded() {
+        // Pure self-loop A -> A: path.len() == 1 is filtered.
+        let cg = build_causal_graph(&[("a", &["a"])]);
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        assert!(circuits.is_empty(), "pure self-loop must not be emitted");
+    }
+
+    #[test]
+    fn johnson_two_node_back_edge_single_circuit() {
+        let cg = build_causal_graph(&[("a", &["b"]), ("b", &["a"])]);
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        assert_eq!(circuits.len(), 1);
+        assert_eq!(
+            circuits[0].iter().map(|n| n.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b"],
+            "circuit must be rotated to start at lex-smallest node"
+        );
+    }
+
+    #[test]
+    fn johnson_three_node_cycle_single_circuit() {
+        let cg = build_causal_graph(&[("a", &["b"]), ("b", &["c"]), ("c", &["a"])]);
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        assert_eq!(circuits.len(), 1);
+        assert_eq!(
+            circuits[0].iter().map(|n| n.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b", "c"]
+        );
+    }
+
+    #[test]
+    fn johnson_two_disjoint_cycles_two_circuits() {
+        let cg = build_causal_graph(&[
+            ("a", &["b"]),
+            ("b", &["c"]),
+            ("c", &["a"]),
+            ("x", &["y"]),
+            ("y", &["z"]),
+            ("z", &["x"]),
+        ]);
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        let names = circuits_as_sorted_name_sets(&circuits);
+        assert_eq!(
+            names,
+            vec![
+                vec!["a".to_string(), "b".to_string(), "c".to_string()],
+                vec!["x".to_string(), "y".to_string(), "z".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn johnson_figure_8_shared_vertex_two_circuits() {
+        // Two cycles sharing node `m`:
+        //   cycle 1: a -> m -> b -> a
+        //   cycle 2: c -> m -> d -> c
+        let cg = build_causal_graph(&[
+            ("a", &["m"]),
+            ("m", &["b", "d"]),
+            ("b", &["a"]),
+            ("c", &["m"]),
+            ("d", &["c"]),
+        ]);
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        let names = circuits_as_sorted_name_sets(&circuits);
+        assert_eq!(
+            names,
+            vec![
+                vec!["a".to_string(), "b".to_string(), "m".to_string()],
+                vec!["c".to_string(), "d".to_string(), "m".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn johnson_complete_k3_all_directed_cycles() {
+        // K3 with all 6 directed edges.  Elementary directed cycles:
+        //   3 two-cycles: {a,b}, {a,c}, {b,c}
+        //   2 three-cycles: a->b->c->a, a->c->b->a
+        // Dedup merges the two 3-cycles (same node set {a,b,c}) so the
+        // public API reports 4 circuits.
+        let cg = build_causal_graph(&[("a", &["b", "c"]), ("b", &["a", "c"]), ("c", &["a", "b"])]);
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        let names = circuits_as_sorted_name_sets(&circuits);
+        assert_eq!(
+            names,
+            vec![
+                vec!["a".to_string(), "b".to_string()],
+                vec!["a".to_string(), "b".to_string(), "c".to_string()],
+                vec!["a".to_string(), "c".to_string()],
+                vec!["b".to_string(), "c".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn johnson_zero_budget_bails_immediately() {
+        let cg = build_causal_graph(&[("a", &["b"]), ("b", &["a"])]);
+        let err = cg
+            .find_circuit_node_lists_with_limit(0)
+            .expect_err("zero budget on a cycle must truncate");
+        assert_eq!(err, TruncatedByBudget);
+    }
+
+    #[test]
+    fn johnson_respects_shared_budget_across_sccs() {
+        // Two disjoint 2-cycles and a generous-but-finite budget.  Both
+        // cycles fit; budget remains positive at the end.
+        let cg = build_causal_graph(&[("a", &["b"]), ("b", &["a"]), ("c", &["d"]), ("d", &["c"])]);
+        let circuits = cg.find_circuit_node_lists_with_limit(2).unwrap();
+        assert_eq!(circuits.len(), 2);
+
+        // Budget of 1 can emit only one of the two cycles before bailing.
+        let err = cg
+            .find_circuit_node_lists_with_limit(1)
+            .expect_err("budget of 1 cannot fit both 2-cycles");
+        assert_eq!(err, TruncatedByBudget);
+    }
+
+    #[test]
+    fn johnson_circuit_emitted_from_lex_smallest_node() {
+        // Construct a cycle where the lex-smallest node is NOT the first
+        // in the edge declarations so we can confirm rotation handling.
+        // Edges listed starting from "c": c -> a -> b -> c.  The cycle's
+        // lex-min is "a", so the emitted circuit is [a, b, c].
+        let cg = build_causal_graph(&[("c", &["a"]), ("a", &["b"]), ("b", &["c"])]);
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        assert_eq!(circuits.len(), 1);
+        assert_eq!(
+            circuits[0].iter().map(|n| n.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b", "c"],
+            "circuit must be rotated to start at 'a'"
+        );
+    }
+
+    #[test]
+    fn johnson_unblock_transitive_chain() {
+        // Graph designed to exercise the B[] chain unblocking.
+        //
+        //   a -> b
+        //   b -> c, b -> e
+        //   c -> a        (closes 1st cycle via b->c)
+        //   c -> d
+        //   d -> e        (d/e won't close by themselves from start=a)
+        //   e -> a        (closes 2nd cycle via b->e)
+        //
+        // When DFS from start=a descends a->b->c->d->e, e has no cycle
+        // back in its initial exploration; e registers as waiter of a in
+        // its B[]. Later when b->e is explored and closes via e->a,
+        // unblock cascades and correct cycle enumeration is preserved.
+        let cg = build_causal_graph(&[
+            ("a", &["b"]),
+            ("b", &["c", "e"]),
+            ("c", &["a", "d"]),
+            ("d", &["e"]),
+            ("e", &["a"]),
+        ]);
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        let names = circuits_as_sorted_name_sets(&circuits);
+        // Elementary directed cycles:
+        //   a -> b -> c -> a            -> {a,b,c}
+        //   a -> b -> e -> a            -> {a,b,e}
+        //   a -> b -> c -> d -> e -> a  -> {a,b,c,d,e}
+        assert_eq!(
+            names,
+            vec![
+                vec!["a".to_string(), "b".to_string(), "c".to_string()],
+                vec![
+                    "a".to_string(),
+                    "b".to_string(),
+                    "c".to_string(),
+                    "d".to_string(),
+                    "e".to_string()
+                ],
+                vec!["a".to_string(), "b".to_string(), "e".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn johnson_cross_scc_edges_not_traversed() {
+        // Two SCCs connected by a cross-SCC edge.
+        //   SCC 1: a <-> b
+        //   SCC 2: x <-> y
+        //   cross: b -> x (one-way; does not close any cycle)
+        // Elementary circuits: {a,b} and {x,y}; the cross edge b->x
+        // must NOT be traversed into SCC 2 when enumerating from SCC 1.
+        let cg = build_causal_graph(&[
+            ("a", &["b"]),
+            ("b", &["a", "x"]),
+            ("x", &["y"]),
+            ("y", &["x"]),
+        ]);
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        let names = circuits_as_sorted_name_sets(&circuits);
+        assert_eq!(
+            names,
+            vec![
+                vec!["a".to_string(), "b".to_string()],
+                vec!["x".to_string(), "y".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn johnson_matches_tiernan_on_fixture_corpus() {
+        // Hand-curated corpus of graphs that exercise the Johnson/Tiernan
+        // equivalence invariant.  Each entry is a list of (from, [to,...])
+        // edge-list fragments, compared after canonicalization.
+        let corpus: Vec<Vec<(&str, &[&str])>> = vec![
+            // Empty graph
+            vec![],
+            // Single cycle
+            vec![("a", &["b"]), ("b", &["c"]), ("c", &["a"])],
+            // Two 2-cycles
+            vec![("a", &["b"]), ("b", &["a"]), ("c", &["d"]), ("d", &["c"])],
+            // Figure-8
+            vec![
+                ("a", &["m"]),
+                ("m", &["b", "d"]),
+                ("b", &["a"]),
+                ("c", &["m"]),
+                ("d", &["c"]),
+            ],
+            // K3 with all edges (multi-digraph, dedup exercises)
+            vec![("a", &["b", "c"]), ("b", &["a", "c"]), ("c", &["a", "b"])],
+            // Bowtie: two triangles sharing a single vertex
+            vec![
+                ("a", &["b"]),
+                ("b", &["c"]),
+                ("c", &["a"]),
+                ("c", &["d"]),
+                ("d", &["e"]),
+                ("e", &["c"]),
+            ],
+            // Self-loop + non-trivial SCC (excluded self-loop)
+            vec![("a", &["a"]), ("b", &["c"]), ("c", &["b"])],
+            // Long chain with side spurs that don't close
+            vec![
+                ("a", &["b"]),
+                ("b", &["c"]),
+                ("c", &["d"]),
+                ("d", &["a", "e"]),
+                ("e", &["f"]),
+                ("f", &["g"]),
+            ],
+            // Graph with many dead-end branches forcing Johnson's blocking to matter
+            vec![
+                ("a", &["b"]),
+                ("b", &["c", "d", "e"]),
+                ("c", &["a"]),
+                ("d", &["f"]),
+                ("e", &["g"]),
+                ("f", &["h"]),
+                ("g", &["h"]),
+                ("h", &["a"]),
+            ],
+            // Arms race style: three-clique (every pair bidirectional)
+            vec![
+                ("alpha", &["beta", "gamma"]),
+                ("beta", &["alpha", "gamma"]),
+                ("gamma", &["alpha", "beta"]),
+            ],
+        ];
+
+        for edges in &corpus {
+            let cg = build_causal_graph(edges);
+            assert_johnson_matches_tiernan(&cg);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Property-based equivalence test: random small graphs.
+    //
+    // For each randomly generated graph, assert Johnson's and Tiernan
+    // agree on the canonicalized set of elementary circuits.  The tight
+    // bound (nodes <= 8, edges up to 16) keeps enumeration cheap while
+    // giving the generator room to produce interesting SCC structures,
+    // bidirectional edges, and self-loops.
+    // ------------------------------------------------------------------
+
+    use proptest::prelude::*;
+
+    fn build_graph_from_pairs(n: usize, pairs: &[(u8, u8)]) -> CausalGraph {
+        // Node names are "v0", "v1", ...  Use two-digit zero-padded
+        // names so lex order matches numeric order (v01 < v02 < ... < v10).
+        let names: Vec<String> = (0..n).map(|i| format!("v{i:02}")).collect();
+        let mut edge_pairs: Vec<(String, String)> = Vec::new();
+        for &(from_raw, to_raw) in pairs {
+            let from = from_raw as usize % n;
+            let to = to_raw as usize % n;
+            edge_pairs.push((names[from].clone(), names[to].clone()));
+        }
+        // Deduplicate: HashMap::entry will overwrite but we need to
+        // aggregate the adjacency list instead.
+        let mut map: HashMap<Ident<Canonical>, Vec<Ident<Canonical>>> = HashMap::new();
+        let mut seen: HashSet<(String, String)> = HashSet::new();
+        for (f, t) in edge_pairs {
+            if seen.insert((f.clone(), t.clone())) {
+                map.entry(Ident::new(&f)).or_default().push(Ident::new(&t));
+            }
+        }
+        CausalGraph {
+            edges: map,
+            stocks: HashSet::new(),
+            variables: HashMap::new(),
+            module_graphs: HashMap::new(),
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(256))]
+
+        /// Johnson's must agree with Tiernan on any random small graph.
+        /// The generator draws a node count 2..=8 and up to 16 directed
+        /// edges (possibly self-loops, possibly duplicates that we
+        /// deduplicate).  Canonicalized circuit lists must match exactly.
+        #[test]
+        fn johnson_matches_tiernan_on_random_small_graphs(
+            n in 2usize..=8,
+            edges in prop::collection::vec((any::<u8>(), any::<u8>()), 0..=16),
+        ) {
+            let cg = build_graph_from_pairs(n, &edges);
+            // Exercise via the CausalGraph public API in addition to the
+            // direct IndexedGraph inspection, to catch divergences at the
+            // API boundary (rotation, SCC ordering, empty-SCC handling).
+            assert_johnson_matches_tiernan(&cg);
+        }
     }
 }

--- a/src/simlin-engine/src/ltm.rs
+++ b/src/simlin-engine/src/ltm.rs
@@ -669,6 +669,16 @@ impl IndexedGraph {
             .map(|&i| self.nodes[i as usize].clone())
             .collect()
     }
+
+    /// Materialize the canonical node-name table as a `Vec<String>`.
+    /// Index `i` corresponds to `NodeIdx(i as u32)` in the indexed
+    /// circuit output.  Allocates one `String` per unique node; the
+    /// dense `Vec<Vec<u32>>` circuit output shares this table so the
+    /// aggregate memory footprint is O(unique_nodes + total_circuit_len)
+    /// rather than O(unique_nodes × circuits × path_len).
+    fn node_name_strings(&self) -> Vec<String> {
+        self.nodes.iter().map(|i| i.as_str().to_string()).collect()
+    }
 }
 
 impl CausalGraph {
@@ -896,6 +906,34 @@ impl CausalGraph {
             .into_iter()
             .map(|c| indexed.graph.circuit_to_idents(&c))
             .collect())
+    }
+
+    /// Indexed view of the elementary circuits: a shared `Vec<String>`
+    /// name table plus circuits as `Vec<Vec<u32>>` indices into that
+    /// table.  Callers that want the named view can reconstruct it on
+    /// demand via the indices, but many consumers only need to iterate,
+    /// length-check, or group circuits -- all of which work on the
+    /// integer form without paying the per-name allocation cost.
+    ///
+    /// Same budget semantics as [`Self::find_circuit_node_lists_with_limit`];
+    /// returns `Err(TruncatedByBudget)` when the enumeration would exceed
+    /// `max_circuits`.
+    pub fn find_indexed_circuits_with_limit(
+        &self,
+        max_circuits: usize,
+    ) -> std::result::Result<(Vec<String>, Vec<Vec<u32>>), TruncatedByBudget> {
+        let indexed = self.enumerate_indexed_circuits(max_circuits)?;
+        let names = indexed.graph.node_name_strings();
+        Ok((names, indexed.circuits))
+    }
+
+    /// Unbounded (default-budget) variant of
+    /// [`Self::find_indexed_circuits_with_limit`]; returns `(names, [])`
+    /// when the DFS budget is exhausted so callers have a uniform empty
+    /// response.
+    pub fn find_indexed_circuits(&self) -> (Vec<String>, Vec<Vec<u32>>) {
+        self.find_indexed_circuits_with_limit(MAX_LTM_CIRCUITS)
+            .unwrap_or_else(|_| (Vec::new(), Vec::new()))
     }
 
     /// Enrich a loop's stock list with stocks from inside any DynamicModule

--- a/src/simlin-engine/src/ltm.rs
+++ b/src/simlin-engine/src/ltm.rs
@@ -5129,7 +5129,7 @@ mod tests {
         // Complete directed graph on 4 nodes (K4) with every pair
         // bidirectional.  The DFS discovers many raw elementary cycles
         // that collapse to fewer distinct node-sets under dedup:
-        //   3 two-cycles: {a,b}, {a,c}, {a,d}, {b,c}, {b,d}, {c,d}
+        //   6 two-cycles: {a,b}, {a,c}, {a,d}, {b,c}, {b,d}, {c,d}
         //   many three-cycles, all over three-node subsets
         //   many four-cycles, all over {a,b,c,d}
         // The raw DFS work -- not the unique output size -- is what

--- a/src/simlin-engine/src/ltm.rs
+++ b/src/simlin-engine/src/ltm.rs
@@ -936,6 +936,22 @@ impl IndexedGraph {
     }
 }
 
+/// Debug-only helper: verify every `Loop` has a distinct node-set.
+/// Used by `debug_assert!` in `find_loops_with_limit` to guard against
+/// future regressions of the inline dedup in `johnson_circuit`.  Release
+/// builds compile the call out via `debug_assert!`'s no-op expansion.
+fn loops_have_unique_node_sets(loops: &[Loop]) -> bool {
+    let mut seen: HashSet<Vec<&str>> = HashSet::with_capacity(loops.len());
+    for loop_item in loops {
+        let mut key: Vec<&str> = loop_item.links.iter().map(|l| l.from.as_str()).collect();
+        key.sort_unstable();
+        if !seen.insert(key) {
+            return false;
+        }
+    }
+    true
+}
+
 /// Johnson 1975 UNBLOCK(u).  Iterative implementation so deeply nested
 /// B[] chains cannot overflow the recursion stack.
 ///
@@ -1101,16 +1117,20 @@ impl CausalGraph {
             }
         }
 
-        // Dedup by node-set at the Loop level.  Duplicates should already
-        // be impossible after `dedup_circuits`, but the classical Loop
-        // dedup also catches any distinct cyclic rotations that would
-        // produce the same set under the old algorithm.
-        let mut unique_loops = self.deduplicate_loops(loops);
+        // The per-SCC inline dedup in `johnson_circuit` already rejects
+        // multidigraph duplicates at the circuit (Vec<u32>) level, so
+        // every circuit that reaches this point has a unique node-set.
+        // A separate Loop-level dedup would be redundant; debug builds
+        // verify the invariant so a future regression trips a test.
+        debug_assert!(
+            loops_have_unique_node_sets(&loops),
+            "circuit enumerator must emit unique node-sets; duplicate loops reached find_loops_with_limit"
+        );
 
         // Assign deterministic IDs based on sorted loop content
-        self.assign_deterministic_loop_ids(&mut unique_loops);
+        self.assign_deterministic_loop_ids(&mut loops);
 
-        Ok(unique_loops)
+        Ok(loops)
     }
 
     /// Shared enumeration core used by both `find_loops_with_limit` and
@@ -1700,29 +1720,6 @@ impl CausalGraph {
     /// Assign deterministic IDs to loops based on their content
     fn assign_deterministic_loop_ids(&self, loops: &mut [Loop]) {
         assign_loop_ids(loops);
-    }
-
-    /// Remove duplicate loops (same set of nodes in different order)
-    fn deduplicate_loops(&self, loops: Vec<Loop>) -> Vec<Loop> {
-        let mut unique_loops = Vec::new();
-        let mut seen_sets = HashSet::new();
-
-        for loop_item in loops {
-            let mut node_set: Vec<_> = loop_item
-                .links
-                .iter()
-                .map(|link| link.from.as_str())
-                .collect();
-            node_set.sort();
-            let key = node_set.join(",");
-
-            if !seen_sets.contains(&key) {
-                seen_sets.insert(key);
-                unique_loops.push(loop_item);
-            }
-        }
-
-        unique_loops
     }
 }
 

--- a/src/simlin-engine/src/ltm.rs
+++ b/src/simlin-engine/src/ltm.rs
@@ -361,7 +361,327 @@ pub struct CausalGraph {
     pub(crate) module_graphs: HashMap<Ident<Canonical>, Box<CausalGraph>>,
 }
 
+/// Compact integer-indexed view of an adjacency list used to accelerate the
+/// core DFS circuit enumeration.  Swapping `Ident<Canonical>` (heap-allocated
+/// `String`) for a `u32` index slashes per-visit cost in three places:
+///
+/// * `visited` becomes a `Vec<bool>` of length `nodes.len()` instead of a
+///   `HashSet<Ident<Canonical>>`.
+/// * `path` becomes a `Vec<u32>` instead of `Vec<Ident<Canonical>>`, so each
+///   push/pop is a trivial `u32` copy rather than a `String` clone/drop.
+/// * Circuit dedup keys are `Vec<u32>` sorted, not joined strings.
+///
+/// Nodes are sorted lexicographically so that "neighbor.as_str() >=
+/// start.as_str()" is equivalent to "neighbor_idx >= start_idx", preserving
+/// the small-start invariant that makes each elementary circuit emerge
+/// exactly once from its lex-smallest node.
+struct IndexedGraph {
+    /// Sorted node identities; index into this vec is a `NodeIdx` (u32).
+    nodes: Vec<Ident<Canonical>>,
+    /// Successor indices per node, each inner Vec sorted ascending.
+    succ: Vec<Vec<u32>>,
+    /// Reverse map for translating external `Ident<Canonical>`s to indices.
+    /// Retained on the struct so callers that hold an IndexedGraph can map
+    /// caller-supplied idents to indices without rebuilding the map; in the
+    /// current call sites it is only exercised via tests.
+    #[allow(dead_code)]
+    node_to_idx: HashMap<Ident<Canonical>, u32>,
+}
+
+/// Marker that DFS exceeded the shared circuit budget.  Used internally by
+/// `enumerate_circuits_in_scc` to propagate bail-out without confusion with
+/// a successful empty-result enumeration.
+struct TruncatedByBudgetInternal;
+
+/// Result bundle from the shared indexed-circuit enumerator: the
+/// IndexedGraph owns the node table (so callers can map indices back to
+/// `Ident<Canonical>` on demand), and `circuits` is already deduplicated
+/// by sorted-node-set.
+struct IndexedCircuits {
+    graph: IndexedGraph,
+    circuits: Vec<Vec<u32>>,
+}
+
+/// Shared mutable state for the per-SCC DFS, bundled to keep the recursive
+/// helper's argument list short and the per-call overhead low.  All four
+/// fields are reset between starts by the enclosing loop.
+struct DfsState {
+    visited: Vec<bool>,
+    path: Vec<u32>,
+    circuits: Vec<Vec<u32>>,
+    in_scc: Vec<bool>,
+}
+
+impl IndexedGraph {
+    /// Build an IndexedGraph from a `CausalGraph`-style adjacency list.
+    ///
+    /// Every node referenced as either an edge source or target is assigned
+    /// an index.  Successor indices are de-duplicated and sorted so the DFS
+    /// can early-exit on the first out-of-range neighbor when needed.
+    fn from_edges(edges: &HashMap<Ident<Canonical>, Vec<Ident<Canonical>>>) -> Self {
+        let mut node_set: HashSet<&Ident<Canonical>> = HashSet::new();
+        for (from, tos) in edges {
+            node_set.insert(from);
+            for to in tos {
+                node_set.insert(to);
+            }
+        }
+        let mut nodes: Vec<Ident<Canonical>> = node_set.into_iter().cloned().collect();
+        nodes.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+
+        let mut node_to_idx: HashMap<Ident<Canonical>, u32> = HashMap::with_capacity(nodes.len());
+        for (i, n) in nodes.iter().enumerate() {
+            node_to_idx.insert(n.clone(), i as u32);
+        }
+
+        let mut succ: Vec<Vec<u32>> = vec![Vec::new(); nodes.len()];
+        for (from, tos) in edges {
+            let fi = node_to_idx[from] as usize;
+            for to in tos {
+                let ti = node_to_idx[to];
+                succ[fi].push(ti);
+            }
+            // Dedup identical successor entries (the input may contain them
+            // if an edge was inserted twice during causal-graph construction)
+            // and sort so the DFS sees the same deterministic order as the
+            // old Ident-based iteration produced via lex sorting.
+            succ[fi].sort_unstable();
+            succ[fi].dedup();
+        }
+
+        IndexedGraph {
+            nodes,
+            succ,
+            node_to_idx,
+        }
+    }
+
+    #[allow(dead_code)]
+    fn len(&self) -> usize {
+        self.nodes.len()
+    }
+
+    /// Iterative Tarjan's algorithm on the full graph.  Iterative form keeps
+    /// WRLD3-style graphs (>300 nodes, long cycles) off the recursion limit.
+    /// SCCs are returned in first-discovery order; each inner `Vec<u32>` is
+    /// sorted ascending so downstream iteration is deterministic regardless
+    /// of the order nodes were popped from Tarjan's stack.
+    fn tarjan_scc(&self) -> Vec<Vec<u32>> {
+        const UNVISITED: i32 = -1;
+        let n = self.nodes.len();
+        let mut indices: Vec<i32> = vec![UNVISITED; n];
+        let mut lowlinks: Vec<i32> = vec![0; n];
+        let mut on_stack: Vec<bool> = vec![false; n];
+        let mut stack: Vec<u32> = Vec::new();
+        let mut sccs: Vec<Vec<u32>> = Vec::new();
+        let mut next_index: i32 = 0;
+
+        // Iterative frames: Enter pushes a node onto Tarjan's stack; Resume
+        // continues iterating its successors (and ultimately pops the SCC
+        // if this node is its own root).
+        enum Frame {
+            Enter(u32),
+            Resume { v: u32, next_child: u32 },
+        }
+
+        for start in 0..n as u32 {
+            if indices[start as usize] != UNVISITED {
+                continue;
+            }
+            let mut frames: Vec<Frame> = vec![Frame::Enter(start)];
+            while let Some(frame) = frames.pop() {
+                match frame {
+                    Frame::Enter(v) => {
+                        indices[v as usize] = next_index;
+                        lowlinks[v as usize] = next_index;
+                        next_index += 1;
+                        stack.push(v);
+                        on_stack[v as usize] = true;
+                        frames.push(Frame::Resume { v, next_child: 0 });
+                    }
+                    Frame::Resume { v, next_child } => {
+                        let succs = &self.succ[v as usize];
+                        if (next_child as usize) < succs.len() {
+                            let w = succs[next_child as usize];
+                            frames.push(Frame::Resume {
+                                v,
+                                next_child: next_child + 1,
+                            });
+                            if indices[w as usize] == UNVISITED {
+                                frames.push(Frame::Enter(w));
+                            } else if on_stack[w as usize]
+                                && indices[w as usize] < lowlinks[v as usize]
+                            {
+                                lowlinks[v as usize] = indices[w as usize];
+                            }
+                        } else {
+                            // All children processed; propagate this node's
+                            // lowlink up to its parent frame (if any) before
+                            // potentially emitting an SCC rooted at v.
+                            if let Some(Frame::Resume {
+                                v: parent,
+                                next_child: _,
+                            }) = frames.last()
+                                && lowlinks[v as usize] < lowlinks[*parent as usize]
+                            {
+                                lowlinks[*parent as usize] = lowlinks[v as usize];
+                            }
+                            if lowlinks[v as usize] == indices[v as usize] {
+                                let mut scc = Vec::new();
+                                loop {
+                                    let w = stack.pop().unwrap();
+                                    on_stack[w as usize] = false;
+                                    scc.push(w);
+                                    if w == v {
+                                        break;
+                                    }
+                                }
+                                scc.sort_unstable();
+                                sccs.push(scc);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        sccs
+    }
+
+    /// Enumerate elementary circuits inside a single SCC using small-start
+    /// DFS.  Only edges whose target is also in the SCC are followed (others
+    /// cannot close a cycle), and starts are restricted to SCC members in
+    /// ascending index order so each cycle is found exactly once from its
+    /// lex-smallest node.
+    ///
+    /// `budget` is the **remaining** circuit budget; it is decremented each
+    /// time a circuit of length > 1 is emitted.  Returns
+    /// `Err(TruncatedByBudgetInternal)` the moment the budget would go
+    /// negative so the caller can stop immediately.
+    fn enumerate_circuits_in_scc(
+        &self,
+        scc: &[u32],
+        budget: &mut usize,
+    ) -> std::result::Result<Vec<Vec<u32>>, TruncatedByBudgetInternal> {
+        if scc.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Trivial 1-node SCC with no self-loop: no circuits possible.  We
+        // still accept the 1-node-with-self-loop case but then `circuit.len()
+        // > 1` below rejects it -- pure self-loops were excluded by the
+        // old implementation and we preserve that contract.
+        if scc.len() == 1 {
+            let v = scc[0];
+            if !self.succ[v as usize].contains(&v) {
+                return Ok(Vec::new());
+            }
+        }
+
+        // Membership as a dense bitset for O(1) intra-SCC checks.  Using a
+        // Vec<bool> avoids pulling in `fixedbitset` as a dep.
+        let mut in_scc: Vec<bool> = vec![false; self.nodes.len()];
+        for &v in scc {
+            in_scc[v as usize] = true;
+        }
+
+        let mut state = DfsState {
+            visited: vec![false; self.nodes.len()],
+            path: Vec::with_capacity(scc.len()),
+            circuits: Vec::new(),
+            in_scc,
+        };
+
+        for &start in scc {
+            state.visited[start as usize] = true;
+            state.path.push(start);
+            let bailed = self.dfs_circuits_indexed(start, start, &mut state, budget);
+            state.path.pop();
+            state.visited[start as usize] = false;
+            if bailed {
+                return Err(TruncatedByBudgetInternal);
+            }
+        }
+
+        Ok(state.circuits)
+    }
+
+    /// Recursive DFS mirroring the old `CausalGraph::dfs_circuits` but on
+    /// integer indices.  Returns `true` if the search bailed out on budget
+    /// so the caller can propagate immediately.  The "neighbor >= start"
+    /// test relies on `nodes` being lex-sorted: then index ordering matches
+    /// string ordering and each circuit emerges from its lex-smallest node.
+    fn dfs_circuits_indexed(
+        &self,
+        start: u32,
+        current: u32,
+        state: &mut DfsState,
+        budget: &mut usize,
+    ) -> bool {
+        for &neighbor in &self.succ[current as usize] {
+            // Restrict traversal to the current SCC: cross-SCC edges never
+            // close a cycle back to `start`, so exploring them is wasted
+            // work (and was a significant portion of WRLD3's runtime).
+            if !state.in_scc[neighbor as usize] {
+                continue;
+            }
+            if neighbor == start && state.path.len() > 1 {
+                if *budget == 0 {
+                    return true;
+                }
+                *budget -= 1;
+                state.circuits.push(state.path.clone());
+            } else if !state.visited[neighbor as usize] && neighbor >= start {
+                state.visited[neighbor as usize] = true;
+                state.path.push(neighbor);
+                let bailed = self.dfs_circuits_indexed(start, neighbor, state, budget);
+                state.path.pop();
+                state.visited[neighbor as usize] = false;
+                if bailed {
+                    return true;
+                }
+            }
+        }
+        false
+    }
+
+    /// Deduplicate circuits by node-set.  Keys are sorted `Vec<u32>` so each
+    /// key is ~4 bytes per node rather than the per-character weight of the
+    /// old `String::join(",")` path.
+    fn dedup_circuits(circuits: Vec<Vec<u32>>) -> Vec<Vec<u32>> {
+        let mut seen: HashSet<Vec<u32>> = HashSet::with_capacity(circuits.len());
+        let mut unique = Vec::with_capacity(circuits.len());
+        for c in circuits {
+            let mut key = c.clone();
+            key.sort_unstable();
+            if seen.insert(key) {
+                unique.push(c);
+            }
+        }
+        unique
+    }
+
+    /// Convert a circuit of indices back to the caller-facing
+    /// `Vec<Ident<Canonical>>` once enumeration and dedup are complete.
+    fn circuit_to_idents(&self, circuit: &[u32]) -> Vec<Ident<Canonical>> {
+        circuit
+            .iter()
+            .map(|&i| self.nodes[i as usize].clone())
+            .collect()
+    }
+}
+
 impl CausalGraph {
+    /// Read-only access to the adjacency list (for benchmarks / debugging).
+    pub fn edges(&self) -> &HashMap<Ident<Canonical>, Vec<Ident<Canonical>>> {
+        &self.edges
+    }
+
+    /// Read-only access to the stock set (for benchmarks / debugging).
+    pub fn stocks(&self) -> &HashSet<Ident<Canonical>> {
+        &self.stocks
+    }
+
     /// Build a causal graph from a model with project context for modules
     pub fn from_model(model: &ModelStage1, project: &Project) -> Result<Self> {
         let mut edges: HashMap<Ident<Canonical>, Vec<Ident<Canonical>>> = HashMap::new();
@@ -459,68 +779,97 @@ impl CausalGraph {
     /// Bounded variant of [`Self::find_loops`].  Returns
     /// `Err(TruncatedByBudget)` when the DFS would enumerate more than
     /// `max_circuits` elementary circuits; otherwise `Ok(loops)`.
-    pub(crate) fn find_loops_with_limit(
+    pub fn find_loops_with_limit(
         &self,
         max_circuits: usize,
     ) -> std::result::Result<Vec<Loop>, TruncatedByBudget> {
-        let mut loops = Vec::new();
+        // Enumerate indexed circuits via SCC-restricted DFS, then rebuild
+        // the polarity-annotated `Loop` structs from the circuits that
+        // survive dedup.  Splitting enumeration from materialization keeps
+        // the hot DFS loop allocating only `Vec<u32>` and lets circuits
+        // that dedup away shed their string storage before we pay for it.
+        let indexed = self.enumerate_indexed_circuits(max_circuits)?;
+        let mut loops = Vec::with_capacity(indexed.circuits.len());
+        for circuit_idx in indexed.circuits {
+            // Circuit length is always > 1 by construction in
+            // `IndexedGraph::enumerate_circuits_in_scc` (pure self-loops
+            // are filtered), so the check below is defensive -- kept to
+            // guarantee the contract even if a future refactor loosens
+            // that invariant.
+            if circuit_idx.len() > 1 {
+                let circuit = indexed.graph.circuit_to_idents(&circuit_idx);
+                let links = self.circuit_to_links(&circuit);
+                let parent_stocks = self.find_stocks_in_loop(&circuit);
+                let stocks = self.enrich_with_module_stocks(&circuit, parent_stocks);
+                let polarity = self.calculate_polarity(&links);
 
-        // Get all nodes, including those that are module instances
-        let mut nodes: Vec<_> = self.edges.keys().cloned().collect();
-        nodes.sort_by(|a, b| a.as_str().cmp(b.as_str())); // Stable ordering
-
-        // Johnson-style enumeration: each start node only visits successors
-        // with a lexicographically equal-or-greater identifier so each
-        // elementary circuit is found exactly once (from its
-        // lexicographically-smallest node).  Module instances appear as
-        // regular nodes in the parent graph, so loops through modules are
-        // found naturally.
-        //
-        // The budget is shared across all start nodes so a handful of
-        // "popular" start nodes cannot silently exhaust the limit on their
-        // own; instead the whole analysis bails out cleanly.
-        let mut budget = max_circuits;
-        for start_node in &nodes {
-            let mut circuits = Vec::new();
-            let mut path = vec![start_node.clone()];
-            let mut visited: HashSet<Ident<Canonical>> = HashSet::new();
-            visited.insert(start_node.clone());
-            let bailed = self.dfs_circuits(
-                start_node,
-                start_node,
-                &mut path,
-                &mut visited,
-                &mut circuits,
-                &mut budget,
-            );
-            if bailed {
-                return Err(TruncatedByBudget);
-            }
-            for circuit in circuits {
-                if circuit.len() > 1 {
-                    let links = self.circuit_to_links(&circuit);
-                    let parent_stocks = self.find_stocks_in_loop(&circuit);
-                    let stocks = self.enrich_with_module_stocks(&circuit, parent_stocks);
-                    let polarity = self.calculate_polarity(&links);
-
-                    loops.push(Loop {
-                        id: String::new(),
-                        links,
-                        stocks,
-                        polarity,
-                        dimensions: vec![],
-                    });
-                }
+                loops.push(Loop {
+                    id: String::new(),
+                    links,
+                    stocks,
+                    polarity,
+                    dimensions: vec![],
+                });
             }
         }
 
-        // Remove duplicate loops (same set of nodes)
+        // Dedup by node-set at the Loop level.  Duplicates should already
+        // be impossible after `dedup_circuits`, but the classical Loop
+        // dedup also catches any distinct cyclic rotations that would
+        // produce the same set under the old algorithm.
         let mut unique_loops = self.deduplicate_loops(loops);
 
-        // Now assign deterministic IDs based on sorted loop content
+        // Assign deterministic IDs based on sorted loop content
         self.assign_deterministic_loop_ids(&mut unique_loops);
 
         Ok(unique_loops)
+    }
+
+    /// Shared enumeration core used by both `find_loops_with_limit` and
+    /// `find_circuit_node_lists_with_limit`.  Builds a compact indexed view
+    /// of the adjacency list, decomposes into strongly-connected components,
+    /// and enumerates circuits only inside non-trivial SCCs -- cross-SCC
+    /// edges cannot close a cycle and exploring them is wasted work (a
+    /// significant fraction of time on dense WRLD3-shaped graphs).
+    ///
+    /// Returns the circuits as integer-index paths plus the `IndexedGraph`
+    /// that owns the canonical node ordering, so callers can convert back
+    /// to `Ident<Canonical>` lazily and only for surviving circuits.
+    fn enumerate_indexed_circuits(
+        &self,
+        max_circuits: usize,
+    ) -> std::result::Result<IndexedCircuits, TruncatedByBudget> {
+        let graph = IndexedGraph::from_edges(&self.edges);
+        let sccs = graph.tarjan_scc();
+        let mut all_circuits: Vec<Vec<u32>> = Vec::new();
+        let mut budget = max_circuits;
+
+        // Iterate SCCs in a deterministic order: sort by smallest index.
+        // The per-SCC enumeration is already deterministic (small-start
+        // DFS over a sorted successor list), so this gives a fully
+        // reproducible iteration overall.
+        let mut scc_order: Vec<usize> = (0..sccs.len()).collect();
+        scc_order.sort_by_key(|&i| sccs[i].first().copied().unwrap_or(u32::MAX));
+
+        for i in scc_order {
+            let scc = &sccs[i];
+            // Skip trivial SCCs (single node, no self-loop): they cannot
+            // carry any elementary circuit and iterating them was
+            // measurable overhead on graphs with many feeder nodes.
+            if scc.len() == 1 && !graph.succ[scc[0] as usize].contains(&scc[0]) {
+                continue;
+            }
+            match graph.enumerate_circuits_in_scc(scc, &mut budget) {
+                Ok(mut circuits) => all_circuits.append(&mut circuits),
+                Err(TruncatedByBudgetInternal) => return Err(TruncatedByBudget),
+            }
+        }
+
+        let unique = IndexedGraph::dedup_circuits(all_circuits);
+        Ok(IndexedCircuits {
+            graph,
+            circuits: unique,
+        })
     }
 
     /// Find all elementary circuits as deduplicated node lists.
@@ -530,53 +879,23 @@ impl CausalGraph {
     /// `MAX_LTM_CIRCUITS`; empty result on budget exhaustion.  Use
     /// [`Self::find_circuit_node_lists_with_limit`] when the caller needs
     /// to distinguish "no loops" from "too many loops to enumerate".
-    pub(crate) fn find_circuit_node_lists(&self) -> Vec<Vec<Ident<Canonical>>> {
+    pub fn find_circuit_node_lists(&self) -> Vec<Vec<Ident<Canonical>>> {
         self.find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
             .unwrap_or_default()
     }
 
     /// Bounded variant of [`Self::find_circuit_node_lists`] exposing the
     /// budget-exhaustion signal explicitly.
-    pub(crate) fn find_circuit_node_lists_with_limit(
+    pub fn find_circuit_node_lists_with_limit(
         &self,
         max_circuits: usize,
     ) -> std::result::Result<Vec<Vec<Ident<Canonical>>>, TruncatedByBudget> {
-        let mut nodes: Vec<_> = self.edges.keys().cloned().collect();
-        nodes.sort_by(|a, b| a.as_str().cmp(b.as_str()));
-
-        let mut all_circuits = Vec::new();
-        let mut seen_sets: HashSet<String> = HashSet::new();
-
-        let mut budget = max_circuits;
-        for start_node in &nodes {
-            let mut circuits = Vec::new();
-            let mut path = vec![start_node.clone()];
-            let mut visited: HashSet<Ident<Canonical>> = HashSet::new();
-            visited.insert(start_node.clone());
-            let bailed = self.dfs_circuits(
-                start_node,
-                start_node,
-                &mut path,
-                &mut visited,
-                &mut circuits,
-                &mut budget,
-            );
-            if bailed {
-                return Err(TruncatedByBudget);
-            }
-            for circuit in circuits {
-                if circuit.len() > 1 {
-                    let mut node_set: Vec<&str> = circuit.iter().map(|n| n.as_str()).collect();
-                    node_set.sort();
-                    let key = node_set.join(",");
-                    if seen_sets.insert(key) {
-                        all_circuits.push(circuit);
-                    }
-                }
-            }
-        }
-
-        Ok(all_circuits)
+        let indexed = self.enumerate_indexed_circuits(max_circuits)?;
+        Ok(indexed
+            .circuits
+            .into_iter()
+            .map(|c| indexed.graph.circuit_to_idents(&c))
+            .collect())
     }
 
     /// Enrich a loop's stock list with stocks from inside any DynamicModule
@@ -633,48 +952,6 @@ impl CausalGraph {
             }
         }
         stocks
-    }
-
-    /// DFS helper for finding circuits.
-    ///
-    /// `budget` is decremented each time a circuit is recorded; when it
-    /// would go below zero, the search short-circuits immediately and the
-    /// function returns `true` so the caller can propagate the bail-out.
-    /// Returns `false` for a complete (in-budget) search.
-    fn dfs_circuits(
-        &self,
-        start: &Ident<Canonical>,
-        current: &Ident<Canonical>,
-        path: &mut Vec<Ident<Canonical>>,
-        visited: &mut HashSet<Ident<Canonical>>,
-        circuits: &mut Vec<Vec<Ident<Canonical>>>,
-        budget: &mut usize,
-    ) -> bool {
-        // First check direct edges in this graph
-        if let Some(neighbors) = self.edges.get(current) {
-            for neighbor in neighbors {
-                if neighbor == start && path.len() > 1 {
-                    // Found a circuit back to start
-                    if *budget == 0 {
-                        return true;
-                    }
-                    *budget -= 1;
-                    circuits.push(path.clone());
-                } else if !visited.contains(neighbor) && neighbor.as_str() >= start.as_str() {
-                    // Only visit nodes that come after start (to avoid duplicates)
-                    visited.insert(neighbor.clone());
-                    path.push(neighbor.clone());
-                    let bailed =
-                        self.dfs_circuits(start, neighbor, path, visited, circuits, budget);
-                    path.pop();
-                    visited.remove(neighbor);
-                    if bailed {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
     }
 
     /// Convert a circuit (list of nodes) to a list of links
@@ -4025,5 +4302,246 @@ mod tests {
             .find_loops_with_limit(0)
             .expect_err("budget of 0 must bail");
         assert_eq!(err, TruncatedByBudget);
+    }
+
+    // --- IndexedGraph + SCC-restricted enumeration tests ---
+    //
+    // These validate the refactor from `HashSet<Ident>` to integer-indexed
+    // DFS.  The goal is to pin down the invariants the public contract
+    // depends on so later optimization passes can't silently break them:
+    // (1) the node-ordering round-trip, (2) SCC decomposition behavior,
+    // (3) self-loop exclusion at length 1, and (4) budget semantics.
+
+    fn build_causal_graph(edges: &[(&str, &[&str])]) -> CausalGraph {
+        let mut map: HashMap<Ident<Canonical>, Vec<Ident<Canonical>>> = HashMap::new();
+        for (from, tos) in edges {
+            let from_id = Ident::new(from);
+            map.entry(from_id)
+                .or_default()
+                .extend(tos.iter().map(|t| Ident::new(t)));
+        }
+        CausalGraph {
+            edges: map,
+            stocks: HashSet::new(),
+            variables: HashMap::new(),
+            module_graphs: HashMap::new(),
+        }
+    }
+
+    fn circuits_as_sorted_name_sets(circuits: &[Vec<Ident<Canonical>>]) -> Vec<Vec<String>> {
+        let mut out: Vec<Vec<String>> = circuits
+            .iter()
+            .map(|c| {
+                let mut names: Vec<String> = c.iter().map(|n| n.as_str().to_string()).collect();
+                names.sort();
+                names
+            })
+            .collect();
+        out.sort();
+        out
+    }
+
+    #[test]
+    fn indexed_graph_empty_round_trip() {
+        let edges: HashMap<Ident<Canonical>, Vec<Ident<Canonical>>> = HashMap::new();
+        let graph = IndexedGraph::from_edges(&edges);
+        assert_eq!(graph.len(), 0);
+        assert!(graph.nodes.is_empty());
+        assert!(graph.succ.is_empty());
+        assert!(graph.node_to_idx.is_empty());
+
+        let cg = CausalGraph {
+            edges,
+            stocks: HashSet::new(),
+            variables: HashMap::new(),
+            module_graphs: HashMap::new(),
+        };
+        let circuits = cg
+            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .expect("empty graph must not trip the budget");
+        assert!(circuits.is_empty(), "empty graph has no circuits");
+    }
+
+    #[test]
+    fn indexed_graph_two_node_back_edge() {
+        // A <-> B: one elementary circuit A -> B -> A.
+        let cg = build_causal_graph(&[("a", &["b"]), ("b", &["a"])]);
+        let graph = IndexedGraph::from_edges(&cg.edges);
+
+        // Nodes must be sorted lex so small-start invariant matches index ordering.
+        assert_eq!(
+            graph.nodes.iter().map(|n| n.as_str()).collect::<Vec<_>>(),
+            vec!["a", "b"]
+        );
+        // Round-trip: every node's index resolves back to the same ident.
+        for (i, n) in graph.nodes.iter().enumerate() {
+            assert_eq!(graph.node_to_idx[n], i as u32);
+        }
+
+        let circuits = cg
+            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .expect("small graph must not exhaust budget");
+        assert_eq!(
+            circuits_as_sorted_name_sets(&circuits),
+            vec![vec!["a".to_string(), "b".to_string()]]
+        );
+    }
+
+    #[test]
+    fn indexed_graph_three_node_cycle() {
+        // A -> B -> C -> A: exactly one elementary circuit.
+        let cg = build_causal_graph(&[("a", &["b"]), ("b", &["c"]), ("c", &["a"])]);
+        let circuits = cg
+            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .expect("tiny cycle must not exhaust budget");
+        assert_eq!(
+            circuits_as_sorted_name_sets(&circuits),
+            vec![vec!["a".to_string(), "b".to_string(), "c".to_string()]]
+        );
+    }
+
+    #[test]
+    fn indexed_graph_two_disjoint_three_cycles() {
+        // Two completely disjoint cycles: {a,b,c} and {x,y,z}.
+        // Each forms its own SCC so we must find exactly two circuits.
+        let cg = build_causal_graph(&[
+            ("a", &["b"]),
+            ("b", &["c"]),
+            ("c", &["a"]),
+            ("x", &["y"]),
+            ("y", &["z"]),
+            ("z", &["x"]),
+        ]);
+        let circuits = cg
+            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .expect("small disjoint graphs must not exhaust budget");
+        let sorted = circuits_as_sorted_name_sets(&circuits);
+        assert_eq!(
+            sorted,
+            vec![
+                vec!["a".to_string(), "b".to_string(), "c".to_string()],
+                vec!["x".to_string(), "y".to_string(), "z".to_string()],
+            ]
+        );
+    }
+
+    #[test]
+    fn indexed_graph_two_cycle_and_self_loop_node() {
+        // A <-> B (one 2-cycle), and separately S -> S (self-loop).
+        // Pure self-loops are intentionally excluded (circuit.len() > 1),
+        // so only the A<->B cycle is returned.
+        let cg = build_causal_graph(&[("a", &["b"]), ("b", &["a"]), ("s", &["s"])]);
+        let circuits = cg
+            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .expect("small graph must not exhaust budget");
+        assert_eq!(
+            circuits_as_sorted_name_sets(&circuits),
+            vec![vec!["a".to_string(), "b".to_string()]]
+        );
+    }
+
+    #[test]
+    fn indexed_graph_scc_pure_dag() {
+        // Pure DAG: a -> b -> c, no cycles.  Tarjan must return only
+        // trivial (size-1, no self-loop) SCCs.
+        let cg = build_causal_graph(&[("a", &["b"]), ("b", &["c"])]);
+        let graph = IndexedGraph::from_edges(&cg.edges);
+        let sccs = graph.tarjan_scc();
+        assert_eq!(sccs.len(), 3, "three nodes -> three trivial SCCs");
+        for scc in &sccs {
+            assert_eq!(scc.len(), 1, "DAG must have only singleton SCCs");
+            let v = scc[0];
+            assert!(
+                !graph.succ[v as usize].contains(&v),
+                "no self-loops in this DAG"
+            );
+        }
+        // And `find_circuit_node_lists_with_limit` agrees: zero circuits.
+        let circuits = cg
+            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .unwrap();
+        assert!(circuits.is_empty());
+    }
+
+    #[test]
+    fn indexed_graph_scc_two_disjoint_cycles() {
+        // Two disjoint 3-cycles produce two non-trivial SCCs of size 3 each.
+        let cg = build_causal_graph(&[
+            ("a", &["b"]),
+            ("b", &["c"]),
+            ("c", &["a"]),
+            ("x", &["y"]),
+            ("y", &["z"]),
+            ("z", &["x"]),
+        ]);
+        let graph = IndexedGraph::from_edges(&cg.edges);
+        let sccs = graph.tarjan_scc();
+        let non_trivial: Vec<_> = sccs
+            .iter()
+            .filter(|s| s.len() > 1 || graph.succ[s[0] as usize].contains(&s[0]))
+            .collect();
+        assert_eq!(
+            non_trivial.len(),
+            2,
+            "two disjoint 3-cycles -> two non-trivial SCCs"
+        );
+        assert!(non_trivial.iter().all(|s| s.len() == 3));
+    }
+
+    #[test]
+    fn indexed_graph_scc_figure_eight_single_scc() {
+        // Figure-8: two cycles sharing node `m`.  Cycle 1: a -> m -> b -> a,
+        // Cycle 2: c -> m -> d -> c.  All five nodes are mutually reachable
+        // so Tarjan must return a single non-trivial SCC of size 5.
+        let cg = build_causal_graph(&[
+            ("a", &["m"]),
+            ("m", &["b", "d"]),
+            ("b", &["a"]),
+            ("c", &["m"]),
+            ("d", &["c"]),
+        ]);
+        let graph = IndexedGraph::from_edges(&cg.edges);
+        let sccs = graph.tarjan_scc();
+        let non_trivial: Vec<_> = sccs
+            .iter()
+            .filter(|s| s.len() > 1 || graph.succ[s[0] as usize].contains(&s[0]))
+            .collect();
+        assert_eq!(non_trivial.len(), 1, "figure-8 shares a node -> single SCC");
+        assert_eq!(non_trivial[0].len(), 5);
+    }
+
+    #[test]
+    fn indexed_graph_self_loop_only_yields_no_circuit() {
+        // Graph with just A -> A must yield zero circuits because pure
+        // self-loops (circuit.len() == 1) are intentionally excluded.
+        let cg = build_causal_graph(&[("a", &["a"])]);
+        let circuits = cg
+            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .expect("tiny graph must not exhaust budget");
+        assert!(
+            circuits.is_empty(),
+            "pure self-loop must NOT produce a circuit"
+        );
+    }
+
+    #[test]
+    fn indexed_graph_zero_budget_nonempty_graph_truncates() {
+        // Non-empty cycle + zero budget -> immediate TruncatedByBudget.
+        let cg = build_causal_graph(&[("a", &["b"]), ("b", &["a"])]);
+        let err = cg
+            .find_circuit_node_lists_with_limit(0)
+            .expect_err("zero budget on a cycle must truncate");
+        assert_eq!(err, TruncatedByBudget);
+    }
+
+    #[test]
+    fn indexed_graph_tiny_in_budget_succeeds() {
+        // Matching positive control for the budget test: same cycle but
+        // with an ample budget must succeed and return exactly one circuit.
+        let cg = build_causal_graph(&[("a", &["b"]), ("b", &["a"])]);
+        let circuits = cg
+            .find_circuit_node_lists_with_limit(MAX_LTM_CIRCUITS)
+            .expect("ample budget must succeed");
+        assert_eq!(circuits.len(), 1);
     }
 }

--- a/src/simlin-engine/src/ltm.rs
+++ b/src/simlin-engine/src/ltm.rs
@@ -26,8 +26,9 @@ use crate::variable::{Variable, identifier_set};
 /// enumeration itself is fast and small.
 ///
 /// Removing this cap cleanly would require first capping the synthetic
-/// variable count inside `model_ltm_variables` (or switching very
-/// large models to discovery mode).  See tech-debt #31 for the plan.
+/// variable count inside `model_ltm_variables`, or auto-falling back
+/// to discovery mode for very large models -- neither of which is on
+/// this branch's scope.
 pub(crate) const MAX_LTM_CIRCUITS: usize = 100_000;
 
 /// Marker returned by circuit-enumeration helpers when the DFS bailed
@@ -759,23 +760,30 @@ impl IndexedGraph {
                 // edge v -> start is implicit -- downstream code
                 // (circuit_to_links) wraps from path[last] to path[0].
                 //
-                // Multidigraph graphs (e.g. arms-race 3-cliques) produce
-                // multiple distinct directed cycles over the same node
-                // set; LTM semantics fold those into a single loop.
-                // Dedup here rather than post-hoc so peak memory stays
-                // proportional to unique output.  Budget consumption
-                // only fires for unique emissions -- a duplicate
-                // traversal still marks `found_cycle = true` so the
+                // Multidigraph graphs (e.g. arms-race 3-cliques, K_n
+                // bidirectional cliques) produce multiple distinct
+                // directed cycles over the same node set; LTM semantics
+                // fold those into a single loop.  Dedup here rather than
+                // post-hoc so peak memory stays proportional to unique
+                // output.
+                //
+                // The budget is charged on every RAW cycle discovery,
+                // not just unique emissions: the cap exists to bound
+                // DFS work, and on a dense multidigraph the raw cycle
+                // count can far exceed the unique-node-set count (K9
+                // has 125,664 elementary directed cycles but only 502
+                // unique node sets).  `found_cycle = true` fires
+                // whether or not the circuit survives dedup so the
                 // blocked/B[] unblock machinery behaves correctly.
+                if *budget == 0 {
+                    return Err(TruncatedByBudgetInternal);
+                }
+                *budget -= 1;
                 state.hash_scratch.clear();
                 state.hash_scratch.extend_from_slice(&state.path);
                 state.hash_scratch.sort_unstable();
                 let fp = hash_u32_slice(&state.hash_scratch);
                 if state.seen.insert(fp) {
-                    if *budget == 0 {
-                        return Err(TruncatedByBudgetInternal);
-                    }
-                    *budget -= 1;
                     state.circuits.push(state.path.clone());
                 }
                 found_cycle = true;
@@ -5113,6 +5121,44 @@ mod tests {
         let err = cg
             .find_circuit_node_lists_with_limit(1)
             .expect_err("budget of 1 cannot fit both 2-cycles");
+        assert_eq!(err, TruncatedByBudget);
+    }
+
+    #[test]
+    fn johnson_budget_charges_duplicate_raw_cycles() {
+        // Complete directed graph on 4 nodes (K4) with every pair
+        // bidirectional.  The DFS discovers many raw elementary cycles
+        // that collapse to fewer distinct node-sets under dedup:
+        //   3 two-cycles: {a,b}, {a,c}, {a,d}, {b,c}, {b,d}, {c,d}
+        //   many three-cycles, all over three-node subsets
+        //   many four-cycles, all over {a,b,c,d}
+        // The raw DFS work -- not the unique output size -- is what
+        // can blow up compile time on dense multidigraphs, so
+        // `max_circuits` must bound raw cycle discovery, not post-
+        // dedup output.  Budget decrement fires on every raw emission
+        // so callers cannot have the DFS run for longer than the cap
+        // implies.
+        let cg = build_causal_graph(&[
+            ("a", &["b", "c", "d"]),
+            ("b", &["a", "c", "d"]),
+            ("c", &["a", "b", "d"]),
+            ("d", &["a", "b", "c"]),
+        ]);
+        // Unique node-sets: C(4,2) + C(4,3) + C(4,4) = 6 + 4 + 1 = 11.
+        let full = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        assert_eq!(
+            full.len(),
+            11,
+            "K4 has exactly 11 distinct node-set circuits after dedup"
+        );
+
+        // Raw (pre-dedup) cycle count for K4 is much larger; a budget
+        // that fits unique output but not raw work must still trip.
+        // If budget is charged per unique circuit the enumeration runs
+        // past the cap -- exactly the regression we're guarding.
+        let err = cg
+            .find_circuit_node_lists_with_limit(11)
+            .expect_err("budget of 11 must trip because raw cycle discovery exceeds 11");
         assert_eq!(err, TruncatedByBudget);
     }
 

--- a/src/simlin-engine/src/ltm.rs
+++ b/src/simlin-engine/src/ltm.rs
@@ -442,9 +442,17 @@ struct JohnsonState {
     /// 64-bit rapidhash fingerprints of already-emitted circuits (by
     /// sorted node-index set).  Lets us reject duplicate node-set
     /// circuits during enumeration so peak memory stays proportional to
-    /// unique output, not to the number of raw DFS emissions.  Shared
-    /// across all DFS starts within a single SCC (different SCCs have
-    /// disjoint node sets, so no cross-SCC collision is possible).
+    /// unique output, not to the number of raw DFS emissions.
+    ///
+    /// Shared across all DFS starts within a single SCC.  Safe to
+    /// share because Johnson's emits each cycle from its lex-smallest
+    /// start (enforced by the `w < start` gate in `johnson_circuit`),
+    /// so cycles surfaced from different starts already have disjoint
+    /// node sets; the deduplication matters only *within* a single
+    /// start, where a multidigraph SCC can emit multiple rotations
+    /// over the same node set.  Different SCCs' node sets are disjoint
+    /// outright; `JohnsonState` is rebuilt per SCC, so `seen` does not
+    /// need manual clearing between SCCs.
     seen: HashSet<u64>,
     /// Scratch buffer for hashing: reused rather than allocated per-call.
     hash_scratch: Vec<u32>,
@@ -487,10 +495,12 @@ const CIRCUIT_HASH_SEED: u64 = 0xabcdef0123456789;
 ///     naive multiplicative hashes (the old FNV-1a callout spelled this
 ///     out explicitly for the `[0, x, y]` vs `[x, y]` case).
 ///   * Collision probability over wrld3's 1.86M circuits sits at the
-///     2^64 birthday bound (~5e-8) -- identical to the FNV-1a tradeoff
-///     the callsite already accepted, and dramatically better than the
-///     ~400 MiB transient footprint of keying the HashSet on
-///     `Vec<u32>`.
+///     2^64 birthday bound (~5e-8) -- the standard risk profile for any
+///     64-bit hash on inputs of that cardinality, and dramatically
+///     better than the ~400 MiB transient footprint of keying the
+///     HashSet on `Vec<u32>`.  See tech-debt item #22 for the option of
+///     promoting to 128-bit fingerprints if a future model regularly
+///     enumerates past a few hundred thousand distinct circuits.
 ///
 /// Callers pass an already-sorted slice (Johnson's algorithm emits
 /// rotations of the same cycle; sorting makes those collide).
@@ -522,32 +532,32 @@ impl IndexedGraph {
         }
 
         let mut succ: Vec<Vec<u32>> = vec![Vec::new(); nodes.len()];
+        // Successor lists use first-seen insertion order to dedup
+        // duplicate edges that `CausalGraph::from_model` can produce
+        // (e.g. a flow that is both an inflow and an outflow of the
+        // same stock).  We deliberately do NOT sort: on multidigraph
+        // inputs (multiple directed cycles sharing a node set, e.g.
+        // K_n with all edges bidirectional) the DFS visit order
+        // determines which rotation survives the fingerprint dedup in
+        // `johnson_circuit`, and we choose not to pin a canonical
+        // "lex-smallest rotation" in production code -- pinning that
+        // invariant would help only tests, not correctness or salsa
+        // cache stability.  Within a single process HashMap iteration
+        // is stable (same hasher seed), so repeat calls on the same
+        // `CausalGraph` yield identical output; across processes the
+        // multidigraph rotation is free to vary.  Downstream consumers
+        // (`circuit_to_links`, polarity analysis, stock enrichment)
+        // operate on whichever rotation is emitted and are robust to
+        // the choice.
         for (from, tos) in edges {
             let fi = node_to_idx[from] as usize;
+            let mut seen: HashSet<u32> = HashSet::new();
             for to in tos {
                 let ti = node_to_idx[to];
-                succ[fi].push(ti);
+                if seen.insert(ti) {
+                    succ[fi].push(ti);
+                }
             }
-            // Successor lists are sorted ascending and deduped.  Together
-            // with the lex-ascending node order, this pins a canonical
-            // *directed-cycle representative* for multidigraph cases
-            // (graphs where multiple elementary directed cycles share a
-            // node set, e.g. a fully-bidirectional K_n).  Starting DFS at
-            // the lex-min node in an SCC, visiting successors smallest-
-            // index-first, and dedup-by-node-set-fingerprint together
-            // yield the **lexicographically smallest sequence** among all
-            // rotations/orientations of a given node set as the surviving
-            // representative.  Downstream polarity and module-stock
-            // enrichment are derived from this representative, so pinning
-            // it is a strict improvement over the pre-refactor code --
-            // which iterated successors in HashMap-insertion order and
-            // therefore picked a **random representative across
-            // processes**, silently varying polarity on multidigraph
-            // inputs between builds.  See
-            // `johnson_canonical_multidigraph_representative` for the
-            // regression test.
-            succ[fi].sort_unstable();
-            succ[fi].dedup();
         }
 
         IndexedGraph {
@@ -637,7 +647,15 @@ impl IndexedGraph {
                                         break;
                                     }
                                 }
-                                scc.sort_unstable();
+                                // SCCs are returned in whatever order
+                                // Tarjan's stack popped them; callers
+                                // that need a specific iteration order
+                                // over SCC members must sort themselves.
+                                // `enumerate_circuits_in_scc` does not --
+                                // each cycle surfaces from its
+                                // index-smallest member by the
+                                // `w < start` gate regardless of the
+                                // order we try starts in.
                                 sccs.push(scc);
                             }
                         }
@@ -1174,15 +1192,14 @@ impl CausalGraph {
         let mut all_circuits: Vec<Vec<u32>> = Vec::new();
         let mut budget = max_circuits;
 
-        // Iterate SCCs in a deterministic order: sort by smallest index.
-        // The per-SCC enumeration is already deterministic (small-start
-        // DFS over a sorted successor list), so this gives a fully
-        // reproducible iteration overall.
-        let mut scc_order: Vec<usize> = (0..sccs.len()).collect();
-        scc_order.sort_by_key(|&i| sccs[i].first().copied().unwrap_or(u32::MAX));
-
-        for i in scc_order {
-            let scc = &sccs[i];
+        // SCC iteration order is whatever Tarjan emitted.  Each SCC's
+        // contribution to `all_circuits` is independent, and per-cycle
+        // uniqueness comes from the per-SCC `seen` fingerprint set, not
+        // from iteration order -- so there's no correctness reason to
+        // pin the order.  Within a single process HashMap iteration is
+        // stable, so repeated calls on the same `CausalGraph` still
+        // yield identical output.
+        for scc in &sccs {
             // Skip trivial SCCs (single node, no self-loop): they cannot
             // carry any elementary circuit and iterating them was
             // measurable overhead on graphs with many feeder nodes.
@@ -1295,6 +1312,20 @@ impl CausalGraph {
             .iter()
             .map(|&old| indexed.graph.nodes[old as usize].as_str().to_string())
             .collect();
+
+        // Belt-and-braces: after remap, every circuit index must address
+        // a real entry in the trimmed `names` table.  A future refactor
+        // that accidentally drops a remapped index, mixes global and
+        // compact indices, or emits a circuit whose node is missing
+        // from `used_vec` would silently corrupt downstream lookups
+        // like `LoopCircuitsResult::circuit_names`.  Release builds
+        // compile this check out.
+        debug_assert!(
+            circuits
+                .iter()
+                .all(|c| c.iter().all(|&i| (i as usize) < names.len())),
+            "every compact index in trimmed circuits must address a valid name-table entry"
+        );
 
         Ok((names, circuits))
     }
@@ -5139,43 +5170,36 @@ mod tests {
     }
 
     #[test]
-    fn johnson_canonical_multidigraph_representative() {
+    fn johnson_multidigraph_dedups_to_single_node_set() {
         // On a multidigraph SCC where multiple elementary directed
-        // cycles share a node set, dedup picks a single representative.
-        // The choice must be deterministic and independent of
-        // HashMap iteration order or any other non-determinism source,
-        // because the representative's edge sequence feeds downstream
-        // polarity analysis and module-stock enrichment.
+        // cycles share a node set, dedup folds them into one surviving
+        // circuit per node set.  We do NOT pin a canonical rotation:
+        // which rotation survives depends on DFS successor-visit order,
+        // which reflects `CausalGraph::edges`'s HashMap iteration order
+        // and is therefore non-deterministic across processes.  Tests
+        // that need a specific rotation should sort/normalize themselves.
         //
-        // IndexedGraph sorts both the node list (lex-ascending
-        // -> u32 index order) and each successor list, which together
-        // guarantee the surviving representative is the
-        // lexicographically smallest sequence among all rotations and
-        // orientations of the node-set.
+        // What we *do* guarantee: the set of node-sets emitted is
+        // correct, and two calls on the same `CausalGraph` within a
+        // single process produce identical output (HashMap iteration
+        // is stable per-instance).  `dedup_deterministic_across_calls`
+        // covers the within-process invariant; here we just check the
+        // node-set reduction.
         //
-        // For the 3-clique K3 (all 6 directed edges) there are two
-        // three-cycles over {a,b,c}: [a,b,c] (a->b->c->a) and [a,c,b]
-        // (a->c->b->a).  Lex-smallest is [a,b,c].
+        // K3 with all 6 directed edges has multiple 3-cycles over
+        // {a,b,c}: dedup keeps exactly one.
         let cg = build_causal_graph(&[("a", &["b", "c"]), ("b", &["a", "c"]), ("c", &["a", "b"])]);
         let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
-        let three_cycle: Vec<&Vec<Ident<Canonical>>> =
+        let three_cycles: Vec<&Vec<Ident<Canonical>>> =
             circuits.iter().filter(|c| c.len() == 3).collect();
-        assert_eq!(three_cycle.len(), 1, "K3 dedups to one 3-node circuit");
+        assert_eq!(three_cycles.len(), 1, "K3 dedups to one 3-node circuit");
+        let mut nodes: Vec<&str> = three_cycles[0].iter().map(|n| n.as_str()).collect();
+        nodes.sort();
         assert_eq!(
-            three_cycle[0]
-                .iter()
-                .map(|n| n.as_str())
-                .collect::<Vec<_>>(),
+            nodes,
             vec!["a", "b", "c"],
-            "surviving representative must be the lex-smallest sequence [a,b,c], \
-             not the equally-valid-but-larger rotation [a,c,b]"
+            "surviving representative must visit {{a, b, c}} in some order"
         );
-
-        // Two independent enumerations of the same graph must produce
-        // byte-identical representatives.  This is the invariant that
-        // keeps the salsa `LoopCircuitsResult` cache stable.
-        let again = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
-        assert_eq!(circuits, again);
     }
 
     #[test]

--- a/src/simlin-engine/src/ltm.rs
+++ b/src/simlin-engine/src/ltm.rs
@@ -528,10 +528,24 @@ impl IndexedGraph {
                 let ti = node_to_idx[to];
                 succ[fi].push(ti);
             }
-            // Dedup identical successor entries (the input may contain them
-            // if an edge was inserted twice during causal-graph construction)
-            // and sort so the DFS sees the same deterministic order as the
-            // old Ident-based iteration produced via lex sorting.
+            // Successor lists are sorted ascending and deduped.  Together
+            // with the lex-ascending node order, this pins a canonical
+            // *directed-cycle representative* for multidigraph cases
+            // (graphs where multiple elementary directed cycles share a
+            // node set, e.g. a fully-bidirectional K_n).  Starting DFS at
+            // the lex-min node in an SCC, visiting successors smallest-
+            // index-first, and dedup-by-node-set-fingerprint together
+            // yield the **lexicographically smallest sequence** among all
+            // rotations/orientations of a given node set as the surviving
+            // representative.  Downstream polarity and module-stock
+            // enrichment are derived from this representative, so pinning
+            // it is a strict improvement over the pre-refactor code --
+            // which iterated successors in HashMap-insertion order and
+            // therefore picked a **random representative across
+            // processes**, silently varying polarity on multidigraph
+            // inputs between builds.  See
+            // `johnson_canonical_multidigraph_representative` for the
+            // regression test.
             succ[fi].sort_unstable();
             succ[fi].dedup();
         }
@@ -5122,6 +5136,46 @@ mod tests {
             .find_circuit_node_lists_with_limit(1)
             .expect_err("budget of 1 cannot fit both 2-cycles");
         assert_eq!(err, TruncatedByBudget);
+    }
+
+    #[test]
+    fn johnson_canonical_multidigraph_representative() {
+        // On a multidigraph SCC where multiple elementary directed
+        // cycles share a node set, dedup picks a single representative.
+        // The choice must be deterministic and independent of
+        // HashMap iteration order or any other non-determinism source,
+        // because the representative's edge sequence feeds downstream
+        // polarity analysis and module-stock enrichment.
+        //
+        // IndexedGraph sorts both the node list (lex-ascending
+        // -> u32 index order) and each successor list, which together
+        // guarantee the surviving representative is the
+        // lexicographically smallest sequence among all rotations and
+        // orientations of the node-set.
+        //
+        // For the 3-clique K3 (all 6 directed edges) there are two
+        // three-cycles over {a,b,c}: [a,b,c] (a->b->c->a) and [a,c,b]
+        // (a->c->b->a).  Lex-smallest is [a,b,c].
+        let cg = build_causal_graph(&[("a", &["b", "c"]), ("b", &["a", "c"]), ("c", &["a", "b"])]);
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        let three_cycle: Vec<&Vec<Ident<Canonical>>> =
+            circuits.iter().filter(|c| c.len() == 3).collect();
+        assert_eq!(three_cycle.len(), 1, "K3 dedups to one 3-node circuit");
+        assert_eq!(
+            three_cycle[0]
+                .iter()
+                .map(|n| n.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a", "b", "c"],
+            "surviving representative must be the lex-smallest sequence [a,b,c], \
+             not the equally-valid-but-larger rotation [a,c,b]"
+        );
+
+        // Two independent enumerations of the same graph must produce
+        // byte-identical representatives.  This is the invariant that
+        // keeps the salsa `LoopCircuitsResult` cache stable.
+        let again = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        assert_eq!(circuits, again);
     }
 
     #[test]

--- a/src/simlin-engine/src/ltm.rs
+++ b/src/simlin-engine/src/ltm.rs
@@ -438,6 +438,64 @@ struct JohnsonState {
     path: Vec<u32>,
     in_scc: Vec<bool>,
     circuits: Vec<Vec<u32>>,
+    /// 64-bit rapidhash fingerprints of already-emitted circuits (by
+    /// sorted node-index set).  Lets us reject duplicate node-set
+    /// circuits during enumeration so peak memory stays proportional to
+    /// unique output, not to the number of raw DFS emissions.  Shared
+    /// across all DFS starts within a single SCC (different SCCs have
+    /// disjoint node sets, so no cross-SCC collision is possible).
+    seen: HashSet<u64>,
+    /// Scratch buffer for hashing: reused rather than allocated per-call.
+    hash_scratch: Vec<u32>,
+}
+
+/// Fixed seed for the LTM circuit fingerprint hash.
+///
+/// rapidhash mixes this into the state alongside the default secret;
+/// the only property we care about is that it's non-zero and stable
+/// across runs, because the resulting fingerprint set is stored in a
+/// salsa-cached `LoopCircuitsResult`.  Changing this value invalidates
+/// every cached circuit-enumeration result (the hashes change even
+/// though the underlying circuits don't), so treat it as a schema-level
+/// constant and bump it only when that invalidation is desired.
+const CIRCUIT_HASH_SEED: u64 = 0xabcdef0123456789;
+
+/// Deterministic 64-bit rapidhash V3 (HashMicro variant) fingerprint
+/// over a slice of `u32`s, hashed as their little-endian byte
+/// representation.
+///
+/// rapidhash replaces an earlier u32-wise FNV-1a implementation.  At
+/// the LTM hot path's size distribution (mean ~188 bytes, max 320
+/// bytes) the `HashMicro` variant sustains ~34 GiB/s on x86-64 vs.
+/// FNV-1a's ~10 GiB/s, a 3.5x throughput improvement per-hash.  On the
+/// wrld3 `ltm_mem_bench` the end-to-end enumeration speedup is ~4%
+/// (hashing is a small but non-negligible share of total time; the
+/// rest is Johnson's DFS, Vec/HashSet bookkeeping, and sort_unstable
+/// on the scratch buffer).  See `benches/rapidhash_bench.rs`.
+///
+/// rapidhash is preferred here for correctness as much as speed:
+///   * It is deterministic given a fixed seed and secret, which matters
+///     because `LoopCircuitsResult` is a salsa cache value -- a
+///     randomized hasher could silently reshuffle surviving circuits on
+///     a rare collision and invalidate the cache even when the input
+///     didn't change.  We pass `CIRCUIT_HASH_SEED` (a fixed non-zero
+///     constant) and the default rapidhash secret from the port.
+///   * It has strong avalanche behavior: single-bit input flips spread
+///     across ~32 output bits, so leading-zero elements and common
+///     prefixes do not collapse into the seed the way they do with
+///     naive multiplicative hashes (the old FNV-1a callout spelled this
+///     out explicitly for the `[0, x, y]` vs `[x, y]` case).
+///   * Collision probability over wrld3's 1.86M circuits sits at the
+///     2^64 birthday bound (~5e-8) -- identical to the FNV-1a tradeoff
+///     the callsite already accepted, and dramatically better than the
+///     ~400 MiB transient footprint of keying the HashSet on
+///     `Vec<u32>`.
+///
+/// Callers pass an already-sorted slice (Johnson's algorithm emits
+/// rotations of the same cycle; sorting makes those collide).
+#[inline]
+fn hash_u32_slice(vals: &[u32]) -> u64 {
+    crate::rapidhash::hash_u32_slice(vals, CIRCUIT_HASH_SEED)
 }
 
 impl IndexedGraph {
@@ -621,6 +679,8 @@ impl IndexedGraph {
             path: Vec::with_capacity(scc.len()),
             in_scc: vec![false; n],
             circuits: Vec::new(),
+            seen: HashSet::new(),
+            hash_scratch: Vec::with_capacity(scc.len()),
         };
         for &v in scc {
             state.in_scc[v as usize] = true;
@@ -698,13 +758,26 @@ impl IndexedGraph {
                 // rules out the self-loop-at-root case).  The closing
                 // edge v -> start is implicit -- downstream code
                 // (circuit_to_links) wraps from path[last] to path[0].
-                // Budget is checked before the push so zero budget bails
-                // cleanly.
-                if *budget == 0 {
-                    return Err(TruncatedByBudgetInternal);
+                //
+                // Multidigraph graphs (e.g. arms-race 3-cliques) produce
+                // multiple distinct directed cycles over the same node
+                // set; LTM semantics fold those into a single loop.
+                // Dedup here rather than post-hoc so peak memory stays
+                // proportional to unique output.  Budget consumption
+                // only fires for unique emissions -- a duplicate
+                // traversal still marks `found_cycle = true` so the
+                // blocked/B[] unblock machinery behaves correctly.
+                state.hash_scratch.clear();
+                state.hash_scratch.extend_from_slice(&state.path);
+                state.hash_scratch.sort_unstable();
+                let fp = hash_u32_slice(&state.hash_scratch);
+                if state.seen.insert(fp) {
+                    if *budget == 0 {
+                        return Err(TruncatedByBudgetInternal);
+                    }
+                    *budget -= 1;
+                    state.circuits.push(state.path.clone());
                 }
-                *budget -= 1;
-                state.circuits.push(state.path.clone());
                 found_cycle = true;
             } else if w == start {
                 // Pure self-loop at the DFS root (v == start).  Excluded
@@ -738,14 +811,19 @@ impl IndexedGraph {
             // in each successor w's b_list, so that if w is later
             // unblocked (because another DFS branch found a cycle
             // through w), v will also be unblocked and retried.
+            //
+            // Classical Johnson's does not guard against duplicate
+            // entries in b_list[w]: `johnson_unblock` short-circuits on
+            // already-unblocked nodes, so at worst we pay one extra
+            // pop+check per duplicate rather than an O(|b_list|) scan
+            // per insertion.  Dropping the linear `contains` check is a
+            // pure win on dense SCCs.
             for i in 0..succs_len {
                 let w = self.succ[v as usize][i];
                 if !state.in_scc[w as usize] || w < start {
                     continue;
                 }
-                if !state.b_list[w as usize].contains(&v) {
-                    state.b_list[w as usize].push(v);
-                }
+                state.b_list[w as usize].push(v);
             }
         }
 
@@ -832,39 +910,20 @@ impl IndexedGraph {
         false
     }
 
-    /// Deduplicate circuits by node-set.
-    ///
-    /// Two distinct elementary circuits can share a node set when the same
-    /// nodes are visited in different rotations (e.g. `a->b->c->a` vs.
-    /// `a->c->b->a` in a graph with edges in both orientations); the LTM
-    /// semantics fold these into a single loop.  See
-    /// `test_layout_arms_race` for a graph where this actually fires.
-    ///
-    /// Keys are a 64-bit fingerprint of the sorted node-index vector via
-    /// the default SipHash-1-3 hasher seeded from process RNG.  This is
-    /// within-process deterministic (every circuit uses the same seed) and
-    /// the birthday-collision probability over wrld3's 1.86M circuits is
-    /// under 1e-7 -- well below any observable impact on loop counts.
-    /// Storing u64 fingerprints instead of full sorted `Vec<u32>` keys
-    /// drops the dedup footprint from ~440 MiB to ~30 MiB on wrld3 at
-    /// uncapped enumeration.
-    fn dedup_circuits(circuits: Vec<Vec<u32>>) -> Vec<Vec<u32>> {
-        use std::collections::hash_map::RandomState;
-        use std::hash::BuildHasher;
-
-        let state = RandomState::new();
-        let mut seen: HashSet<u64> = HashSet::with_capacity(circuits.len());
-        let mut unique = Vec::with_capacity(circuits.len());
-        let mut scratch: Vec<u32> = Vec::new();
+    /// Debug-only helper: confirm the invariant that
+    /// `enumerate_circuits_in_scc` emits each node-set at most once per
+    /// SCC.  Used by `debug_assert!` callers; release builds compile
+    /// the call out via `debug_assert!`'s no-op expansion.
+    fn has_no_duplicate_node_sets(circuits: &[Vec<u32>]) -> bool {
+        let mut seen: HashSet<Vec<u32>> = HashSet::with_capacity(circuits.len());
         for c in circuits {
-            scratch.clear();
-            scratch.extend_from_slice(&c);
-            scratch.sort_unstable();
-            if seen.insert(state.hash_one(&scratch)) {
-                unique.push(c);
+            let mut key = c.clone();
+            key.sort_unstable();
+            if !seen.insert(key) {
+                return false;
             }
         }
-        unique
+        true
     }
 
     /// Convert a circuit of indices back to the caller-facing
@@ -874,16 +933,6 @@ impl IndexedGraph {
             .iter()
             .map(|&i| self.nodes[i as usize].clone())
             .collect()
-    }
-
-    /// Materialize the canonical node-name table as a `Vec<String>`.
-    /// Index `i` corresponds to `NodeIdx(i as u32)` in the indexed
-    /// circuit output.  Allocates one `String` per unique node; the
-    /// dense `Vec<Vec<u32>>` circuit output shares this table so the
-    /// aggregate memory footprint is O(unique_nodes + total_circuit_len)
-    /// rather than O(unique_nodes × circuits × path_len).
-    fn node_name_strings(&self) -> Vec<String> {
-        self.nodes.iter().map(|i| i.as_str().to_string()).collect()
     }
 }
 
@@ -1104,10 +1153,17 @@ impl CausalGraph {
             }
         }
 
-        let unique = IndexedGraph::dedup_circuits(all_circuits);
+        // Each SCC's enumerator already deduplicates by sorted node-set,
+        // and different SCCs share no nodes -- so `all_circuits` has no
+        // cross-SCC duplicates.  Debug builds verify the invariant.
+        debug_assert!(
+            IndexedGraph::has_no_duplicate_node_sets(&all_circuits),
+            "enumerate_circuits_in_scc should emit unique node-sets per SCC"
+        );
+
         Ok(IndexedCircuits {
             graph,
-            circuits: unique,
+            circuits: all_circuits,
         })
     }
 
@@ -1144,16 +1200,61 @@ impl CausalGraph {
     /// length-check, or group circuits -- all of which work on the
     /// integer form without paying the per-name allocation cost.
     ///
+    /// The returned name table is trimmed to **only the nodes that
+    /// actually appear in a circuit**: non-cyclic feeder variables are
+    /// omitted, and `circuits` use compact indices into the trimmed
+    /// table.  This matters for salsa cache stability -- otherwise a
+    /// rename of any acyclic variable would change the (full) name
+    /// table and invalidate every downstream LTM query even though the
+    /// loop structure is unchanged.  `names` is empty when `circuits`
+    /// is empty (pure DAG / truncated budget).
+    ///
     /// Same budget semantics as [`Self::find_circuit_node_lists_with_limit`];
-    /// returns `Err(TruncatedByBudget)` when the enumeration would exceed
-    /// `max_circuits`.
+    /// returns `Err(TruncatedByBudget)` when the enumeration would
+    /// exceed `max_circuits`.
     pub fn find_indexed_circuits_with_limit(
         &self,
         max_circuits: usize,
     ) -> std::result::Result<(Vec<String>, Vec<Vec<u32>>), TruncatedByBudget> {
         let indexed = self.enumerate_indexed_circuits(max_circuits)?;
-        let names = indexed.graph.node_name_strings();
-        Ok((names, indexed.circuits))
+        let mut circuits = indexed.circuits;
+
+        if circuits.is_empty() {
+            return Ok((Vec::new(), circuits));
+        }
+
+        // Compact the name table to only the indices that appear in a
+        // circuit.  Using BTreeSet preserves ascending order so the
+        // trimmed `names` stays lex-sorted (the enumerator's canonical
+        // ordering, which downstream tests rely on).
+        let mut used: std::collections::BTreeSet<u32> = std::collections::BTreeSet::new();
+        for c in &circuits {
+            for &n in c {
+                used.insert(n);
+            }
+        }
+        let used_vec: Vec<u32> = used.into_iter().collect();
+
+        // Sparse mapping old_idx -> new_idx.  used_vec.len() is bounded
+        // by the (non-trivial) SCC size -- at most a few hundred even
+        // on dense SD models -- so a Vec<i32> keyed by old index is
+        // both faster and denser than a HashMap.
+        let mut old_to_new: Vec<i32> = vec![-1; indexed.graph.nodes.len()];
+        for (new_i, &old_i) in used_vec.iter().enumerate() {
+            old_to_new[old_i as usize] = new_i as i32;
+        }
+        for c in &mut circuits {
+            for n in c {
+                *n = old_to_new[*n as usize] as u32;
+            }
+        }
+
+        let names: Vec<String> = used_vec
+            .iter()
+            .map(|&old| indexed.graph.nodes[old as usize].as_str().to_string())
+            .collect();
+
+        Ok((names, circuits))
     }
 
     /// Default-budget variant of [`Self::find_indexed_circuits_with_limit`];
@@ -4827,27 +4928,28 @@ mod tests {
     //       max_circuits + 1st circuit,
     //   (5) cross-SCC edges never traversed.
 
-    /// Helper: canonicalize a list of circuits for comparison.  Rotates
-    /// each circuit so that its lex-smallest node comes first, then sorts
-    /// the outer list.  Used by the equivalence test to compare Johnson's
-    /// output against Tiernan's ignoring rotation differences (both
-    /// algorithms SHOULD produce identical rotations under our
-    /// small-start discipline, but being rotation-insensitive in the test
-    /// hardens against future refactors).
-    fn canonicalize_circuits(mut circuits: Vec<Vec<u32>>) -> Vec<Vec<u32>> {
-        for c in &mut circuits {
-            if c.is_empty() {
-                continue;
-            }
-            let min_idx = c.iter().enumerate().min_by_key(|(_, v)| **v).unwrap().0;
-            c.rotate_left(min_idx);
-        }
-        circuits.sort();
-        circuits
+    /// Canonicalize a list of circuits to the set of sorted node-sets.
+    /// LTM semantics fold distinct rotations with the same node-set into
+    /// one loop (see `deduplicate_loops` and the multidigraph handling
+    /// in `johnson_circuit`).  The post-refactor Johnson's deduplicates
+    /// inline during emission; the Tiernan oracle still emits every
+    /// rotation.  Reducing to sorted + deduped node-sets puts them on
+    /// equal footing for equivalence comparisons.
+    fn canonicalize_circuits(circuits: Vec<Vec<u32>>) -> Vec<Vec<u32>> {
+        let mut keys: Vec<Vec<u32>> = circuits
+            .into_iter()
+            .map(|mut c| {
+                c.sort_unstable();
+                c
+            })
+            .collect();
+        keys.sort();
+        keys.dedup();
+        keys
     }
 
     /// Run both Johnson's (production) and Tiernan (oracle) on a graph
-    /// and assert their canonicalized outputs are equal.
+    /// and assert their canonicalized node-set coverage is equal.
     fn assert_johnson_matches_tiernan(cg: &CausalGraph) {
         let graph = IndexedGraph::from_edges(cg.edges());
         let sccs = graph.tarjan_scc();
@@ -4868,16 +4970,12 @@ mod tests {
             tiernan_circuits.append(&mut part);
         }
 
-        // Both should emit each cycle exactly once with the same total
-        // count.  Dedup (at the IndexedGraph::dedup_circuits layer) would
-        // normally fold multidigraph duplicates, but here we compare the
-        // raw output of each algorithm to confirm they're on equal footing.
         let johnson_canon = canonicalize_circuits(johnson_circuits);
         let tiernan_canon = canonicalize_circuits(tiernan_circuits);
         assert_eq!(
             johnson_canon,
             tiernan_canon,
-            "Johnson's and Tiernan enumerations disagree on edges {:?}",
+            "Johnson's and Tiernan node-set coverage disagrees on edges {:?}",
             cg.edges()
         );
     }
@@ -5103,6 +5201,114 @@ mod tests {
                 vec!["a".to_string(), "b".to_string()],
                 vec!["x".to_string(), "y".to_string()],
             ]
+        );
+    }
+
+    #[test]
+    fn dedup_deterministic_across_calls() {
+        // Multidigraph (K3 with all 6 directed edges) yields two
+        // distinct directed 3-cycles sharing node set {a,b,c}; LTM
+        // semantics fold those into one.  A non-deterministic hasher
+        // could pick different representatives between calls on rare
+        // collisions, which would silently invalidate the salsa
+        // LoopCircuitsResult cache.  The rapidhash fingerprint is
+        // content-addressed and deterministic (fixed seed, fixed
+        // secret); calling twice on the same graph must produce
+        // byte-identical output.
+        let cg = build_causal_graph(&[("a", &["b", "c"]), ("b", &["a", "c"]), ("c", &["a", "b"])]);
+        let r1 = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        let r2 = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        assert_eq!(
+            r1, r2,
+            "repeated enumeration of the same graph must be byte-identical"
+        );
+
+        // The indexed form must also be byte-identical, including the
+        // trimmed name table and compact indices.
+        let i1 = cg.find_indexed_circuits();
+        let i2 = cg.find_indexed_circuits();
+        assert_eq!(
+            i1, i2,
+            "repeated indexed enumeration must be byte-identical"
+        );
+    }
+
+    #[test]
+    fn find_indexed_circuits_trims_names_to_cycle_participants() {
+        // Graph: non-cyclic feeder -> entry -> [ entry <-> loop_a <-> loop_b ]
+        // feeder is acyclic and must NOT appear in the names table.
+        // Keeping it would invalidate salsa caching whenever an acyclic
+        // variable elsewhere in the project is renamed, even though the
+        // loop structure is unchanged.
+        let cg = build_causal_graph(&[
+            ("feeder", &["entry"]),
+            ("entry", &["loop_a"]),
+            ("loop_a", &["loop_b"]),
+            ("loop_b", &["entry"]),
+        ]);
+        let (names, circuits) = cg.find_indexed_circuits();
+        assert_eq!(circuits.len(), 1, "exactly one elementary cycle");
+        assert!(
+            !names.iter().any(|n| n == "feeder"),
+            "non-cyclic feeder must be excluded from the names table: {names:?}"
+        );
+        let mut expected = vec![
+            "entry".to_string(),
+            "loop_a".to_string(),
+            "loop_b".to_string(),
+        ];
+        expected.sort();
+        let mut got = names.clone();
+        got.sort();
+        assert_eq!(
+            got, expected,
+            "names table must contain exactly the cycle participants"
+        );
+
+        // Compact indices must all resolve to valid names-table entries.
+        for c in &circuits {
+            for &idx in c {
+                assert!(
+                    (idx as usize) < names.len(),
+                    "compact index {idx} out of range"
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn find_indexed_circuits_empty_on_dag_returns_empty_names() {
+        // Pure DAG has no circuits; the (names, circuits) pair must both
+        // be empty so salsa sees a stable "no LTM" result across any
+        // rename/reshape of the DAG.
+        let cg = build_causal_graph(&[("a", &["b"]), ("b", &["c"])]);
+        let (names, circuits) = cg.find_indexed_circuits();
+        assert!(circuits.is_empty(), "DAG has no circuits");
+        assert!(
+            names.is_empty(),
+            "empty circuits must produce empty names table: {names:?}"
+        );
+    }
+
+    #[test]
+    fn find_loops_and_find_circuit_node_lists_agree_on_count() {
+        // Both public APIs share `enumerate_indexed_circuits`, so their
+        // circuit counts must remain in lock-step.  This guards against
+        // accidental drift if future refactors thread a separate dedup
+        // or filter through one path but not the other.
+        let cg = build_causal_graph(&[
+            ("a", &["b", "c"]),
+            ("b", &["a", "c"]),
+            ("c", &["a", "b"]),
+            ("x", &["y"]),
+            ("y", &["x"]),
+        ]);
+        let loops = cg.find_loops_with_limit(usize::MAX).unwrap();
+        let circuits = cg.find_circuit_node_lists_with_limit(usize::MAX).unwrap();
+        assert_eq!(
+            loops.len(),
+            circuits.len(),
+            "find_loops and find_circuit_node_lists must produce the same count"
         );
     }
 

--- a/src/simlin-engine/src/ltm_augment.rs
+++ b/src/simlin-engine/src/ltm_augment.rs
@@ -206,7 +206,7 @@ fn generate_link_score_equation(
         generate_flow_to_stock_equation(from.as_str(), to.as_str(), to_var)
     } else if is_stock_to_flow {
         // Use stock-to-flow formula
-        generate_stock_to_flow_equation(from, to, to_var, all_vars)
+        generate_stock_to_flow_equation(from, to, to_var)
     } else {
         // Use standard auxiliary-to-auxiliary formula
         generate_auxiliary_to_auxiliary_equation(from, to, to_var)
@@ -328,7 +328,6 @@ fn generate_stock_to_flow_equation(
     stock: &Ident<Canonical>,
     flow: &Ident<Canonical>,
     flow_var: &Variable,
-    all_vars: &HashMap<Ident<Canonical>, Variable>,
 ) -> String {
     // For stock-to-flow, we need to calculate how the stock influences the flow
     // This is similar to auxiliary-to-auxiliary but we know the 'from' is a stock
@@ -368,17 +367,6 @@ fn generate_stock_to_flow_equation(
     };
 
     let partial_eq = build_partial_equation(&flow_equation, &deps, stock);
-
-    // Check if this flow affects the stock (is it an inflow or outflow?)
-    let stock_var = all_vars.get(stock);
-    let _is_affecting_stock = if let Some(Variable::Stock {
-        inflows, outflows, ..
-    }) = stock_var
-    {
-        inflows.contains(flow) || outflows.contains(flow)
-    } else {
-        false
-    };
 
     // Link score formula from LTM paper: |Δxz/Δz| × sign(Δxz/Δx)
     // For stock-to-flow: x=stock, z=flow

--- a/src/simlin-engine/src/rapidhash.rs
+++ b/src/simlin-engine/src/rapidhash.rs
@@ -1,0 +1,567 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+//
+// ---------------------------------------------------------------------
+// Portions of this file are adapted from rapidhash V3 and retain their
+// upstream MIT license.  The original rapidhash is:
+//
+//   Copyright (C) 2025 Nicolas De Carli
+//   based on 'wyhash' by Wang Yi
+//   https://github.com/Nicoshev/rapidhash
+//
+// and the Go reference port used for cross-validation is:
+//
+//   Copyright (C) 2025 Bobby Powers
+//   third_party/go-rapidhash
+//
+// Both are MIT-licensed (see their LICENSE files):
+//
+// Permission is hereby granted, free of charge, to any person obtaining a
+// copy of this software and associated documentation files (the "Software"),
+// to deal in the Software without restriction, including without limitation
+// the rights to use, copy, modify, merge, publish, distribute, sublicense,
+// and/or sell copies of the Software, and to permit persons to whom the
+// Software is furnished to do so, subject to the following conditions:
+// The above copyright notice and this permission notice shall be included
+// in all copies or substantial portions of the Software.
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+// OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+// IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+// CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+// TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+// SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+//! Targeted port of the rapidhash V3 `HashMicro` variant.
+//!
+//! rapidhash is a fast, high-quality 64-bit non-cryptographic hash derived
+//! from Wang Yi's wyhash.  We port only the `HashMicro` variant because
+//! our call site in `ltm.rs` feeds it sorted `u32` circuit fingerprints
+//! in the 2..=80 element range (8..320 bytes, mean ~188 bytes) and
+//! `HashMicro`'s 80-byte unrolled inner loop is an excellent match for
+//! that size distribution (the general `Hash` variant's 112-byte unroll
+//! and 224-byte mega-loop pay for themselves only above ~1 KB, which we
+//! never see; `HashNano` loses throughput above 48 bytes).
+//!
+//! Determinism is a hard requirement: the caller stores the returned
+//! fingerprint in a `HashSet<u64>` that is later used as a salsa cache
+//! key, so the hash for a given input must be identical across runs.
+//! We use the default rapidhash V3 secret and a caller-supplied fixed
+//! seed, and we assume little-endian byte order (enforced by a
+//! compile-time check below -- our targets are x86-64, aarch64, and
+//! wasm32, all little-endian).
+//!
+//! The core algorithm reads 8 bytes at a time via `u64::from_le_bytes`,
+//! which LLVM lowers to a single `mov` on little-endian hosts and gives
+//! us safe unaligned reads for free.
+//!
+//! # Correctness
+//!
+//! The byte-level output is cross-validated against the Go reference
+//! port (`third_party/go-rapidhash`) for a fixed corpus of inputs
+//! spanning all branches of the length-dispatch cascade.  Those vectors
+//! are baked into the module-level tests below.
+
+// The crate is compiled with `#![deny(unsafe_code)]`. We opt in to a
+// single narrowly-scoped `unsafe` call below (slice re-interpretation of
+// `&[u32]` as `&[u8]`) with an explicit SAFETY comment.  Everything else
+// is safe Rust.
+#![allow(unsafe_code)]
+
+// Compile-time guard: the rapidhash V3 reference implementations assume
+// little-endian byte order for their 8-byte / 4-byte reads, and the Go
+// cross-validation vectors were generated in that mode.  Running on a
+// big-endian host would silently produce different hash values and
+// invalidate cached `LoopCircuitsResult`s, so we refuse to compile.
+#[cfg(not(target_endian = "little"))]
+compile_error!(
+    "simlin-engine::rapidhash requires a little-endian target: \
+     the hash output is intentionally byte-order-dependent so salsa \
+     cache keys stay stable across runs."
+);
+
+/// Default 8x64-bit secret from rapidhash V3 (`rapid_secret` in
+/// `third_party/rapidhash/rapidhash.h`).  Hard-coded rather than derived
+/// so the Rust and Go implementations produce identical hashes.
+const DEFAULT_SECRET: [u64; 8] = [
+    0x2d358dccaa6c78a5,
+    0x8bb84b93962eacc9,
+    0x4b33a62ed433d4a3,
+    0x4d5a2da51de1aa47,
+    0xa0761d6478bd642f,
+    0xe7037ed1a0b428db,
+    0x90ed1765281c388c,
+    0xaaaaaaaaaaaaaaaa,
+];
+
+/// 64x64 -> 128 multiply returning `(low, high)`.
+///
+/// On x86-64 and aarch64 the `u128` path compiles to a single `mulq`
+/// / `umulh`+`mul` pair -- no stack spill, no slow multi-limb expansion.
+/// Forced-inlined because the hot loop calls this ~10x per 80-byte
+/// block; letting a `callq` remain here stalls the in-flight mul chain.
+#[inline(always)]
+fn rapid_mum(a: u64, b: u64) -> (u64, u64) {
+    let r = (a as u128).wrapping_mul(b as u128);
+    (r as u64, (r >> 64) as u64)
+}
+
+/// Multiply-and-xor mix: returns the XOR of the high and low 64 bits
+/// of `a * b`.  This is the lone non-linear primitive of rapidhash; all
+/// other operations are XORs and loads.
+#[inline(always)]
+fn rapid_mix(a: u64, b: u64) -> u64 {
+    let (lo, hi) = rapid_mum(a, b);
+    lo ^ hi
+}
+
+/// Read 8 little-endian bytes from the first 8 bytes of `block`.
+///
+/// Callers pass in a typed chunk slice (e.g. `&[u8; 80]`) so LLVM
+/// knows statically that the read is in bounds -- no runtime check is
+/// emitted.  The `try_into().unwrap()` on a known-length array slice
+/// collapses to a direct unaligned 8-byte load on x86-64 / aarch64.
+/// Using `copy_from_slice` instead generates a `memcpy`-style callq.
+#[inline(always)]
+fn read64_at<const N: usize>(block: &[u8; N], off: usize) -> u64 {
+    let chunk: [u8; 8] = block[off..off + 8].try_into().unwrap();
+    u64::from_le_bytes(chunk)
+}
+
+/// Read 4 little-endian bytes from `p` at offset `off`.
+///
+/// Used only on the <=16-byte path where the input slice length is not
+/// fixed at compile time, so we can't template over `N`.  The caller
+/// guarantees `off + 4 <= p.len()`.
+#[inline(always)]
+fn read32_dyn(p: &[u8], off: usize) -> u64 {
+    let chunk: [u8; 4] = p[off..off + 4].try_into().unwrap();
+    u32::from_le_bytes(chunk) as u64
+}
+
+/// Read 8 little-endian bytes from `p` at offset `off` (dynamic-length
+/// slice form for the <=16-byte path and the finalization tail read).
+#[inline(always)]
+fn read64_dyn(p: &[u8], off: usize) -> u64 {
+    let chunk: [u8; 8] = p[off..off + 8].try_into().unwrap();
+    u64::from_le_bytes(chunk)
+}
+
+/// `HashMicro`-variant byte hash.
+///
+/// Faithful port of `rapidhashMicro_internal` in
+/// `third_party/rapidhash/rapidhash.h` using the default rapid secret.
+/// The control flow, lane ordering, and final mix exactly mirror the
+/// C/Go reference; the only differences are Rust idioms (slice reads,
+/// branching by match, `u128`-backed multiply).
+///
+/// # Determinism
+///
+/// For any `(key, seed)` pair the output is byte-for-byte stable across
+/// runs and matches the Go port's `HashMicro(key, seed)`.
+#[inline]
+pub fn hash_bytes(key: &[u8], seed: u64) -> u64 {
+    let len = key.len();
+    let len_u64 = len as u64;
+    let mut seed = seed ^ rapid_mix(seed ^ DEFAULT_SECRET[2], DEFAULT_SECRET[1]);
+
+    // `i` starts at the full length and is decremented inside the big-input
+    // branch as whole 80-byte blocks are consumed.  The final mix folds
+    // `i` (not the original `len`) into `b ^ secret[1] ^ i` -- in the
+    // <= 16-byte branch `i == len` so the two are identical, but in the
+    // large-input branch `i` ends as the 0..=80 residual byte count and
+    // the hash would mismatch the reference if we substituted `len`.
+    let mut i = len_u64;
+
+    let (a, b) = if len <= 16 {
+        if len >= 4 {
+            // The `seed ^= len` mutation is part of the rapidhash spec
+            // for 4..=16-byte inputs: it folds the length into the
+            // entropy pool before the tail mix.  It is not a bug.
+            seed ^= len_u64;
+            if len >= 8 {
+                (read64_dyn(key, 0), read64_dyn(key, len - 8))
+            } else {
+                (read32_dyn(key, 0), read32_dyn(key, len - 4))
+            }
+        } else if len > 0 {
+            (
+                ((key[0] as u64) << 45) | (key[len - 1] as u64),
+                key[len >> 1] as u64,
+            )
+        } else {
+            (0u64, 0u64)
+        }
+    } else {
+        let mut off = 0usize;
+
+        if i > 80 {
+            // Four parallel accumulator lanes beyond `seed`. Splitting
+            // the mixing state into independent chains is what lets the
+            // out-of-order pipeline run the mul/xor sequence at one
+            // block per ~5 cycles instead of serializing on a single
+            // dependency chain.
+            let mut see1 = seed;
+            let mut see2 = seed;
+            let mut see3 = seed;
+            let mut see4 = seed;
+
+            // Each iteration consumes 80 bytes = 10 * u64 reads = 5
+            // parallel `rapid_mix` calls.  We split an 80-byte typed
+            // block out of `key` so every subsequent `read64_at` sees a
+            // slice whose length is a compile-time constant -- without
+            // this, LLVM emits a full slice bounds check per read and
+            // the loop runs ~2x slower on x86-64.
+            while i > 80 {
+                let block: &[u8; 80] = key[off..off + 80]
+                    .try_into()
+                    .expect("bounds-checked by i > 80");
+                seed = rapid_mix(
+                    read64_at(block, 0) ^ DEFAULT_SECRET[0],
+                    read64_at(block, 8) ^ seed,
+                );
+                see1 = rapid_mix(
+                    read64_at(block, 16) ^ DEFAULT_SECRET[1],
+                    read64_at(block, 24) ^ see1,
+                );
+                see2 = rapid_mix(
+                    read64_at(block, 32) ^ DEFAULT_SECRET[2],
+                    read64_at(block, 40) ^ see2,
+                );
+                see3 = rapid_mix(
+                    read64_at(block, 48) ^ DEFAULT_SECRET[3],
+                    read64_at(block, 56) ^ see3,
+                );
+                see4 = rapid_mix(
+                    read64_at(block, 64) ^ DEFAULT_SECRET[4],
+                    read64_at(block, 72) ^ see4,
+                );
+                off += 80;
+                i -= 80;
+            }
+            // `i` is now the 0..=80-byte residual; the tail drain reads
+            // from `off` and the final 16 bytes are read from the end
+            // of the original buffer.
+
+            // Collapse lanes pairwise into `seed`.  The fold order
+            // matches the reference implementation byte-for-byte.
+            seed ^= see1;
+            see2 ^= see3;
+            seed ^= see4;
+            seed ^= see2;
+        }
+
+        // Drain the 17..=80-byte tail with 0..=3 serial mixes.  Each
+        // `if i > N` nest reads up to byte (N, N+16] from `off`, so we
+        // take a fixed-size &[u8; K] block per level; the `try_into`
+        // collapses to a length check that LLVM can propagate through
+        // all 4 / 8 / 12 / 16 subsequent `read64_at` calls.  The old
+        // dynamic-index form (`key[off..off+8]`) re-checked bounds on
+        // every read and roughly doubled the hash's runtime on our
+        // inputs.
+        if i > 16 {
+            let tail16: &[u8; 16] = key[off..off + 16]
+                .try_into()
+                .expect("i > 16 implies at least 16 bytes remain");
+            seed = rapid_mix(
+                read64_at(tail16, 0) ^ DEFAULT_SECRET[2],
+                read64_at(tail16, 8) ^ seed,
+            );
+            if i > 32 {
+                let tail32: &[u8; 32] = key[off..off + 32]
+                    .try_into()
+                    .expect("i > 32 implies at least 32 bytes remain");
+                seed = rapid_mix(
+                    read64_at(tail32, 16) ^ DEFAULT_SECRET[2],
+                    read64_at(tail32, 24) ^ seed,
+                );
+                if i > 48 {
+                    let tail48: &[u8; 48] = key[off..off + 48]
+                        .try_into()
+                        .expect("i > 48 implies at least 48 bytes remain");
+                    seed = rapid_mix(
+                        read64_at(tail48, 32) ^ DEFAULT_SECRET[1],
+                        read64_at(tail48, 40) ^ seed,
+                    );
+                    if i > 64 {
+                        let tail64: &[u8; 64] = key[off..off + 64]
+                            .try_into()
+                            .expect("i > 64 implies at least 64 bytes remain");
+                        seed = rapid_mix(
+                            read64_at(tail64, 48) ^ DEFAULT_SECRET[1],
+                            read64_at(tail64, 56) ^ seed,
+                        );
+                    }
+                }
+            }
+        }
+
+        // Final 16 bytes are always taken from the tail of the original
+        // buffer so single-bit flips in any byte affect the output (the
+        // interior lane mixes cover middle bytes, the tail ensures the
+        // final two u64s are included regardless of `i`).
+        let a = read64_dyn(key, len - 16) ^ i;
+        let b = read64_dyn(key, len - 8);
+        (a, b)
+    };
+
+    // Finalization: reduce `a`, `b`, `seed`, and the residual `i` into a
+    // single u64.  The `a ^ secret[7]` / `b ^ secret[1] ^ i` avalanche
+    // stirs in the remaining entropy and length residue.  In the small-
+    // input branch `i` was never decremented so it still equals `len_u64`,
+    // which matches the reference behavior.  The `rapid_mum` before
+    // `rapid_mix` is arithmetically redundant with the next mix but is
+    // part of the specified finalization, so we keep it byte-for-byte.
+    let a = a ^ DEFAULT_SECRET[1];
+    let b = b ^ seed;
+    let (a, b) = rapid_mum(a, b);
+    rapid_mix(a ^ DEFAULT_SECRET[7], b ^ DEFAULT_SECRET[1] ^ i)
+}
+
+/// Convenience wrapper for the LTM callsite: hash the little-endian byte
+/// representation of a `&[u32]`.
+///
+/// This is the primary entry point used from `ltm.rs::johnson_circuit`
+/// to fingerprint sorted vertex sets of discovered cycles.  On every
+/// target we support (x86-64 Linux/macOS, aarch64 Linux/macOS, wasm32)
+/// `u32` values are already stored little-endian, so
+/// re-interpreting the slice as raw bytes is equivalent to a logical
+/// `u32::to_le_bytes` on each element without the memcpy.
+#[inline]
+pub fn hash_u32_slice(vals: &[u32], seed: u64) -> u64 {
+    // SAFETY:
+    //   * `vals.as_ptr()` is valid for reads of `vals.len() * 4` bytes,
+    //     because a `&[u32]` guarantees contiguous storage of that
+    //     many initialized bytes.
+    //   * Every bit pattern of `u8` is valid, so reinterpreting the
+    //     storage as `&[u8]` is sound regardless of the original
+    //     `u32` values.
+    //   * The produced `&[u8]` does not outlive the input slice -- we
+    //     only pass it into `hash_bytes`, which is itself bounded by
+    //     the caller's borrow.
+    //   * Alignment: u32 has alignment 4, but `*const u8` only requires
+    //     alignment 1, so the downcast is trivially aligned.
+    //   * `vals.len() * 4` cannot overflow: a slice's size in bytes is
+    //     constrained by `isize::MAX` per Rust's pointer aliasing
+    //     rules, which bounds `vals.len() <= isize::MAX / 4`.
+    //   * Endianness: enforced little-endian at crate level via the
+    //     `compile_error!` guard above, so the byte sequence matches
+    //     what a caller would get from flattening
+    //     `u32::to_le_bytes` per element.
+    let bytes: &[u8] =
+        unsafe { std::slice::from_raw_parts(vals.as_ptr() as *const u8, vals.len() * 4) };
+    hash_bytes(bytes, seed)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---------------------------------------------------------------
+    // Stability / self-consistency
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn empty_input_is_stable() {
+        // Expected values mirror the Go port's test vector for
+        // HashMicro(len=0, seed=0).
+        assert_eq!(hash_bytes(&[], 0), 0x0338dc4be2cecdae);
+        assert_eq!(hash_bytes(&[], 0), hash_bytes(&[], 0));
+    }
+
+    #[test]
+    fn hashes_are_deterministic_across_calls() {
+        // Cover every branch of the length cascade.
+        let sizes: [usize; 13] = [1, 2, 3, 4, 7, 8, 15, 16, 17, 80, 81, 188, 320];
+        for &n in &sizes {
+            let buf: Vec<u8> = (0..n).map(|i| (i as u8).wrapping_mul(7)).collect();
+            let h1 = hash_bytes(&buf, 0xabcdef0123456789);
+            let h2 = hash_bytes(&buf, 0xabcdef0123456789);
+            assert_eq!(h1, h2, "hash not stable for len={n}");
+            // Different seed must change the hash (collision at 2^-64
+            // is negligible for a single pair).
+            let h3 = hash_bytes(&buf, 0xabcdef0123456788);
+            assert_ne!(h1, h3, "seed did not affect hash for len={n}");
+        }
+    }
+
+    #[test]
+    fn u32_and_bytes_roundtrip_match() {
+        // Whatever the `hash_u32_slice` wrapper feeds into `hash_bytes`
+        // must match a manual flatten via `u32::to_le_bytes`.
+        let vals: Vec<u32> = (0u32..47).map(|i| 7 + 13 * i).collect();
+        let mut flat = Vec::with_capacity(vals.len() * 4);
+        for &v in &vals {
+            flat.extend_from_slice(&v.to_le_bytes());
+        }
+        let seed = 0xabcdef0123456789u64;
+        assert_eq!(hash_u32_slice(&vals, seed), hash_bytes(&flat, seed));
+    }
+
+    #[test]
+    fn u32_slice_wrapper_handles_empty() {
+        // `&[u32]` of length 0 must produce the same hash as an empty
+        // byte slice -- both are "no bytes" inputs.
+        let empty: &[u32] = &[];
+        assert_eq!(
+            hash_u32_slice(empty, 0xabcdef0123456789),
+            hash_bytes(&[], 0xabcdef0123456789),
+        );
+    }
+
+    // ---------------------------------------------------------------
+    // Cross-validation vs. Go reference port.
+    //
+    // These vectors were generated by running the Go `HashMicro`
+    // implementation in `third_party/go-rapidhash` on the exact inputs
+    // below (see the commit message for the harness).  A mismatch here
+    // means the Rust port has diverged from the reference: do not
+    // "fix" it by changing the expected value without re-running the
+    // Go generator.
+    // ---------------------------------------------------------------
+
+    /// Mirror of the Go helper's `makeBuffer`: a Knuth-style LCG with
+    /// the same constants that feeds `byte(state >> 33)` per step so
+    /// Rust and Go produce byte-identical buffers from the same seed.
+    fn lcg_buffer(n: usize, seed: u64) -> Vec<u8> {
+        let mut state = seed;
+        let mut out = Vec::with_capacity(n);
+        for _ in 0..n {
+            state = state
+                .wrapping_mul(6_364_136_223_846_793_005)
+                .wrapping_add(1_442_695_040_888_963_407);
+            out.push((state >> 33) as u8);
+        }
+        out
+    }
+
+    fn check_vec(input: &[u8], seed: u64, expected: u64, label: &str) {
+        let got = hash_bytes(input, seed);
+        assert_eq!(
+            got,
+            expected,
+            "{label}: len={} seed={:#x} expected={:#x} got={:#x}",
+            input.len(),
+            seed,
+            expected,
+            got,
+        );
+    }
+
+    #[test]
+    fn cross_validate_go_vectors_small() {
+        // Tiny inputs (<= 16 bytes): all three Go variants produce the
+        // same values, so these also double-check we picked the right
+        // low-length branch.
+        check_vec(&[], 0, 0x0338dc4be2cecdae, "empty/s=0");
+        check_vec(&[], 1, 0xad700ecdf353d5ca, "empty/s=1");
+        check_vec(&[], 0xabcdef0123456789, 0xf5e4283856d3700b, "empty/sSim");
+        check_vec(&[0x42], 0, 0xdf39ad7f42b5c997, "1b");
+        check_vec(&[0x01, 0x02, 0x03], 0, 0x1adbce663d9a75a6, "3b");
+        check_vec(&[0xde, 0xad, 0xbe, 0xef], 0, 0x3faf8cd66e874f03, "4b");
+        check_vec(
+            &[0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07],
+            0,
+            0x882c9ab41aa6037a,
+            "7b",
+        );
+        check_vec(
+            &[0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77],
+            0,
+            0xe4c6bfcfaf1f80d1,
+            "8b",
+        );
+        check_vec(
+            &[
+                0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d,
+                0x0e,
+            ],
+            0,
+            0x8ec6dfea933104bb,
+            "15b",
+        );
+        check_vec(
+            &[
+                0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77, 0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd,
+                0xee, 0xff,
+            ],
+            0,
+            0x1a32399179c20bd9,
+            "16b",
+        );
+        check_vec(
+            &[
+                0x64, 0x65, 0x66, 0x67, 0x68, 0x69, 0x6a, 0x6b, 0x6c, 0x6d, 0x6e, 0x6f, 0x70, 0x71,
+                0x72, 0x73, 0x74,
+            ],
+            0,
+            0xe2416cd4ea7bf627,
+            "17b",
+        );
+    }
+
+    #[test]
+    fn cross_validate_go_vectors_medium_and_large() {
+        // Each entry: (len, go_seed_arg, expected_hash, label).
+        // The buffer is generated by `lcg_buffer(len, 0xcafebabedeadbeef + len)`
+        // which mirrors the helper in `tmp/rapidhash-vectors/main.go`.
+        let cases: &[(usize, u64, u64, &str)] = &[
+            (32, 0, 0xbb5ea522d9542c20, "lcg-32"),
+            (32, 0xabcdef0123456789, 0x40d571bd2796812c, "lcg-32-sSim"),
+            (64, 0, 0x2e51fee0460d578e, "lcg-64"),
+            (64, 0xabcdef0123456789, 0x2411fb1c17179b87, "lcg-64-sSim"),
+            (80, 0, 0x24ffd6329bc85560, "lcg-80"),
+            (80, 0xabcdef0123456789, 0xb6b43e4361bc51f5, "lcg-80-sSim"),
+            (81, 0, 0xd283841d362feb50, "lcg-81"),
+            (81, 0xabcdef0123456789, 0x86c57b5e9ba9e23c, "lcg-81-sSim"),
+            (112, 0, 0x6e5e5d3c246ef77c, "lcg-112"),
+            (112, 0xabcdef0123456789, 0xb813e805b03921d3, "lcg-112-sSim"),
+            (113, 0, 0x8e2c3315965051dc, "lcg-113"),
+            (113, 0xabcdef0123456789, 0xe9f81ac5fb3cd2f0, "lcg-113-sSim"),
+            (128, 0, 0x431a517fbf803d4f, "lcg-128"),
+            (128, 0xabcdef0123456789, 0x1d16f322de3fb7b0, "lcg-128-sSim"),
+            (188, 0, 0xe9cf0dc52eb51f94, "lcg-188"),
+            (188, 0xabcdef0123456789, 0x92595f0113b5ed45, "lcg-188-sSim"),
+            (256, 0, 0xf5439e104fb80782, "lcg-256"),
+            (256, 0xabcdef0123456789, 0x8f15bec5bf5dcaa7, "lcg-256-sSim"),
+            (320, 0, 0x5decab8ff49b9b8a, "lcg-320"),
+            (320, 0xabcdef0123456789, 0xb588bda4b626826a, "lcg-320-sSim"),
+            (321, 0, 0xd48ef9fab69d9034, "lcg-321"),
+            (321, 0xabcdef0123456789, 0xc974b3f67e459c9b, "lcg-321-sSim"),
+            (1024, 0, 0x94614af768e41862, "lcg-1024"),
+            (
+                1024,
+                0xabcdef0123456789,
+                0xb836b6c3c94fe09c,
+                "lcg-1024-sSim",
+            ),
+        ];
+        for &(n, seed, expected, label) in cases {
+            let lcg_seed = 0xcafebabedeadbeefu64.wrapping_add(n as u64);
+            let buf = lcg_buffer(n, lcg_seed);
+            check_vec(&buf, seed, expected, label);
+        }
+    }
+
+    #[test]
+    fn cross_validate_zero_buffers() {
+        // All-zero buffers catch bugs where the state is swallowed by a
+        // leading zero but the tail-read recovers it -- a common failure
+        // mode when porting length-dependent mixes.
+        check_vec(&[0u8; 80], 0, 0xb4e056afb71930da, "zeros-80");
+        check_vec(&[0u8; 188], 0, 0xea799a86d07f38e9, "zeros-188");
+        check_vec(&[0u8; 320], 0, 0x75c7bc181a164136, "zeros-320");
+    }
+
+    #[test]
+    fn cross_validate_u32_slice() {
+        // A representative sorted-index input for our callsite (47
+        // u32s, strided); ensures the u32-slice wrapper byte-matches
+        // the Go output on an LTM-shaped vector.
+        let vals: Vec<u32> = (0u32..47).map(|i| 7 + 13 * i).collect();
+        assert_eq!(vals.len() * 4, 188);
+        let got = hash_u32_slice(&vals, 0xabcdef0123456789);
+        assert_eq!(got, 0xed024dfa5a5c4344, "u32-47 slice");
+    }
+}

--- a/src/simlin-engine/tests/simulate_ltm.rs
+++ b/src/simlin-engine/tests/simulate_ltm.rs
@@ -3494,17 +3494,21 @@ fn test_discovery_cross_validates_with_exhaustive_arrayed() {
     // Discovery mode: find loops post-simulation
     let found = discover_loops_element_level(&project);
 
+    // Materialize the named view once for error messages and per-circuit
+    // iteration; production callers avoid this allocation entirely.
+    let exhaustive_named = exhaustive_circuits.to_named_circuits();
+
     // Both modes should find the same number of loops
     assert_eq!(
         found.len(),
-        exhaustive_circuits.circuits.len(),
+        exhaustive_named.len(),
         "Discovery ({}) should find the same number of loops as exhaustive ({}) \
          for a small arrayed model. \
          Exhaustive circuits: {:?}. \
          Discovery loops: {:?}",
         found.len(),
-        exhaustive_circuits.circuits.len(),
-        exhaustive_circuits.circuits,
+        exhaustive_named.len(),
+        exhaustive_named,
         found
             .iter()
             .map(|l| l
@@ -3518,7 +3522,7 @@ fn test_discovery_cross_validates_with_exhaustive_arrayed() {
 
     // Verify that every exhaustive circuit's node set appears in
     // the discovery results
-    for circuit in &exhaustive_circuits.circuits {
+    for circuit in &exhaustive_named {
         let mut exhaustive_nodes: Vec<String> = circuit.clone();
         exhaustive_nodes.sort();
 


### PR DESCRIPTION
## Summary

Five-commit stack that takes wrld3-03 LTM circuit enumeration from 8.45 GiB / 27 s to 491 MiB / 1.2 s (17x smaller, 22x faster) while preserving all existing LTM semantics. Production `MAX_LTM_CIRCUITS=100_000` path drops from 322 MiB / 569 ms to 33 MiB / ~29 ms.

| Commit | What it does | wrld3-03 uncapped impact |
|---|---|---|
| 7303af3d | SCC-restricted indexed (u32) DFS, skip trivial SCCs | 8.45 GiB → 5.87 GiB, 26.8 s → 2.87 s |
| 2fd4a8f5 | Indexed `LoopCircuitsResult` (names table + `Vec<Vec<u32>>`) | 5.87 GiB → 914 MiB, 2.87 s → 1.73 s |
| 7334e1dd | Hash-fingerprint dedup keys | 914 MiB → 491 MiB, 1.73 s → 1.49 s |
| aa56c5a1 | Johnson 1975 with blocked-set unblocking | 491 MiB (unchanged), 1.49 s → 1.23 s |
| c0e9aa96 | Tech-debt items from LTM critical review | -- |

## Test plan

- [x] `cargo test -p simlin-engine --lib` (3016 passed)
- [x] `cargo test -p simlin-engine --features file_io --test simulate_ltm` (45 passed)
- [x] `cargo test -p simlin-engine --test layout` (includes `test_layout_arms_race`, 31 passed)
- [x] `cargo test -p simlin-engine --test wrld3_ltm_panic` (60 s budget, passes comfortably)
- [x] Johnson-vs-Tiernan equivalence test: fixture corpus + 256-case proptest (both agree)
- [x] Peak RSS measured via `ltm_mem_bench` example on wrld3-03 at budget 100K and unbounded