### PR TITLE
diagram: treat sub-threshold pointer wobble as a click, not a drag

### DIFF
--- a/src/diagram/drawing/Canvas.tsx
+++ b/src/diagram/drawing/Canvas.tsx
@@ -48,7 +48,7 @@ import { Module, moduleBounds, moduleContains, ModuleProps } from './Module';
 import { anyModuleHasModelReference } from '../module-warning';
 import { CustomElement } from './SlateEditor';
 import { Stock, stockBounds, stockContains, StockHeight, StockProps, StockWidth } from './Stock';
-import { shouldShowVariableDetails } from './pointer-utils';
+import { isDragMovement, shouldShowVariableDetails } from './pointer-utils';
 import {
   computeMouseDownSelection,
   computeMouseUpSelection,
@@ -896,6 +896,7 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
     const showDetails = shouldShowVariableDetails(
       this.selectionCenterOffset !== undefined,
       this.state.moveDelta,
+      this.props.view.zoom,
       this.state.isMovingArrow,
       this.state.isMovingSource,
       this.state.isMovingLabel,
@@ -907,8 +908,7 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
     // without modifier, we deferred the selection change to allow group drag.
     // Now on mouseUp, if no drag occurred, collapse to the single element.
     if (this.deferredSingleSelectUid !== undefined) {
-      const didDrag =
-        this.state.moveDelta !== undefined && (this.state.moveDelta.x !== 0 || this.state.moveDelta.y !== 0);
+      const didDrag = isDragMovement(this.state.moveDelta, this.props.view.zoom);
       const newSel = computeMouseUpSelection(this.deferredSingleSelectUid, didDrag);
       const wasDeferredText = this.deferredIsText;
       this.deferredSingleSelectUid = undefined;
@@ -974,7 +974,12 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
           // we do weird one off things in this codepath, so exit early
           return;
         } else if (!this.state.isMovingArrow && !this.state.isMovingSource) {
-          this.props.onMoveSelection(delta, arcPoint, this.state.draggingSegmentIndex);
+          // A sub-threshold pointer wobble during a click is not a drag: don't
+          // nudge the element. shouldShowVariableDetails (which applies the
+          // same threshold) will open the details panel for it instead.
+          if (isDragMovement(delta, this.props.view.zoom)) {
+            this.props.onMoveSelection(delta, arcPoint, this.state.draggingSegmentIndex);
+          }
         } else {
           const element = this.getElementByUid(only(this.props.selection));
           let foundInvalidTarget = false;
@@ -991,7 +996,8 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
             this.props.onAttachLink(linkToAttach, defined(validTarget.ident));
           } else if (element.type === 'flow') {
             // don't create a flow stacked on top of 2 clouds due to a misclick
-            if (this.state.moveDelta.x === 0 && this.state.moveDelta.y === 0 && this.state.inCreation) {
+            // (a click that wobbled a pixel is still a misclick, not a drag)
+            if (!isDragMovement(this.state.moveDelta, this.props.view.zoom) && this.state.inCreation) {
               this.clearPointerState();
               return;
             }

--- a/src/diagram/drawing/pointer-utils.ts
+++ b/src/diagram/drawing/pointer-utils.ts
@@ -5,22 +5,49 @@
 import type { Point } from './common';
 
 /**
+ * A pointerdown→pointerup whose cursor wobbled less than this many *screen*
+ * pixels is a click, not a drag. Physical trackpad/mouse clicks routinely
+ * move a pixel or two as the button is pressed and released, and touch taps
+ * move even more; treating that jitter as a drag both nudges the element and
+ * (because dragging suppresses it) leaves the variable-details panel closed.
+ */
+export const ClickDragThresholdPx = 5;
+
+/**
+ * Whether a pointer move is far enough to count as a drag rather than the
+ * incidental jitter of a click.
+ *
+ * `moveDelta` is in model/canvas coordinates (screen pixels divided by the
+ * view zoom), so we multiply by `zoom` to compare against a fixed
+ * screen-pixel threshold: the user moves a finger/mouse in screen space, so
+ * the same model-coord delta should count as a drag when zoomed in and as
+ * jitter when zoomed far out.
+ */
+export function isDragMovement(moveDelta: Point | undefined, zoom: number): boolean {
+  if (moveDelta === undefined) {
+    return false;
+  }
+  return Math.hypot(moveDelta.x, moveDelta.y) * zoom >= ClickDragThresholdPx;
+}
+
+/**
  * Determines whether to show variable details panel after a pointer interaction.
  *
  * We only want to show details on a pure click on an element body - not when
  * dragging elements, clicking arrowheads/sources (which are for repositioning),
- * or clicking on empty canvas.
+ * or clicking on empty canvas. A sub-threshold pointer wobble during a click
+ * still counts as a click (see `isDragMovement`).
  */
 export function shouldShowVariableDetails(
   hadSelection: boolean,
   moveDelta: Point | undefined,
+  zoom: number,
   isMovingArrow: boolean,
   isMovingSource: boolean,
   isMovingLabel: boolean,
 ): boolean {
-  const hadMovement = moveDelta !== undefined && (moveDelta.x !== 0 || moveDelta.y !== 0);
   if (!hadSelection) return false;
-  if (hadMovement) return false;
+  if (isDragMovement(moveDelta, zoom)) return false;
   if (isMovingArrow || isMovingSource) return false;
   if (isMovingLabel) return false;
   return true;

--- a/src/diagram/tests/pointer-utils.test.ts
+++ b/src/diagram/tests/pointer-utils.test.ts
@@ -2,114 +2,89 @@
 // Use of this source code is governed by the Apache License,
 // Version 2.0, that can be found in the LICENSE file.
 
-import { shouldShowVariableDetails } from '../drawing/pointer-utils';
+import { ClickDragThresholdPx, isDragMovement, shouldShowVariableDetails } from '../drawing/pointer-utils';
+
+describe('isDragMovement', () => {
+  it('is false for an undefined delta (no pointer move at all)', () => {
+    expect(isDragMovement(undefined, 1)).toBe(false);
+  });
+
+  it('is false for a zero delta', () => {
+    expect(isDragMovement({ x: 0, y: 0 }, 1)).toBe(false);
+  });
+
+  it('is false for sub-threshold jitter at zoom 1', () => {
+    // a click commonly wobbles a pixel or two -- not a drag
+    expect(isDragMovement({ x: 1, y: 1 }, 1)).toBe(false);
+    expect(isDragMovement({ x: ClickDragThresholdPx - 0.5, y: 0 }, 1)).toBe(false);
+  });
+
+  it('is true once the move reaches the threshold at zoom 1', () => {
+    expect(isDragMovement({ x: ClickDragThresholdPx, y: 0 }, 1)).toBe(true);
+    expect(isDragMovement({ x: 50, y: 0 }, 1)).toBe(true);
+  });
+
+  it('measures the threshold in screen pixels, not model units', () => {
+    // moveDelta is in model coords (screen px / zoom). At 4x zoom a 2-unit
+    // model delta is 8 screen px -- a real drag. The same 2-unit delta at
+    // 0.5x zoom is only 1 screen px -- jitter.
+    const delta = { x: 2, y: 0 };
+    expect(isDragMovement(delta, 4)).toBe(true);
+    expect(isDragMovement(delta, 0.5)).toBe(false);
+  });
+
+  it('uses Euclidean distance, not per-axis', () => {
+    // each axis is below threshold but the combined move is not
+    const half = (ClickDragThresholdPx / Math.SQRT2) + 0.1;
+    expect(isDragMovement({ x: half, y: half }, 1)).toBe(true);
+  });
+});
 
 describe('shouldShowVariableDetails', () => {
-  it('returns true for a click on element body', () => {
-    expect(
-      shouldShowVariableDetails(
-        true, // hadSelection
-        undefined, // moveDelta
-        false, // isMovingArrow
-        false, // isMovingSource
-        false, // isMovingLabel
-      ),
-    ).toBe(true);
+  it('returns true for a click on element body (no pointer move)', () => {
+    expect(shouldShowVariableDetails(true, undefined, 1, false, false, false)).toBe(true);
   });
 
   it('returns true when moveDelta is zero', () => {
-    expect(
-      shouldShowVariableDetails(
-        true, // hadSelection
-        { x: 0, y: 0 }, // moveDelta
-        false, // isMovingArrow
-        false, // isMovingSource
-        false, // isMovingLabel
-      ),
-    ).toBe(true);
+    expect(shouldShowVariableDetails(true, { x: 0, y: 0 }, 1, false, false, false)).toBe(true);
   });
 
-  it('returns false when dragging an element', () => {
-    expect(
-      shouldShowVariableDetails(
-        true, // hadSelection
-        { x: 1, y: 1 }, // moveDelta
-        false, // isMovingArrow
-        false, // isMovingSource
-        false, // isMovingLabel
-      ),
-    ).toBe(false);
+  it('returns true when the move is only incidental click jitter', () => {
+    // regression: a stock click that wobbled a pixel used to leave the
+    // details panel closed (the deselect/reselect-fixes-it bug)
+    expect(shouldShowVariableDetails(true, { x: 1, y: 1 }, 1, false, false, false)).toBe(true);
+    expect(shouldShowVariableDetails(true, { x: 2, y: 0 }, 1, false, false, false)).toBe(true);
+  });
+
+  it('returns false when actually dragging an element', () => {
+    expect(shouldShowVariableDetails(true, { x: 50, y: 50 }, 1, false, false, false)).toBe(false);
+  });
+
+  it('returns false when a small model-coord move is a real drag at high zoom', () => {
+    expect(shouldShowVariableDetails(true, { x: 3, y: 0 }, 4, false, false, false)).toBe(false);
   });
 
   it('returns false when dragging an arrowhead', () => {
-    expect(
-      shouldShowVariableDetails(
-        true, // hadSelection
-        { x: 4, y: 2 }, // moveDelta
-        true, // isMovingArrow
-        false, // isMovingSource
-        false, // isMovingLabel
-      ),
-    ).toBe(false);
+    expect(shouldShowVariableDetails(true, { x: 40, y: 20 }, 1, true, false, false)).toBe(false);
   });
 
   it('returns false when dragging a source', () => {
-    expect(
-      shouldShowVariableDetails(
-        true, // hadSelection
-        { x: 2, y: 4 }, // moveDelta
-        false, // isMovingArrow
-        true, // isMovingSource
-        false, // isMovingLabel
-      ),
-    ).toBe(false);
+    expect(shouldShowVariableDetails(true, { x: 20, y: 40 }, 1, false, true, false)).toBe(false);
   });
 
   it('returns false when dragging a label', () => {
-    expect(
-      shouldShowVariableDetails(
-        true, // hadSelection
-        undefined, // moveDelta
-        false, // isMovingArrow
-        false, // isMovingSource
-        true, // isMovingLabel
-      ),
-    ).toBe(false);
+    expect(shouldShowVariableDetails(true, undefined, 1, false, false, true)).toBe(false);
   });
 
   it('returns false when clicking on empty canvas', () => {
-    expect(
-      shouldShowVariableDetails(
-        false, // hadSelection
-        undefined, // moveDelta
-        false, // isMovingArrow
-        false, // isMovingSource
-        false, // isMovingLabel
-      ),
-    ).toBe(false);
+    expect(shouldShowVariableDetails(false, undefined, 1, false, false, false)).toBe(false);
   });
 
   it('returns false when clicking on arrowhead without movement', () => {
-    expect(
-      shouldShowVariableDetails(
-        true, // hadSelection
-        undefined, // moveDelta
-        true, // isMovingArrow
-        false, // isMovingSource
-        false, // isMovingLabel
-      ),
-    ).toBe(false);
+    expect(shouldShowVariableDetails(true, undefined, 1, true, false, false)).toBe(false);
   });
 
   it('returns false when clicking on source without movement', () => {
-    expect(
-      shouldShowVariableDetails(
-        true, // hadSelection
-        undefined, // moveDelta
-        false, // isMovingArrow
-        true, // isMovingSource
-        false, // isMovingLabel
-      ),
-    ).toBe(false);
+    expect(shouldShowVariableDetails(true, undefined, 1, false, true, false)).toBe(false);
   });
 });


### PR DESCRIPTION
## Bug

Sometimes clicking a stock shows its name in the "Find in Model" box but doesn't open the variable-details panel; deselecting and reselecting often fixes it.

## Root cause

`shouldShowVariableDetails` (added so the panel doesn't pop open when you *drag* an element) classified *any* nonzero pointer movement between pointerdown and pointerup as a drag. Physical trackpad/mouse clicks — and touch taps especially — routinely move a pixel or two, so on those clicks the panel was suppressed (and the element nudged a hair). "Deselect and reselect often works" because the next click happens to be perfectly still.

## Fix

Introduce a screen-pixel drag threshold — `isDragMovement` / `ClickDragThresholdPx` in `pointer-utils.ts` — and apply it consistently for:

- opening the variable-details panel (`shouldShowVariableDetails`),
- the deferred-single-select "did the user drag?" check,
- deciding whether to commit an element move (`onMoveSelection`),
- the flow-creation misclick guard.

`moveDelta` is in model coordinates, so the threshold is scaled by the view zoom — the click-vs-drag feel is the same screen distance at any zoom level. A pure click also no longer kicks off a wasted optimistic-view round-trip.

## Tests

`src/diagram/tests/pointer-utils.test.ts` is expanded: `isDragMovement` (zero/sub-threshold/at-threshold, zoom scaling, Euclidean distance) and `shouldShowVariableDetails` (incidental jitter still opens the panel; a real drag, or a small model-coord move at high zoom, doesn't). Full pre-commit suite passes.

Note: this changes the signature of `shouldShowVariableDetails` (adds a `zoom` argument).