### PR TITLE
diagram: don't crash the canvas when a selected element is deleted

### DIFF
--- a/src/diagram/Editor.tsx
+++ b/src/diagram/Editor.tsx
@@ -799,6 +799,19 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       payload: { ident },
     }));
 
+    // Clear the selection now, in the same synchronous block (before any
+    // await) as the view update below, so React batches them into a single
+    // render: no consumer should ever observe a selection that references an
+    // element the view no longer contains. (Clearing it after
+    // `await this.updateView(...)` instead left a window where props.view had
+    // dropped the deleted element but props.selection still pointed at it --
+    // Canvas.buildSelectionMap now tolerates that, but the state transition
+    // should still be atomic.) The deleteOps above were computed from the
+    // pre-clear selection.
+    this.setState({
+      selection: new Set<number>(),
+    });
+
     if (deleteOps.length > 0) {
       const patch: JsonProjectPatch = {
         models: [{ name: modelName, ops: deleteOps }],
@@ -813,9 +826,6 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     }
 
     await this.updateView({ ...view, elements, nextUid });
-    this.setState({
-      selection: new Set<number>(),
-    });
     this.scheduleSimRun();
   };
 

--- a/src/diagram/drawing/Canvas.tsx
+++ b/src/diagram/drawing/Canvas.tsx
@@ -294,10 +294,21 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
         // When inCreation is undefined the async Editor update hasn't
         // finished yet — skip this transient UID; the next render after
         // Editor.setState will carry the real selection.
-      } else {
-        const e = getOrThrow(elements, uid);
-        selection.set(e.uid, e);
+        continue;
       }
+      const e = elements.get(uid);
+      if (e === undefined) {
+        // The selection can transiently reference an element that has just
+        // been removed from the view (e.g. dropping a connector's arrowhead
+        // off-canvas deletes it): Editor updates the view and clears the
+        // selection in separate setState calls, so there is a render in
+        // between where props.view no longer has the element but
+        // props.selection still does. Skip it rather than crashing the whole
+        // canvas; the next render after the selection-clear lands is
+        // consistent. (Same rationale as the inCreationUid case above.)
+        continue;
+      }
+      selection.set(e.uid, e);
     }
     return selection;
   }

--- a/src/diagram/tests/build-selection-map.test.ts
+++ b/src/diagram/tests/build-selection-map.test.ts
@@ -58,4 +58,23 @@ describe('Canvas.buildSelectionMap', () => {
     expect(result.size).toBe(1);
     expect(result.get(1)).toBe(aux1);
   });
+
+  it('skips a selected UID that is no longer present in elements (async race after delete)', () => {
+    // Reproduces the white-screen crash: when a selected connector is deleted,
+    // Editor updates the view (removing the connector) before clearing the
+    // selection, so there is a render where props.selection still references
+    // the now-missing element. buildSelectionMap must not throw on it.
+    const props = { selection: new Set([1, 13, 2]) } as CanvasProps;
+    const result = Canvas.buildSelectionMap(props, elements, undefined);
+    expect(result.size).toBe(2);
+    expect(result.get(1)).toBe(aux1);
+    expect(result.get(2)).toBe(aux2);
+    expect(result.has(13)).toBe(false);
+  });
+
+  it('returns an empty map when every selected UID is missing from elements', () => {
+    const props = { selection: new Set([13, 14]) } as CanvasProps;
+    const result = Canvas.buildSelectionMap(props, elements, undefined);
+    expect(result.size).toBe(0);
+  });
 });


### PR DESCRIPTION
## Bug

In the reliability default project, clicking the arrowhead of the connector from `available developers for product work` → `changes`, dragging it off the `changes` flow, and releasing turns the screen white with:

```
Uncaught Error: Missing key: 13
    at getOrThrow (collections.ts:45)
    at Canvas.buildSelectionMap (Canvas.tsx:298)
    at Canvas.renderInitAndCache (Canvas.tsx:820)
    at Canvas.render (Canvas.tsx:2331)
```

## Root cause

Dropping a connector's arrowhead with no valid target under it hits the delete path (`onDeleteSelection`). `Editor.handleSelectionDelete` then updated the view (removing the connector) *before* clearing the selection — they're separate `setState` calls — so there was a render where `props.view` no longer contained the connector but `props.selection` still referenced its UID. `Canvas.buildSelectionMap` resolved every selected UID through `getOrThrow`, threw `Missing key: 13`, and React turned that into a blank screen.

## Fix

- `Canvas.buildSelectionMap` now *skips* selected UIDs that aren't in the elements map instead of throwing — the same rationale (and the same `continue`-and-move-on shape) as the existing `inCreationUid` skip: the selection can transiently lag the view across async Editor updates, and a stale reference shouldn't take down the whole canvas.
- `Editor.handleSelectionDelete` now clears the selection in the same synchronous block as the view update, so the two land in one React batch and the transient state never occurs at all. The delete ops are still computed from the pre-clear selection.

## Tests

`src/diagram/tests/build-selection-map.test.ts` gains cases for a stale selected UID (one not in the elements map) and an all-stale selection — both formerly threw `Missing key`. Full pre-commit suite passes.