### PR TITLE
engine: bound module pathway depth by graph node count

### DIFF
--- a/src/simlin-engine/src/ltm.rs
+++ b/src/simlin-engine/src/ltm.rs
@@ -1547,6 +1547,21 @@ impl CausalGraph {
             }
         }
 
+        // The DFS depth cap is the principled upper bound on simple-path
+        // length: a simple path can visit each distinct node at most
+        // once, so N nodes -> at most N entries on the path stack. The
+        // visited set inside `dfs_simple_paths` already enforces simple-
+        // path semantics; the cap's only remaining job is recursion-stack
+        // safety, which N satisfies. The total node set is the union of
+        // the adjacency-list keys (sources) and `has_incoming` (targets),
+        // matching the convention in `detect_output_ports`.
+        let node_count = self
+            .edges
+            .keys()
+            .filter(|node| !has_incoming.contains(*node))
+            .count()
+            + has_incoming.len();
+
         for input_port in self.edges.keys() {
             if input_port == output_name {
                 continue;
@@ -1556,7 +1571,7 @@ impl CausalGraph {
                 continue;
             }
 
-            let raw_paths = self.find_all_simple_paths(input_port, output_name, 20);
+            let raw_paths = self.find_all_simple_paths(input_port, output_name, node_count);
             if raw_paths.is_empty() {
                 continue;
             }
@@ -4721,6 +4736,61 @@ mod tests {
             "Should find pathways with standard 'output' name"
         );
         assert!(pathways.contains_key(&Ident::new("input")));
+    }
+
+    #[test]
+    fn test_enumerate_module_pathways_deeper_than_legacy_cap() {
+        // Build a strictly-linear module graph deeper than the legacy
+        // hard-coded depth=20 truncation: input -> n0 -> n1 -> ... -> n19
+        // -> output, which is 22 distinct nodes and 21 edges.  A simple
+        // path can visit at most N distinct nodes (the visited set
+        // already enforces that), so the principled DFS cap is the
+        // module-graph node count.  A 21-element chain is enough to
+        // prove the old cap is gone without blowing past the per-test
+        // time budget.
+        const INTERMEDIATE_NODES: usize = 20;
+
+        let mut edges: HashMap<Ident<Canonical>, Vec<Ident<Canonical>>> = HashMap::new();
+
+        // input -> n0
+        edges.insert(Ident::new("input"), vec![Ident::new("n0")]);
+        // n_i -> n_{i+1}
+        for i in 0..INTERMEDIATE_NODES - 1 {
+            edges.insert(
+                Ident::new(&format!("n{i}")),
+                vec![Ident::new(&format!("n{}", i + 1))],
+            );
+        }
+        // n_{LAST} -> output
+        edges.insert(
+            Ident::new(&format!("n{}", INTERMEDIATE_NODES - 1)),
+            vec![Ident::new("output")],
+        );
+
+        let graph = CausalGraph {
+            edges,
+            stocks: HashSet::new(),
+            variables: HashMap::new(),
+            module_graphs: HashMap::new(),
+        };
+
+        let pathways = graph.enumerate_module_pathways(&Ident::new("output"));
+        let from_input = pathways.get(&Ident::new("input")).expect(
+            "input -> output pathway should be enumerated regardless of \
+             chain depth; a hardcoded depth-20 cap silently drops chains \
+             this long",
+        );
+        assert_eq!(
+            from_input.len(),
+            1,
+            "expected exactly one simple input -> output pathway"
+        );
+        // 22 nodes -> 21 directed links along the chain.
+        assert_eq!(
+            from_input[0].len(),
+            INTERMEDIATE_NODES + 1,
+            "pathway should traverse every link in the chain"
+        );
     }
 
     /// Construct a three-node reinforcing cycle (A → B → C → A) for

--- a/src/simlin-serve/src/git.rs
+++ b/src/simlin-serve/src/git.rs
@@ -261,10 +261,17 @@ fn run_git(cwd: &Path, args: &[&str]) -> std::io::Result<String> {
     // test suite running inside the project pre-commit hook), the
     // inherited variables would override `cwd` and silently report
     // status against the wrong repository.
+    //
+    // Use `vars_os` + byte-prefix comparison (rather than `vars()` + str
+    // prefix) so a non-UTF-8 env var anywhere in the parent process's
+    // environment cannot crash this code path. Production callers expect
+    // `Unavailable` on probe failure, not a panic. The "GIT_" prefix is
+    // ASCII, so an OsStr containing non-UTF-8 bytes definitionally
+    // cannot start with it.
     let mut cmd = Command::new("git");
     cmd.current_dir(cwd).args(args);
-    for (key, _) in std::env::vars() {
-        if key.starts_with("GIT_") {
+    for (key, _) in std::env::vars_os() {
+        if key.as_encoded_bytes().starts_with(b"GIT_") {
             cmd.env_remove(&key);
         }
     }
@@ -321,11 +328,15 @@ mod tests {
     /// freshly-`git init`'d temp dir, producing surprising failures like
     /// `pathspec 'model.stmx' did not match any files` or invoking the
     /// outer repo's pre-commit hook on the temp commit.
+    ///
+    /// Uses `vars_os` so a non-UTF-8 env var anywhere in the parent process
+    /// cannot panic the test runner; the "GIT_" prefix is ASCII so a
+    /// byte-level comparison is sufficient.
     fn must_git(cwd: &Path, args: &[&str]) -> String {
         let mut cmd = Command::new("git");
         cmd.current_dir(cwd).args(args);
-        for (key, _) in std::env::vars() {
-            if key.starts_with("GIT_") {
+        for (key, _) in std::env::vars_os() {
+            if key.as_encoded_bytes().starts_with(b"GIT_") {
                 cmd.env_remove(&key);
             }
         }

--- a/src/simlin-serve/src/git.rs
+++ b/src/simlin-serve/src/git.rs
@@ -254,7 +254,21 @@ fn build_repo_cache(repo_root: &Path) -> std::io::Result<RepoCache> {
 }
 
 fn run_git(cwd: &Path, args: &[&str]) -> std::io::Result<String> {
-    let output = Command::new("git").current_dir(cwd).args(args).output()?;
+    // Strip inherited `GIT_*` env vars so this command always operates on
+    // the repository at `cwd`. If the simlin-serve binary is launched
+    // from inside another git context (e.g. a developer running it from
+    // a terminal where `GIT_DIR` happens to be set, or the workspace
+    // test suite running inside the project pre-commit hook), the
+    // inherited variables would override `cwd` and silently report
+    // status against the wrong repository.
+    let mut cmd = Command::new("git");
+    cmd.current_dir(cwd).args(args);
+    for (key, _) in std::env::vars() {
+        if key.starts_with("GIT_") {
+            cmd.env_remove(&key);
+        }
+    }
+    let output = cmd.output()?;
     if !output.status.success() {
         return Err(std::io::Error::other(format!(
             "git {} exited with {:?}: {}",
@@ -297,10 +311,25 @@ mod tests {
     use std::process::Command;
 
     /// Run `git` in `cwd` with `args`. Asserts success; returns stdout as String.
+    ///
+    /// Clears every `GIT_*` environment variable inherited from the parent
+    /// before spawning. This matters when the test runs from inside an outer
+    /// `git commit` (e.g. the project pre-commit hook invokes
+    /// `cargo test --workspace`): without sanitization, `GIT_DIR`,
+    /// `GIT_WORK_TREE`, and `GIT_INDEX_FILE` propagate down to the inner
+    /// `git` and cause it to operate on the OUTER repository instead of the
+    /// freshly-`git init`'d temp dir, producing surprising failures like
+    /// `pathspec 'model.stmx' did not match any files` or invoking the
+    /// outer repo's pre-commit hook on the temp commit.
     fn must_git(cwd: &Path, args: &[&str]) -> String {
-        let out = Command::new("git")
-            .current_dir(cwd)
-            .args(args)
+        let mut cmd = Command::new("git");
+        cmd.current_dir(cwd).args(args);
+        for (key, _) in std::env::vars() {
+            if key.starts_with("GIT_") {
+                cmd.env_remove(&key);
+            }
+        }
+        let out = cmd
             .output()
             .unwrap_or_else(|e| panic!("spawn git {args:?}: {e}"));
         if !out.status.success() {

--- a/src/simlin-serve/tests/git_integration.rs
+++ b/src/simlin-serve/tests/git_integration.rs
@@ -27,9 +27,20 @@ fn git_available() -> bool {
 }
 
 fn run_git(cwd: &Path, args: &[&str]) {
-    let status = Command::new("git")
-        .current_dir(cwd)
-        .args(args)
+    // Strip every `GIT_*` env var inherited from the parent: when the
+    // workspace test suite runs from inside an outer `git commit` (the
+    // project pre-commit hook invokes `cargo test --workspace`),
+    // `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` propagate down and
+    // would make this `git` operate on the outer repository instead of
+    // the freshly-initialised temp dir.
+    let mut cmd = Command::new("git");
+    cmd.current_dir(cwd).args(args);
+    for (key, _) in std::env::vars() {
+        if key.starts_with("GIT_") {
+            cmd.env_remove(&key);
+        }
+    }
+    let status = cmd
         .status()
         .unwrap_or_else(|_| panic!("git {} failed to spawn", args.join(" ")));
     assert!(status.success(), "git {} failed", args.join(" "));

--- a/src/simlin-serve/tests/git_integration.rs
+++ b/src/simlin-serve/tests/git_integration.rs
@@ -33,10 +33,14 @@ fn run_git(cwd: &Path, args: &[&str]) {
     // `GIT_DIR`, `GIT_WORK_TREE`, and `GIT_INDEX_FILE` propagate down and
     // would make this `git` operate on the outer repository instead of
     // the freshly-initialised temp dir.
+    //
+    // Iterate `vars_os` rather than `vars()` so a non-UTF-8 env var in the
+    // parent process cannot panic the test runner. The "GIT_" prefix is
+    // ASCII, so a byte-level comparison is sufficient.
     let mut cmd = Command::new("git");
     cmd.current_dir(cwd).args(args);
-    for (key, _) in std::env::vars() {
-        if key.starts_with("GIT_") {
+    for (key, _) in std::env::vars_os() {
+        if key.as_encoded_bytes().starts_with(b"GIT_") {
             cmd.env_remove(&key);
         }
     }


### PR DESCRIPTION
## Summary

- `enumerate_module_pathways` previously called `find_all_simple_paths(input_port, output_name, 20)`, silently dropping internal pathways longer than 20 nodes in deeper user modules and producing incomplete composite link scores.
- Compute the node count of the module graph (union of adjacency-list keys and edge targets) once per call and pass it as the DFS depth cap.
- Added a unit test that builds a 22-node `input -> n0 -> ... -> n19 -> output` chain and verifies the pathway is enumerated end to end. The test fails on the previous code and passes with the fix.

## Why N is the correct bound

A simple path can visit each distinct node at most once, so the number of nodes in the graph is the principled upper bound on simple-path length. The visited set inside `dfs_simple_paths` already enforces simple-path semantics; the cap's only remaining job is recursion-stack safety, which N satisfies exactly.

This branch also includes a cherry-pick of `serve: clear inherited GIT_* env in git probe and tests` (already on `ltm/480-array-reducer-polarity`) so the project pre-commit hook can run `cargo test` without recursive invocation triggered by the `simlin-serve` git probe tests. Without this prep commit, the pre-commit hook fails on a test isolation issue unrelated to the LTM fix.

Fixes #312