### PR TITLE
diagram, engine: exact equation-preview click-to-caret mapping via source-range annotations

### DIFF
--- a/src/diagram/VariableDetails.tsx
+++ b/src/diagram/VariableDetails.tsx
@@ -162,9 +162,9 @@ function collectRenderedGlyphs(root: Element): RenderedGlyph[] {
   return glyphs;
 }
 
-// Parse a `data-eqnloc="START_END"` attribute value (emitted by the engine's
-// annotated LaTeX) into a `[start, end)` byte range in the equation text.
-function parseEqnloc(value: string | undefined): readonly [number, number] | undefined {
+// Parse a `data-eqnloc`/`data-oploc` attribute value ("START_END", emitted by
+// the engine's annotated LaTeX) into a `[start, end)` byte range.
+function parseLocAttr(value: string | undefined): readonly [number, number] | undefined {
   if (value === undefined) {
     return undefined;
   }
@@ -174,10 +174,11 @@ function parseEqnloc(value: string | undefined): readonly [number, number] | und
 
 // Map a click on the equation preview to a caret offset in `equationStr`.
 // Primary path: find the innermost source-annotated span the click landed in
-// (`data-eqnloc`) and resolve the click within it. Fallback: the rendered
-// LaTeX has no annotations (engine produced none; preview shows raw text), so
-// reconstruct from the glyph boxes -- or, if KaTeX rendered nothing
-// measurable, a coarse proportional mapping over the preview's content box.
+// (`data-eqnloc` for a syntax node, `data-oploc` for an operator gap) and
+// resolve the click within it. Fallback: the rendered LaTeX has no annotations
+// (engine produced none; preview shows raw text), so reconstruct from the
+// glyph boxes -- or, if KaTeX rendered nothing measurable, a coarse
+// proportional mapping over the preview's content box.
 function caretOffsetForPreviewClick(
   host: HTMLElement,
   clicked: Element | null,
@@ -185,12 +186,13 @@ function caretOffsetForPreviewClick(
   clientY: number,
   equationStr: string,
 ): number {
-  const annotated = clicked?.closest('[data-eqnloc]') ?? null;
+  const annotated = clicked?.closest('[data-eqnloc],[data-oploc]') ?? null;
   if (annotated instanceof HTMLElement && host.contains(annotated)) {
-    const range = parseEqnloc(annotated.dataset.eqnloc);
+    const isOperatorGap = annotated.dataset.oploc !== undefined;
+    const range = parseLocAttr(isOperatorGap ? annotated.dataset.oploc : annotated.dataset.eqnloc);
     if (range) {
       const glyphs = collectRenderedGlyphs(annotated);
-      return caretOffsetWithinSpan(glyphs, clientX, clientY, equationStr, range[0], range[1]);
+      return caretOffsetWithinSpan(glyphs, clientX, clientY, equationStr, range[0], range[1], isOperatorGap);
     }
   }
   const glyphs = collectRenderedGlyphs(host);

--- a/src/diagram/VariableDetails.tsx
+++ b/src/diagram/VariableDetails.tsx
@@ -26,6 +26,7 @@ import { defined, Series } from '@simlin/core/common';
 import { at } from '@simlin/core/collections';
 import { plainDeserialize, plainSerialize } from './drawing/common';
 import { CustomElement, FormattedText, CustomEditor } from './drawing/SlateEditor';
+import { caretOffsetForClick, RenderedGlyph } from './equation-caret';
 import { LookupEditor } from './LookupEditor';
 import { errorCodeDescription } from '@simlin/engine';
 
@@ -123,6 +124,36 @@ function highlightErrors(
 
 // LaTeX provided by engine (Ast.to_latex); keep trivial passthrough fallback
 const passthroughLatex = (s: string) => s;
+
+// Walk the rendered KaTeX subtree of `host` (the equation preview <div>) and
+// return each visible glyph with its on-screen box. KaTeX often packs several
+// characters into a single span, so each character is measured with a
+// one-character Range. Only the `.katex-html` render tree is walked: the
+// MathML accessibility mirror (`.katex-mathml`) is clipped to a 1px box and
+// would yield bogus rects. This is the imperative-shell counterpart to the
+// pure caret-mapping logic in equation-caret.ts.
+function collectRenderedGlyphs(host: HTMLElement): RenderedGlyph[] {
+  const glyphs: RenderedGlyph[] = [];
+  const htmlTree = host.querySelector('.katex-html');
+  if (!(htmlTree instanceof HTMLElement)) {
+    return glyphs;
+  }
+  const walker = document.createTreeWalker(htmlTree, NodeFilter.SHOW_TEXT);
+  for (let node = walker.nextNode(); node !== null; node = walker.nextNode()) {
+    const text = node.nodeValue ?? '';
+    for (let i = 0; i < text.length; i++) {
+      const range = document.createRange();
+      range.setStart(node, i);
+      range.setEnd(node, i + 1);
+      const r = range.getBoundingClientRect();
+      if (r.width <= 0 || r.height <= 0) {
+        continue;
+      }
+      glyphs.push({ char: text[i], left: r.left, right: r.right, top: r.top, bottom: r.bottom });
+    }
+  }
+  return glyphs;
+}
 
 export class VariableDetails extends React.PureComponent<VariableDetailsProps, VariableDetailsState> {
   private _latexRequestId = 0;
@@ -438,362 +469,28 @@ export class VariableDetails extends React.PureComponent<VariableDetailsProps, V
     );
   }
 
-  handlePreviewClick = (e: React.MouseEvent<HTMLDivElement>, equationStr: string) => {
+  handlePreviewClick = (e: React.MouseEvent<HTMLDivElement>, equationStr: string): void => {
     const target = e.currentTarget as HTMLElement;
-    const rect = target.getBoundingClientRect();
-    const style = window.getComputedStyle(target);
-    const padLeft = parseFloat(style.paddingLeft || '0');
-    const padRight = parseFloat(style.paddingRight || '0');
-    const usableWidth = Math.max(1, rect.width - padLeft - padRight);
-    const clickX = Math.max(0, Math.min(usableWidth, e.clientX - rect.left - padLeft));
+    const glyphs = collectRenderedGlyphs(target);
 
-    // Map click to text offset.
-    // Strategy:
-    // 1) Try to resolve the specific KaTeX glyph under the click, map it to the matching ASCII
-    //    character, and place the caret immediately after the closest matching occurrence in the
-    //    ASCII equation (by proximity to the coarse proportional index).
-    // 2) Otherwise, prefer proportional mapping over KaTeX content width.
-    // 3) Fall back to a hidden monospace ghost with per-char spans and midpoints.
-    // 4) Finally fall back to plain proportional mapping over the container width.
-    const computeOffset = (): number => {
-      // Utility: map KaTeX glyph to ASCII char
-      const mapGlyphToAscii = (ch: string): string => {
-        if (ch === '\u00b7' || ch === '\u00d7' || ch === '\u22c5') return '*';
-        if (ch === '\u2212') return '-';
-        return ch;
-      };
-
-      // Build a linear list of KaTeX glyphs with positions to enable context disambiguation
-      const buildGlyphs = () => {
-        const list: { raw: string; ascii: string; left: number; right: number; top: number; bottom: number }[] = [];
-        const root = target.querySelector('.katex') as HTMLElement | null;
-        if (!root) return { list, contentRect: target.getBoundingClientRect() };
-        const html = target.querySelector('.katex .katex-html, .katex-display .katex-html') as HTMLElement | null;
-        const contentRect = (html ?? root).getBoundingClientRect();
-        try {
-          const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
-          while (walker.nextNode()) {
-            const tn = walker.currentNode;
-            const text: string = tn?.nodeValue ?? '';
-            for (let i = 0; i < text.length; i++) {
-              const rng = document.createRange();
-              rng.setStart(tn, i);
-              rng.setEnd(tn, i + 1);
-              const r = rng.getBoundingClientRect();
-              if (!r || r.width <= 0 || r.height <= 0) continue;
-              const raw = text[i];
-              const ascii = mapGlyphToAscii(raw);
-              list.push({ raw, ascii, left: r.left, right: r.right, top: r.top, bottom: r.bottom });
-            }
-          }
-        } catch {
-          // ignore
-        }
-        try {
-          console.log('[CaretMap] glyphs', {
-            count: list.length,
-            ascii: list.map((g) => g.ascii).join(''),
-            first20: list
-              .slice(0, 20)
-              .map((g) => g.ascii)
-              .join(''),
-          });
-        } catch {}
-        return { list, contentRect };
-      };
-
-      // Utility: try to find the KaTeX glyph index at click coordinates
-      const glyphIndexAtPoint = (glyphs: ReturnType<typeof buildGlyphs>['list']): number => {
-        // First, exact hit
-        for (let i = 0; i < glyphs.length; i++) {
-          const g = glyphs[i];
-          if (e.clientX >= g.left && e.clientX <= g.right && e.clientY >= g.top && e.clientY <= g.bottom) {
-            try {
-              console.log('[CaretMap] exact glyph hit', { index: i, ascii: g.ascii, raw: g.raw });
-            } catch {}
-            return i;
-          }
-        }
-        // Otherwise nearest on same line (by center distance)
-        let best = -1;
-        let bestDist = Number.POSITIVE_INFINITY;
-        for (let i = 0; i < glyphs.length; i++) {
-          const g = glyphs[i];
-          const cx = (g.left + g.right) / 2;
-          const cy = (g.top + g.bottom) / 2;
-          const dx = Math.abs(e.clientX - cx);
-          const dy = Math.abs(e.clientY - cy);
-          const d = dx + dy * 0.5;
-          if (d < bestDist) {
-            bestDist = d;
-            best = i;
-          }
-        }
-        try {
-          if (best >= 0) {
-            const g = glyphs[best];
-            console.log('[CaretMap] nearest glyph', { index: best, ascii: g.ascii, raw: g.raw, dist: bestDist });
-          } else {
-            console.log('[CaretMap] no glyph found');
-          }
-        } catch {}
-        return best;
-      };
-
-      // Try glyph-based mapping first
-      try {
-        const { list: glyphs, contentRect } = buildGlyphs();
-        if (glyphs.length > 0) {
-          const gidx = glyphIndexAtPoint(glyphs);
-          if (gidx >= 0) {
-            const center = glyphs[gidx].ascii;
-            const prev = gidx > 0 ? glyphs[gidx - 1].ascii : '';
-            const next = gidx + 1 < glyphs.length ? glyphs[gidx + 1].ascii : '';
-            const pattern = (prev + center + next).trim();
-            const len = equationStr.length;
-            // Try word-token based mapping for alphanumeric/underscore sequences
-            const isTokenChar = (ch: string) => /[A-Za-z0-9_]/.test(ch);
-            if (isTokenChar(center)) {
-              let li = gidx;
-              let ri = gidx;
-              while (li - 1 >= 0 && isTokenChar(glyphs[li - 1].ascii)) li--;
-              while (ri + 1 < glyphs.length && isTokenChar(glyphs[ri + 1].ascii)) ri++;
-              const token = glyphs
-                .slice(li, ri + 1)
-                .map((g) => g.ascii)
-                .join('');
-              const posInToken = gidx - li;
-              if (token.length > 1) {
-                // Prefer nearest occurrence of the token to the coarse proportional index
-                const cx = Math.max(0, Math.min(contentRect.width, e.clientX - contentRect.left));
-                const coarse = Math.max(0, Math.min(len, Math.round((cx / Math.max(1, contentRect.width)) * len)));
-                const candidates: number[] = [];
-                let s = 0;
-                for (;;) {
-                  const idx = equationStr.indexOf(token, s);
-                  if (idx === -1) break;
-                  candidates.push(idx);
-                  s = idx + 1;
-                }
-                if (candidates.length > 0) {
-                  let choiceIdx = candidates[0];
-                  let bestDist = Math.abs(choiceIdx - coarse);
-                  for (const c of candidates) {
-                    const d = Math.abs(c - coarse);
-                    if (d < bestDist) {
-                      bestDist = d;
-                      choiceIdx = c;
-                    }
-                  }
-                  try {
-                    console.log('[CaretMap] token match', { token, candidates, choiceIdx, posInToken });
-                  } catch {}
-                  return choiceIdx + posInToken + 1;
-                } else {
-                  try {
-                    console.log('[CaretMap] token not found', { token });
-                  } catch {}
-                }
-              }
-            }
-            // Signature neighbor matching for punctuation/operators/digits (and single-char tokens)
-            const isSigChar = (ch: string) => /[A-Za-z0-9_()*+\-]/.test(ch);
-            const prevSig = (() => {
-              for (let k = gidx - 1; k >= 0; k--) if (isSigChar(glyphs[k].ascii)) return glyphs[k].ascii;
-              return '';
-            })();
-            const nextSig = (() => {
-              for (let k = gidx + 1; k < glyphs.length; k++) if (isSigChar(glyphs[k].ascii)) return glyphs[k].ascii;
-              return '';
-            })();
-            if (center && (prevSig || nextSig)) {
-              const positions: number[] = [];
-              for (let i = 0; i < len; i++) if (equationStr[i] === center) positions.push(i);
-              const matchScore = (idx: number) => {
-                let score = 0;
-                if (prevSig) {
-                  let j = idx - 1;
-                  while (j >= 0 && /\s/.test(equationStr[j])) j--;
-                  if (j >= 0 && equationStr[j] === prevSig) score += 2;
-                }
-                if (nextSig) {
-                  let j = idx + 1;
-                  while (j < len && /\s/.test(equationStr[j])) j++;
-                  if (j < len && equationStr[j] === nextSig) score += 2;
-                }
-                return score;
-              };
-              let bestIdx = -1;
-              let bestScore = -1;
-              for (const p of positions) {
-                const s = matchScore(p);
-                if (s > bestScore) {
-                  bestScore = s;
-                  bestIdx = p;
-                }
-              }
-              if (bestIdx >= 0) {
-                try {
-                  console.log('[CaretMap] sig-neighbor match', { center, prevSig, nextSig, bestIdx, bestScore });
-                } catch {}
-                return bestIdx + 1;
-              }
-              try {
-                console.log('[CaretMap] sig-neighbor no match', { center, prevSig, nextSig, positions });
-              } catch {}
-            }
-
-            // Try contextual match: prev+center+next
-            if (pattern.length >= 2) {
-              const idx = equationStr.indexOf(pattern);
-              if (idx >= 0) {
-                try {
-                  console.log('[CaretMap] context match', { pattern, idx, prev, center, next });
-                } catch {}
-                const centerOffset = prev ? 1 : 0;
-                return idx + centerOffset + 1;
-              }
-              try {
-                console.log('[CaretMap] context not found', { pattern });
-              } catch {}
-            }
-            // Fallback: match just center using nth occurrence by glyph index
-            if (center) {
-              // Count occurrences among glyphs up to this glyph to get the per-char occurrence index
-              let glyphOcc = 0;
-              for (let k = 0; k < gidx; k++) if (glyphs[k].ascii === center) glyphOcc++;
-              let count = -1;
-              for (let i = 0; i < len; i++) {
-                if (equationStr[i] === center) {
-                  count++;
-                  if (count === glyphOcc) {
-                    try {
-                      console.log('[CaretMap] nth occurrence fallback', { center, glyphOcc, index: i });
-                    } catch {}
-                    return i + 1;
-                  }
-                }
-              }
-              try {
-                console.log('[CaretMap] nth occurrence not found', { center, glyphOcc });
-              } catch {}
-            }
-            // Fallback: choose occurrence closest to coarse proportional position
-            const cx = Math.max(0, Math.min(contentRect.width, e.clientX - contentRect.left));
-            const coarse = Math.max(0, Math.min(len, Math.round((cx / Math.max(1, contentRect.width)) * len)));
-            const positions: number[] = [];
-            for (let i = 0; i < len; i++) if (equationStr[i] === center) positions.push(i);
-            if (positions.length > 0) {
-              let choice = positions[0];
-              let bestDist = Math.abs(choice - coarse);
-              for (const p of positions) {
-                const d = Math.abs(p - coarse);
-                if (d < bestDist) {
-                  bestDist = d;
-                  choice = p;
-                }
-              }
-              try {
-                console.log('[CaretMap] coarse fallback', { center, coarse, positions, choice });
-              } catch {}
-              return choice + 1;
-            }
-            try {
-              console.log('[CaretMap] no positions for center', { center });
-            } catch {}
-          }
-        }
-      } catch {
-        // ignore and try next strategy
-      }
-
-      try {
-        // Prefer mapping relative to actual KaTeX content box, ignoring padding.
-        const katexHtml = target.querySelector('.katex .katex-html, .katex-display .katex-html') as HTMLElement | null;
-        if (katexHtml) {
-          const contentRect = katexHtml.getBoundingClientRect();
-          const cx = Math.max(0, Math.min(contentRect.width, e.clientX - contentRect.left));
-          const len = equationStr.length;
-          try {
-            console.log('[CaretMap] proportional over KaTeX content', { width: contentRect.width, cx, len });
-          } catch {}
-          return Math.max(0, Math.min(len, Math.round((cx / Math.max(1, contentRect.width)) * len)));
-        }
-      } catch {
-        // ignore and try ghost mapping
-      }
-
-      // Precise caret mapping via hidden monospace ghost with per-char spans
-      try {
-        const ghost = document.createElement('div');
-        ghost.style.position = 'absolute';
-        ghost.style.left = `${padLeft}px`;
-        ghost.style.top = '0';
-        ghost.style.visibility = 'hidden';
-        ghost.style.whiteSpace = 'pre-wrap';
-        ghost.style.pointerEvents = 'none';
-        ghost.style.width = `${usableWidth}px`;
-        // Match editor font
-        ghost.style.fontFamily = "'Roboto Mono', monospace";
-        // Try to inherit approximate size
-        ghost.style.fontSize = window.getComputedStyle(document.body).fontSize || '16px';
-        target.appendChild(ghost);
-
-        const spans: HTMLSpanElement[] = [];
-        for (let i = 0; i < equationStr.length; i++) {
-          const s = document.createElement('span');
-          s.textContent = equationStr[i];
-          // Ensure each char is measurable
-          s.style.display = 'inline-block';
-          ghost.appendChild(s);
-          spans.push(s);
-        }
-
-        // Build cumulative right edge positions
-        const ghostRect = ghost.getBoundingClientRect();
-        const rights: number[] = [];
-        for (let i = 0; i < spans.length; i++) {
-          const r = spans[i].getBoundingClientRect();
-          rights.push(r.right - ghostRect.left);
-        }
-
-        // Prefer nearest character boundary using midpoints between glyph boxes
-        // left edge for i is rights[i-1] (or 0 for i=0)
-        let idx = spans.length;
-        for (let i = 0; i < spans.length; i++) {
-          const left = i === 0 ? 0 : rights[i - 1];
-          const right = rights[i];
-          const mid = (left + right) / 2;
-          if (clickX < mid) {
-            idx = i;
-            break;
-          }
-          // If past the midpoint, caret should go after this character; keep scanning
-        }
-
-        // Cleanup
-        target.removeChild(ghost);
-        try {
-          console.log('[CaretMap] ghost midpoint idx', { idx });
-        } catch {}
-        return idx;
-      } catch {
-        // Fallback to proportional mapping
-        const len = equationStr.length;
-        try {
-          console.log('[CaretMap] container proportional fallback', { usableWidth, clickX, len });
-        } catch {}
-        return Math.max(0, Math.min(len, Math.round((clickX / usableWidth) * len)));
-      }
-    };
-
-    const offset = computeOffset();
-    try {
-      console.log('[CaretMap] final offset', { offset });
-    } catch {}
+    let offset: number;
+    if (glyphs.length > 0) {
+      offset = caretOffsetForClick(glyphs, e.clientX, e.clientY, equationStr);
+    } else {
+      // KaTeX rendered nothing measurable (rare -- e.g. an empty equation, or
+      // a render error): fall back to a coarse proportional mapping over the
+      // preview's content box.
+      const rect = target.getBoundingClientRect();
+      const style = window.getComputedStyle(target);
+      const padLeft = parseFloat(style.paddingLeft || '0');
+      const padRight = parseFloat(style.paddingRight || '0');
+      const usableWidth = Math.max(1, rect.width - padLeft - padRight);
+      const clickX = Math.max(0, Math.min(usableWidth, e.clientX - rect.left - padLeft));
+      offset = Math.max(0, Math.min(equationStr.length, Math.round((clickX / usableWidth) * equationStr.length)));
+    }
 
     this.setState({ editingEquation: true }, () => {
-      // Focus and set caret after the editor renders
+      // Focus and place the caret once the editable equation editor has rendered.
       requestAnimationFrame(() => {
         try {
           const editor = this.state.equationEditor;
@@ -803,7 +500,7 @@ export class VariableDetails extends React.PureComponent<VariableDetailsProps, V
             focus: { path: [0, 0], offset },
           });
         } catch {
-          // ignore if selection fails; user can click to place caret
+          // ignore if selection fails; the user can click to place the caret
         }
       });
     });

--- a/src/diagram/VariableDetails.tsx
+++ b/src/diagram/VariableDetails.tsx
@@ -26,7 +26,7 @@ import { defined, Series } from '@simlin/core/common';
 import { at } from '@simlin/core/collections';
 import { plainDeserialize, plainSerialize } from './drawing/common';
 import { CustomElement, FormattedText, CustomEditor } from './drawing/SlateEditor';
-import { caretOffsetForClick, RenderedGlyph } from './equation-caret';
+import { caretOffsetForClick, caretOffsetWithinSpan, RenderedGlyph } from './equation-caret';
 import { LookupEditor } from './LookupEditor';
 import { errorCodeDescription } from '@simlin/engine';
 
@@ -122,24 +122,31 @@ function highlightErrors(
   return result;
 }
 
-// LaTeX provided by engine (Ast.to_latex); keep trivial passthrough fallback
+// LaTeX provided by engine (Ast::to_latex, with \htmlData{eqnloc=…} source
+// annotations). When the engine couldn't produce LaTeX, the preview falls back
+// to rendering the raw equation text (a trivial passthrough, no annotations).
 const passthroughLatex = (s: string) => s;
 
-// Walk the rendered KaTeX subtree of `host` (the equation preview <div>) and
-// return each visible glyph with its on-screen box. KaTeX often packs several
-// characters into a single span, so each character is measured with a
-// one-character Range. Only the `.katex-html` render tree is walked: the
-// MathML accessibility mirror (`.katex-mathml`) is clipped to a 1px box and
-// would yield bogus rects. This is the imperative-shell counterpart to the
-// pure caret-mapping logic in equation-caret.ts.
-function collectRenderedGlyphs(host: HTMLElement): RenderedGlyph[] {
+// KaTeX needs `trust` enabled to honor `\htmlData`. Scope it to that one
+// command so a user identifier that smuggled in a `\href`/`\url`/etc. is still
+// rejected; `\htmlData` only emits inert `data-*` attributes.
+const katexTrust = (context: { command: string }): boolean => context.command === '\\htmlData';
+
+// Walk the rendered KaTeX subtree under `root` and return each visible glyph
+// with its on-screen box. KaTeX often packs several characters into one span,
+// so each character is measured with a one-character Range. Text inside the
+// MathML accessibility mirror (`.katex-mathml`, clipped to a 1px box) is
+// skipped -- it would yield bogus rects. This is the imperative-shell
+// counterpart to the pure caret-mapping logic in equation-caret.ts. `root` is
+// either the whole preview <div> (fallback path) or a single
+// `\htmlData{eqnloc=…}` span (annotation path).
+function collectRenderedGlyphs(root: Element): RenderedGlyph[] {
   const glyphs: RenderedGlyph[] = [];
-  const htmlTree = host.querySelector('.katex-html');
-  if (!(htmlTree instanceof HTMLElement)) {
-    return glyphs;
-  }
-  const walker = document.createTreeWalker(htmlTree, NodeFilter.SHOW_TEXT);
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT);
   for (let node = walker.nextNode(); node !== null; node = walker.nextNode()) {
+    if (node.parentElement?.closest('.katex-mathml')) {
+      continue;
+    }
     const text = node.nodeValue ?? '';
     for (let i = 0; i < text.length; i++) {
       const range = document.createRange();
@@ -153,6 +160,50 @@ function collectRenderedGlyphs(host: HTMLElement): RenderedGlyph[] {
     }
   }
   return glyphs;
+}
+
+// Parse a `data-eqnloc="START_END"` attribute value (emitted by the engine's
+// annotated LaTeX) into a `[start, end)` byte range in the equation text.
+function parseEqnloc(value: string | undefined): readonly [number, number] | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+  const m = /^(\d+)_(\d+)$/.exec(value);
+  return m ? [Number(m[1]), Number(m[2])] : undefined;
+}
+
+// Map a click on the equation preview to a caret offset in `equationStr`.
+// Primary path: find the innermost source-annotated span the click landed in
+// (`data-eqnloc`) and resolve the click within it. Fallback: the rendered
+// LaTeX has no annotations (engine produced none; preview shows raw text), so
+// reconstruct from the glyph boxes -- or, if KaTeX rendered nothing
+// measurable, a coarse proportional mapping over the preview's content box.
+function caretOffsetForPreviewClick(
+  host: HTMLElement,
+  clicked: Element | null,
+  clientX: number,
+  clientY: number,
+  equationStr: string,
+): number {
+  const annotated = clicked?.closest('[data-eqnloc]') ?? null;
+  if (annotated instanceof HTMLElement && host.contains(annotated)) {
+    const range = parseEqnloc(annotated.dataset.eqnloc);
+    if (range) {
+      const glyphs = collectRenderedGlyphs(annotated);
+      return caretOffsetWithinSpan(glyphs, clientX, clientY, equationStr, range[0], range[1]);
+    }
+  }
+  const glyphs = collectRenderedGlyphs(host);
+  if (glyphs.length > 0) {
+    return caretOffsetForClick(glyphs, clientX, clientY, equationStr);
+  }
+  const rect = host.getBoundingClientRect();
+  const style = window.getComputedStyle(host);
+  const padLeft = parseFloat(style.paddingLeft || '0');
+  const padRight = parseFloat(style.paddingRight || '0');
+  const usableWidth = Math.max(1, rect.width - padLeft - padRight);
+  const clickX = Math.max(0, Math.min(usableWidth, clientX - rect.left - padLeft));
+  return Math.max(0, Math.min(equationStr.length, Math.round((clickX / usableWidth) * equationStr.length)));
 }
 
 export class VariableDetails extends React.PureComponent<VariableDetailsProps, VariableDetailsState> {
@@ -367,18 +418,11 @@ export class VariableDetails extends React.PureComponent<VariableDetailsProps, V
     let latexHTML = '';
     if (showPreview) {
       try {
-        let latex = this.state.latexEquation ?? passthroughLatex(equationStr);
-        // Hint line breaks after common binary operators and commas for nicer wrapping
-        const insertBreaks = (s: string): string =>
-          s
-            .replace(/\\cdot/g, '\\cdot\\allowbreak{} ')
-            .replace(/\\times/g, '\\times\\allowbreak{} ')
-            .replace(/\+/g, '+\\allowbreak{} ')
-            .replace(/-/g, '-\\allowbreak{} ')
-            .replace(/=/g, '=\\allowbreak{} ')
-            .replace(/,/g, ',\\allowbreak{} ');
-        latex = insertBreaks(latex);
-        latexHTML = katex.renderToString(latex, { throwOnError: false, displayMode: true });
+        const latex = this.state.latexEquation ?? passthroughLatex(equationStr);
+        // `displayMode` so it renders block-style; `trust` (scoped to
+        // \htmlData) so the engine's source-range annotations survive. Long
+        // equations wrap via the .eqnPreview CSS (overflow-wrap: anywhere).
+        latexHTML = katex.renderToString(latex, { throwOnError: false, displayMode: true, trust: katexTrust });
       } catch {
         // fall back to plain text
         latexHTML = '';
@@ -471,23 +515,8 @@ export class VariableDetails extends React.PureComponent<VariableDetailsProps, V
 
   handlePreviewClick = (e: React.MouseEvent<HTMLDivElement>, equationStr: string): void => {
     const target = e.currentTarget as HTMLElement;
-    const glyphs = collectRenderedGlyphs(target);
-
-    let offset: number;
-    if (glyphs.length > 0) {
-      offset = caretOffsetForClick(glyphs, e.clientX, e.clientY, equationStr);
-    } else {
-      // KaTeX rendered nothing measurable (rare -- e.g. an empty equation, or
-      // a render error): fall back to a coarse proportional mapping over the
-      // preview's content box.
-      const rect = target.getBoundingClientRect();
-      const style = window.getComputedStyle(target);
-      const padLeft = parseFloat(style.paddingLeft || '0');
-      const padRight = parseFloat(style.paddingRight || '0');
-      const usableWidth = Math.max(1, rect.width - padLeft - padRight);
-      const clickX = Math.max(0, Math.min(usableWidth, e.clientX - rect.left - padLeft));
-      offset = Math.max(0, Math.min(equationStr.length, Math.round((clickX / usableWidth) * equationStr.length)));
-    }
+    const clicked = e.target instanceof Element ? e.target : null;
+    const offset = caretOffsetForPreviewClick(target, clicked, e.clientX, e.clientY, equationStr);
 
     this.setState({ editingEquation: true }, () => {
       // Focus and place the caret once the editable equation editor has rendered.

--- a/src/diagram/equation-caret.ts
+++ b/src/diagram/equation-caret.ts
@@ -33,11 +33,16 @@ export interface RenderedGlyph {
   readonly bottom: number;
 }
 
-/** Map a rendered glyph back to the ASCII character it stands for in the
- *  source equation. KaTeX renders `*` (multiplication) as `\cdot`/`\times`,
- *  binary `-` as a true minus sign, and `not` as `\neg`; everything else --
- *  letters, digits, parentheses, `+`, comparison operators -- renders as the
- *  same character that appears in the source. */
+/** Map a rendered glyph back to the source text it stands for. KaTeX renders
+ *  `*` (multiplication) as `\cdot`/`\times` and binary `-` as a true minus
+ *  sign, so those map back to single ASCII operators. The engine's
+ *  `Ast::to_latex` renders the `not` keyword (XMILE spells logical negation as
+ *  the word `NOT`, not `!` -- `!` isn't a token in Simlin equations at all)
+ *  as `\neg`, which KaTeX draws as a `¬` glyph; that one glyph stands for the
+ *  whole three-letter keyword, so it maps to the string `'not'` and the
+ *  alignment consumes that many source characters. Everything else -- letters,
+ *  digits, parentheses, `+`, comparison operators -- renders as the same
+ *  character that appears in the source and passes through unchanged. */
 export function glyphToAscii(ch: string): string {
   switch (ch) {
     case '·': // MIDDLE DOT
@@ -46,8 +51,8 @@ export function glyphToAscii(ch: string): string {
       return '*';
     case '−': // MINUS SIGN           (binary -)
       return '-';
-    case '¬': // NOT SIGN             (\neg)
-      return '!';
+    case '¬': // NOT SIGN             (\neg, i.e. the `not` keyword)
+      return 'not';
     default:
       return ch;
   }
@@ -68,12 +73,15 @@ const isWhitespace = (ch: string | undefined): boolean => ch !== undefined && /\
  * is the end of the equation). The result is monotonically non-decreasing.
  *
  * The match is case-insensitive (identifiers are lower-cased in LaTeX) and
- * skips whitespace in the source (the rendered math drops it). Where a glyph
- * has no source counterpart at the current position the alignment first tries
- * to resync by skipping up to `MAX_RESYNC_SKIP` source characters (the `/`
- * of a fraction, the `^` of an exponent); failing that it treats the glyph as
- * "extra" -- rendered but absent from the source, e.g. a parenthesis KaTeX
- * added for precedence -- and lets it occupy no source characters.
+ * skips whitespace in the source (the rendered math drops it). A glyph can
+ * stand for more than one source character -- the `¬` glyph stands for the
+ * `not` keyword (see `glyphToAscii`) -- in which case the whole substring is
+ * matched and consumed. Where a glyph has no source counterpart at the current
+ * position the alignment first tries to resync by skipping up to
+ * `MAX_RESYNC_SKIP` source characters (the `/` of a fraction, the `^` of an
+ * exponent); failing that it treats the glyph as "extra" -- rendered but
+ * absent from the source, e.g. a parenthesis KaTeX added for precedence -- and
+ * lets it occupy no source characters.
  */
 export function alignGlyphsToSource(glyphs: readonly RenderedGlyph[], equationStr: string): number[] {
   const n = glyphs.length;
@@ -92,9 +100,9 @@ export function alignGlyphsToSource(glyphs: readonly RenderedGlyph[], equationSt
       continue;
     }
 
-    if (ei < len && eqLower[ei] === g) {
+    if (eqLower.startsWith(g, ei)) {
       mapping[gi] = ei;
-      ei++;
+      ei += g.length;
       continue;
     }
 
@@ -105,14 +113,14 @@ export function alignGlyphsToSource(glyphs: readonly RenderedGlyph[], equationSt
     for (let step = 0; step < MAX_RESYNC_SKIP && probe < len; step++) {
       probe++;
       while (probe < len && isWhitespace(equationStr[probe])) probe++;
-      if (probe < len && eqLower[probe] === g) {
+      if (probe < len && eqLower.startsWith(g, probe)) {
         resynced = probe;
         break;
       }
     }
     if (resynced >= 0) {
       mapping[gi] = resynced;
-      ei = resynced + 1;
+      ei = resynced + g.length;
       continue;
     }
 

--- a/src/diagram/equation-caret.ts
+++ b/src/diagram/equation-caret.ts
@@ -5,22 +5,22 @@
 // Mapping a click on the rendered (KaTeX) equation preview back to a caret
 // offset in the editable equation text.
 //
-// The rendered equation is a *transformed* view of the source text -- `*`
-// becomes `\cdot`, `/` becomes a fraction, identifiers are lower-cased,
-// whitespace is dropped, etc. -- so we can't read the source offset directly
-// off the DOM. This module takes the glyphs the preview rendered (extracted by
-// the imperative shell, with their on-screen boxes) and:
+// Primary path: the engine's `Ast::to_latex` (used by the FFI) wraps every
+// node in a `\htmlData{eqnloc=START_END}` annotation carrying the source byte
+// range it covers, so KaTeX renders each atom inside a span with a
+// `data-eqnloc` attribute. The click handler finds the innermost annotated
+// span under the cursor and maps the click within it (`caretOffsetWithinSpan`)
+// -- this is exact rather than heuristic.
 //
-//   1. finds the glyph *boundary* nearest the click in 2D (so a click in the
-//      whitespace around a small operator glyph snaps to the side of that
-//      operator instead of landing inside an adjacent identifier, and so
-//      clicks on a wrapped line work);
-//   2. aligns the rendered glyph string to the source text -- character for
-//      character in the common case, with a little slack for the few places
-//      they disagree -- to translate that boundary into a source offset.
+// Fallback path: when the rendered LaTeX has no annotations (e.g. the engine
+// couldn't produce LaTeX and the UI rendered the raw equation text instead),
+// `caretOffsetForClick` reconstructs the mapping from the glyph boxes: it
+// finds the nearest glyph boundary in 2D, then aligns the rendered glyph
+// string to the source text -- character for character in the common case,
+// with a little slack for the few places they disagree.
 //
 // The functions here are pure and DOM-free; `VariableDetails.tsx` owns the DOM
-// walk that produces `RenderedGlyph`s.
+// walk that produces `RenderedGlyph`s and reads the `data-eqnloc` attributes.
 
 /** A single glyph from the rendered equation, with its on-screen bounding box
  *  in client (viewport) coordinates -- the same space as a `MouseEvent`'s
@@ -132,31 +132,20 @@ export function alignGlyphsToSource(glyphs: readonly RenderedGlyph[], equationSt
 }
 
 /**
- * Given the glyphs of a rendered equation preview (in DOM/reading order), a
- * click point in client coordinates, and the source equation text, return the
- * character offset in `equationStr` where the caret should be placed.
+ * Find the caret boundary nearest a click among `glyphs` (in DOM/reading
+ * order), returning an index in `[0, glyphs.length]` -- boundary `k` sits
+ * "before glyph k" / "after glyph k-1".
  *
- * Returns 0 when there are no glyphs (the caller is expected to fall back to a
- * coarse proportional mapping in that case, since it needs the DOM rect).
+ * Each boundary has up to two visual points: the left edge of glyph `k` and
+ * the right edge of glyph `k-1`. Those coincide except across a KaTeX line
+ * break, where the same logical boundary appears at the end of one line and
+ * the start of the next; taking whichever point is closest in 2D handles both
+ * the wrapped-line case and a click in the whitespace around a small operator
+ * glyph (it snaps to the operator's side rather than into an adjacent atom).
+ * On a tie the lower index wins, so a click dead-centre on a glyph lands
+ * before it.
  */
-export function caretOffsetForClick(
-  glyphs: readonly RenderedGlyph[],
-  clickX: number,
-  clickY: number,
-  equationStr: string,
-): number {
-  const len = equationStr.length;
-  if (glyphs.length === 0) {
-    return 0;
-  }
-
-  // A caret boundary `k` (0..glyphs.length) sits "before glyph k" and "after
-  // glyph k-1". Visually those are two points -- the left edge of glyph k and
-  // the right edge of glyph k-1 -- which coincide except across a KaTeX line
-  // break, where the same logical boundary shows up at the end of one line and
-  // the start of the next. Take the boundary whose nearest visual point is
-  // closest to the click; on a tie prefer the lower index (the left side),
-  // which makes a click dead-centre on a glyph land before it.
+export function nearestGlyphBoundary(glyphs: readonly RenderedGlyph[], clickX: number, clickY: number): number {
   let bestK = 0;
   let bestDistSq = Number.POSITIVE_INFINITY;
   const consider = (k: number, x: number, y: number): void => {
@@ -178,8 +167,73 @@ export function caretOffsetForClick(
       consider(k, g.right, (g.top + g.bottom) / 2);
     }
   }
+  return bestK;
+}
 
+/**
+ * Given the glyphs of a rendered equation preview (in DOM/reading order), a
+ * click point in client coordinates, and the source equation text, return the
+ * character offset in `equationStr` where the caret should be placed. This is
+ * the heuristic path used when the rendered LaTeX carries no source-range
+ * annotations (e.g. when the engine couldn't produce LaTeX and we fall back to
+ * rendering the raw equation text).
+ *
+ * Returns 0 when there are no glyphs (the caller is expected to fall back to a
+ * coarse proportional mapping in that case, since it needs the DOM rect).
+ */
+export function caretOffsetForClick(
+  glyphs: readonly RenderedGlyph[],
+  clickX: number,
+  clickY: number,
+  equationStr: string,
+): number {
+  const len = equationStr.length;
+  if (glyphs.length === 0) {
+    return 0;
+  }
+  const k = nearestGlyphBoundary(glyphs, clickX, clickY);
   const mapping = alignGlyphsToSource(glyphs, equationStr);
-  const offset = mapping[bestK];
-  return Math.max(0, Math.min(len, offset));
+  return Math.max(0, Math.min(len, mapping[k]));
+}
+
+/**
+ * Map a click within a single source-annotated span -- the element the engine
+ * tagged with `\htmlData{eqnloc=START_END}` (see `latex_eqn_expr0_annotated`
+ * on the Rust side) -- to a caret offset in the equation text.
+ *
+ * `[spanStart, spanEnd)` is the half-open byte range the span covers. For an
+ * operator annotation that range is the *gap* between the operands, which
+ * holds the operator token plus any surrounding whitespace, so we first trim
+ * whitespace off both ends to home in on the operator itself; for a leaf
+ * (identifier, number) the trim is a no-op. Within the trimmed range, the
+ * click is mapped by glyph: for the common case where the span renders one
+ * glyph per source character (identifiers, numbers, single-character
+ * operators) the boundary index *is* the offset; otherwise it interpolates.
+ */
+export function caretOffsetWithinSpan(
+  glyphs: readonly RenderedGlyph[],
+  clickX: number,
+  clickY: number,
+  sourceText: string,
+  spanStart: number,
+  spanEnd: number,
+): number {
+  const len = sourceText.length;
+  const lo = Math.max(0, Math.min(len, Math.min(spanStart, spanEnd)));
+  const hi = Math.max(0, Math.min(len, Math.max(spanStart, spanEnd)));
+  let ts = lo;
+  while (ts < hi && isWhitespace(sourceText[ts])) ts++;
+  let te = hi;
+  while (te > ts && isWhitespace(sourceText[te - 1])) te--;
+  if (ts >= te) {
+    // The span is empty or all whitespace -- shouldn't happen for a real
+    // `eqnloc`, but fall back to the span start.
+    return lo;
+  }
+  if (glyphs.length === 0) {
+    return ts;
+  }
+  const k = nearestGlyphBoundary(glyphs, clickX, clickY); // 0..glyphs.length
+  const offset = ts + Math.round((k * (te - ts)) / glyphs.length);
+  return Math.max(ts, Math.min(te, offset));
 }

--- a/src/diagram/equation-caret.ts
+++ b/src/diagram/equation-caret.ts
@@ -196,19 +196,28 @@ export function caretOffsetForClick(
   return Math.max(0, Math.min(len, mapping[k]));
 }
 
+// A parenthesis. Trimmed off the ends of an *operator-gap* span (in addition
+// to whitespace): that span is the gap between the parser's two operand
+// ranges, which can include the grouping parens those ranges exclude -- e.g.
+// in `(a+b)*c` the gap between `a+b` and `c` is `)*`, so trimming the `)`
+// homes in on the `*`. Leaf/node spans never have a `(`/`)` at their edges
+// except a function call's trailing `)`, which we must keep, so the trim is
+// applied only when the span was tagged as an operator gap (`data-oploc`).
+const isParen = (ch: string | undefined): boolean => ch === '(' || ch === ')';
+
 /**
- * Map a click within a single source-annotated span -- the element the engine
- * tagged with `\htmlData{eqnloc=START_END}` (see `latex_eqn_expr0_annotated`
- * on the Rust side) -- to a caret offset in the equation text.
+ * Map a click within a single source-annotated span -- an element the engine
+ * tagged with `\htmlData{eqnloc=…}` (a syntax-node span) or `\htmlData{oploc=…}`
+ * (the gap around a binary/unary operator); see `latex_eqn_expr0_annotated` on
+ * the Rust side -- to a caret offset in the equation text.
  *
- * `[spanStart, spanEnd)` is the half-open byte range the span covers. For an
- * operator annotation that range is the *gap* between the operands, which
- * holds the operator token plus any surrounding whitespace, so we first trim
- * whitespace off both ends to home in on the operator itself; for a leaf
- * (identifier, number) the trim is a no-op. Within the trimmed range, the
- * click is mapped by glyph: for the common case where the span renders one
- * glyph per source character (identifiers, numbers, single-character
- * operators) the boundary index *is* the offset; otherwise it interpolates.
+ * `[spanStart, spanEnd)` is the half-open byte range the span covers. We trim
+ * whitespace (and, for an operator gap, parentheses) off both ends so the
+ * caret homes in on the operator token / on the leaf's text; within the
+ * trimmed range the click is mapped by glyph -- for the common case where the
+ * span renders one glyph per source character (identifiers, numbers, single-
+ * character operators) the boundary index *is* the offset; otherwise it
+ * interpolates.
  */
 export function caretOffsetWithinSpan(
   glyphs: readonly RenderedGlyph[],
@@ -217,14 +226,16 @@ export function caretOffsetWithinSpan(
   sourceText: string,
   spanStart: number,
   spanEnd: number,
+  isOperatorGap: boolean,
 ): number {
   const len = sourceText.length;
   const lo = Math.max(0, Math.min(len, Math.min(spanStart, spanEnd)));
   const hi = Math.max(0, Math.min(len, Math.max(spanStart, spanEnd)));
+  const trim = (ch: string | undefined): boolean => isWhitespace(ch) || (isOperatorGap && isParen(ch));
   let ts = lo;
-  while (ts < hi && isWhitespace(sourceText[ts])) ts++;
+  while (ts < hi && trim(sourceText[ts])) ts++;
   let te = hi;
-  while (te > ts && isWhitespace(sourceText[te - 1])) te--;
+  while (te > ts && trim(sourceText[te - 1])) te--;
   if (ts >= te) {
     // The span is empty or all whitespace -- shouldn't happen for a real
     // `eqnloc`, but fall back to the span start.

--- a/src/diagram/equation-caret.ts
+++ b/src/diagram/equation-caret.ts
@@ -1,0 +1,177 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+// Mapping a click on the rendered (KaTeX) equation preview back to a caret
+// offset in the editable equation text.
+//
+// The rendered equation is a *transformed* view of the source text -- `*`
+// becomes `\cdot`, `/` becomes a fraction, identifiers are lower-cased,
+// whitespace is dropped, etc. -- so we can't read the source offset directly
+// off the DOM. This module takes the glyphs the preview rendered (extracted by
+// the imperative shell, with their on-screen boxes) and:
+//
+//   1. finds the glyph *boundary* nearest the click in 2D (so a click in the
+//      whitespace around a small operator glyph snaps to the side of that
+//      operator instead of landing inside an adjacent identifier, and so
+//      clicks on a wrapped line work);
+//   2. aligns the rendered glyph string to the source text -- character for
+//      character in the common case, with a little slack for the few places
+//      they disagree -- to translate that boundary into a source offset.
+//
+// The functions here are pure and DOM-free; `VariableDetails.tsx` owns the DOM
+// walk that produces `RenderedGlyph`s.
+
+/** A single glyph from the rendered equation, with its on-screen bounding box
+ *  in client (viewport) coordinates -- the same space as a `MouseEvent`'s
+ *  `clientX`/`clientY`. */
+export interface RenderedGlyph {
+  readonly char: string;
+  readonly left: number;
+  readonly right: number;
+  readonly top: number;
+  readonly bottom: number;
+}
+
+/** Map a rendered glyph back to the ASCII character it stands for in the
+ *  source equation. KaTeX renders `*` (multiplication) as `\cdot`/`\times`,
+ *  binary `-` as a true minus sign, and `not` as `\neg`; everything else --
+ *  letters, digits, parentheses, `+`, comparison operators -- renders as the
+ *  same character that appears in the source. */
+export function glyphToAscii(ch: string): string {
+  switch (ch) {
+    case '·': // MIDDLE DOT
+    case '×': // MULTIPLICATION SIGN  (\times)
+    case '⋅': // DOT OPERATOR         (\cdot)
+      return '*';
+    case '−': // MINUS SIGN           (binary -)
+      return '-';
+    case '¬': // NOT SIGN             (\neg)
+      return '!';
+    default:
+      return ch;
+  }
+}
+
+// How many "extra" source characters the alignment will skip over to resync
+// with the glyph stream (e.g. a `/` that rendered as a fraction bar, or a `^`
+// that rendered as a superscript). Kept small so a genuinely-extra glyph
+// doesn't get matched to a far-away same-letter source character.
+const MAX_RESYNC_SKIP = 2;
+
+const isWhitespace = (ch: string | undefined): boolean => ch !== undefined && /\s/.test(ch);
+
+/**
+ * Greedily align the rendered glyph stream to the source equation text,
+ * returning a `glyphs.length + 1` long array where entry `k` is the source
+ * offset for "caret immediately before glyph `k`" (and entry `glyphs.length`
+ * is the end of the equation). The result is monotonically non-decreasing.
+ *
+ * The match is case-insensitive (identifiers are lower-cased in LaTeX) and
+ * skips whitespace in the source (the rendered math drops it). Where a glyph
+ * has no source counterpart at the current position the alignment first tries
+ * to resync by skipping up to `MAX_RESYNC_SKIP` source characters (the `/`
+ * of a fraction, the `^` of an exponent); failing that it treats the glyph as
+ * "extra" -- rendered but absent from the source, e.g. a parenthesis KaTeX
+ * added for precedence -- and lets it occupy no source characters.
+ */
+export function alignGlyphsToSource(glyphs: readonly RenderedGlyph[], equationStr: string): number[] {
+  const n = glyphs.length;
+  const eqLower = equationStr.toLowerCase();
+  const len = equationStr.length;
+
+  const mapping = new Array<number>(n + 1);
+  let ei = 0;
+  for (let gi = 0; gi < n; gi++) {
+    const g = glyphToAscii(glyphs[gi].char).toLowerCase();
+    while (ei < len && isWhitespace(equationStr[ei])) ei++;
+
+    if (g === '') {
+      // An invisible glyph (shouldn't normally reach us) -- occupies nothing.
+      mapping[gi] = ei;
+      continue;
+    }
+
+    if (ei < len && eqLower[ei] === g) {
+      mapping[gi] = ei;
+      ei++;
+      continue;
+    }
+
+    // Mismatch: probe ahead for the glyph, skipping a few non-matching
+    // (and whitespace) source characters.
+    let probe = ei;
+    let resynced = -1;
+    for (let step = 0; step < MAX_RESYNC_SKIP && probe < len; step++) {
+      probe++;
+      while (probe < len && isWhitespace(equationStr[probe])) probe++;
+      if (probe < len && eqLower[probe] === g) {
+        resynced = probe;
+        break;
+      }
+    }
+    if (resynced >= 0) {
+      mapping[gi] = resynced;
+      ei = resynced + 1;
+      continue;
+    }
+
+    // The glyph isn't in the source here -- it's extra (e.g. an added paren).
+    mapping[gi] = ei;
+  }
+  mapping[n] = len;
+  return mapping;
+}
+
+/**
+ * Given the glyphs of a rendered equation preview (in DOM/reading order), a
+ * click point in client coordinates, and the source equation text, return the
+ * character offset in `equationStr` where the caret should be placed.
+ *
+ * Returns 0 when there are no glyphs (the caller is expected to fall back to a
+ * coarse proportional mapping in that case, since it needs the DOM rect).
+ */
+export function caretOffsetForClick(
+  glyphs: readonly RenderedGlyph[],
+  clickX: number,
+  clickY: number,
+  equationStr: string,
+): number {
+  const len = equationStr.length;
+  if (glyphs.length === 0) {
+    return 0;
+  }
+
+  // A caret boundary `k` (0..glyphs.length) sits "before glyph k" and "after
+  // glyph k-1". Visually those are two points -- the left edge of glyph k and
+  // the right edge of glyph k-1 -- which coincide except across a KaTeX line
+  // break, where the same logical boundary shows up at the end of one line and
+  // the start of the next. Take the boundary whose nearest visual point is
+  // closest to the click; on a tie prefer the lower index (the left side),
+  // which makes a click dead-centre on a glyph land before it.
+  let bestK = 0;
+  let bestDistSq = Number.POSITIVE_INFINITY;
+  const consider = (k: number, x: number, y: number): void => {
+    const dx = clickX - x;
+    const dy = clickY - y;
+    const d = dx * dx + dy * dy;
+    if (d < bestDistSq) {
+      bestDistSq = d;
+      bestK = k;
+    }
+  };
+  for (let k = 0; k <= glyphs.length; k++) {
+    if (k < glyphs.length) {
+      const g = glyphs[k];
+      consider(k, g.left, (g.top + g.bottom) / 2);
+    }
+    if (k > 0) {
+      const g = glyphs[k - 1];
+      consider(k, g.right, (g.top + g.bottom) / 2);
+    }
+  }
+
+  const mapping = alignGlyphsToSource(glyphs, equationStr);
+  const offset = mapping[bestK];
+  return Math.max(0, Math.min(len, offset));
+}

--- a/src/diagram/tests/equation-caret.test.ts
+++ b/src/diagram/tests/equation-caret.test.ts
@@ -301,7 +301,7 @@ describe('nearestGlyphBoundary', () => {
 });
 
 describe('caretOffsetWithinSpan', () => {
-  it('maps boundary to offset 1:1 within an identifier span', () => {
+  it('maps boundary to offset 1:1 within an identifier span (eqnloc, not an operator gap)', () => {
     // source: "x = average + 1"; the identifier `average` is bytes [4,11)
     const src = 'x = average + 1';
     const glyphs = lineOf([
@@ -313,11 +313,11 @@ describe('caretOffsetWithinSpan', () => {
       ['g', 50, 10],
       ['e', 60, 10],
     ]);
-    expect(caretOffsetWithinSpan(glyphs, 5, 6, src, 4, 11)).toBe(4); // before `a`
-    expect(caretOffsetWithinSpan(glyphs, 15, 6, src, 4, 11)).toBe(5); // before `v`
-    expect(caretOffsetWithinSpan(glyphs, 35, 6, src, 4, 11)).toBe(7); // before `r`
-    expect(caretOffsetWithinSpan(glyphs, -50, 6, src, 4, 11)).toBe(4); // clamps to span start
-    expect(caretOffsetWithinSpan(glyphs, 999, 6, src, 4, 11)).toBe(11); // clamps to span end
+    expect(caretOffsetWithinSpan(glyphs, 5, 6, src, 4, 11, false)).toBe(4); // before `a`
+    expect(caretOffsetWithinSpan(glyphs, 15, 6, src, 4, 11, false)).toBe(5); // before `v`
+    expect(caretOffsetWithinSpan(glyphs, 35, 6, src, 4, 11, false)).toBe(7); // before `r`
+    expect(caretOffsetWithinSpan(glyphs, -50, 6, src, 4, 11, false)).toBe(4); // clamps to span start
+    expect(caretOffsetWithinSpan(glyphs, 999, 6, src, 4, 11, false)).toBe(11); // clamps to span end
   });
 
   it('trims surrounding whitespace from an operator-gap span to the operator', () => {
@@ -326,20 +326,33 @@ describe('caretOffsetWithinSpan', () => {
     // single `⋅` glyph.
     const src = 'a   *  b';
     const glyphs = lineOf([['⋅', 20, 6]]); // box [20,26], centre x=23
-    expect(caretOffsetWithinSpan(glyphs, 21, 6, src, 1, 7)).toBe(4); // left half -> before `*`
-    expect(caretOffsetWithinSpan(glyphs, 25, 6, src, 1, 7)).toBe(5); // right half -> after `*`
+    expect(caretOffsetWithinSpan(glyphs, 21, 6, src, 1, 7, true)).toBe(4); // left half -> before `*`
+    expect(caretOffsetWithinSpan(glyphs, 25, 6, src, 1, 7, true)).toBe(5); // right half -> after `*`
+  });
+
+  it('trims grouping parentheses from an operator-gap span (e.g. `(a+b)*c`)', () => {
+    // source: "(a+b)*c"; the parser's operand ranges are `a+b` [1,4) and `c`
+    // [6,7), so the `*` gap is bytes [4,6) = ")*". The `)` is part of the
+    // left operand's grouping, not the operator, so it's trimmed: the `*` is
+    // byte 5.
+    const src = '(a+b)*c';
+    const glyphs = lineOf([['⋅', 30, 6]]); // box [30,36]
+    expect(caretOffsetWithinSpan(glyphs, 31, 6, src, 4, 6, true)).toBe(5); // before `*`
+    expect(caretOffsetWithinSpan(glyphs, 35, 6, src, 4, 6, true)).toBe(6); // after `*`
   });
 
   it('returns the trimmed span start when there are no glyphs or the span is empty', () => {
-    expect(caretOffsetWithinSpan([], 100, 50, 'a + b', 1, 4)).toBe(2); // " + " trims to start at byte 2
+    expect(caretOffsetWithinSpan([], 100, 50, 'a + b', 1, 4, true)).toBe(2); // " + " trims to start at byte 2
     const glyphs = lineOf([['x', 0, 10]]);
-    expect(caretOffsetWithinSpan(glyphs, 5, 6, '   ', 0, 3)).toBe(0); // all-whitespace span
+    expect(caretOffsetWithinSpan(glyphs, 5, 6, '   ', 0, 3, false)).toBe(0); // all-whitespace span
   });
 
-  it('interpolates when the glyph count and source-byte count differ, staying in bounds', () => {
+  it('keeps a function call’s trailing paren (eqnloc spans are not trimmed of parens)', () => {
     // source: "min(a, b)" [0,9) but KaTeX renders 8 glyphs (the space after the
     // comma is dropped); a click on the function name / parens lands roughly
-    // right and never escapes the span.
+    // right and never escapes the span -- and the trailing `)` is *not*
+    // trimmed (this is a node span, not an operator gap), so a far-right click
+    // lands after it at byte 9.
     const src = 'min(a, b)';
     const glyphs = lineOf([
       ['m', 0, 10],
@@ -351,10 +364,10 @@ describe('caretOffsetWithinSpan', () => {
       ['b', 60, 10],
       [')', 70, 10],
     ]);
-    expect(caretOffsetWithinSpan(glyphs, -1, 6, src, 0, 9)).toBe(0);
-    expect(caretOffsetWithinSpan(glyphs, 999, 6, src, 0, 9)).toBe(9);
+    expect(caretOffsetWithinSpan(glyphs, -1, 6, src, 0, 9, false)).toBe(0);
+    expect(caretOffsetWithinSpan(glyphs, 999, 6, src, 0, 9, false)).toBe(9);
     for (const x of [5, 25, 45, 65, 79]) {
-      const off = caretOffsetWithinSpan(glyphs, x, 6, src, 0, 9);
+      const off = caretOffsetWithinSpan(glyphs, x, 6, src, 0, 9, false);
       expect(off).toBeGreaterThanOrEqual(0);
       expect(off).toBeLessThanOrEqual(9);
     }

--- a/src/diagram/tests/equation-caret.test.ts
+++ b/src/diagram/tests/equation-caret.test.ts
@@ -50,8 +50,12 @@ describe('glyphToAscii', () => {
     expect(glyphToAscii('−')).toBe('-'); // U+2212
   });
 
-  it('maps the negation sign back to "!"', () => {
-    expect(glyphToAscii('¬')).toBe('!'); // \neg
+  it('maps the negation sign back to the `not` keyword', () => {
+    // KaTeX draws `\neg` (the engine's rendering of `not`) as a single `¬`
+    // glyph, but XMILE spells logical negation as the word `not` -- there is
+    // no `!` operator in Simlin equations -- so the glyph stands for the
+    // three-letter keyword.
+    expect(glyphToAscii('¬')).toBe('not'); // \neg
   });
 
   it('passes ordinary characters through unchanged', () => {
@@ -143,6 +147,41 @@ describe('alignGlyphsToSource', () => {
     // the stray `(` maps to the position before the `*` and consumes nothing
     expect(alignGlyphsToSource(glyphs, eq)).toEqual([0, 1, 1, 2, 3]);
   });
+
+  it('consumes the `not` keyword for the `¬` glyph that `\\neg` renders', () => {
+    // `not running` -> `\neg \mathrm{running}` -> a single `¬` glyph followed
+    // by the identifier glyphs. The `¬` stands for the 3-char `not` keyword;
+    // its trailing space is then skipped before the operand.
+    const eq = 'not running';
+    const glyphs = lineOf([
+      ['¬', 0, 12],
+      ['r', 12, 10],
+      ['u', 22, 10],
+      ['n', 32, 10],
+      ['n', 42, 10],
+      ['i', 52, 10],
+      ['n', 62, 10],
+      ['g', 72, 10],
+    ]);
+    expect(alignGlyphsToSource(glyphs, eq)).toEqual([0, 4, 5, 6, 7, 8, 9, 10, 11]);
+  });
+
+  it('resyncs the operand past parentheses when `not` has no space (`not(x)`)', () => {
+    const eq = 'not(running)';
+    const glyphs = lineOf([
+      ['¬', 0, 12],
+      ['r', 12, 10],
+      ['u', 22, 10],
+      ['n', 32, 10],
+      ['n', 42, 10],
+      ['i', 52, 10],
+      ['n', 62, 10],
+      ['g', 72, 10],
+    ]);
+    // `¬` -> "not"; the `(` is skipped to land `r` on its source index; the
+    // trailing `)` falls outside any glyph so the end maps to eq.length.
+    expect(alignGlyphsToSource(glyphs, eq)).toEqual([0, 4, 5, 6, 7, 8, 9, 10, 12]);
+  });
 });
 
 describe('caretOffsetForClick', () => {
@@ -167,6 +206,31 @@ describe('caretOffsetForClick', () => {
     for (const x of [92, 96, 100, 104, 108, 112]) {
       const off = caretOffsetForClick(glyphs, x, 6, eq);
       expect(off === 9 || off === 10).toBe(true);
+    }
+  });
+
+  it('places the caret inside the operand of `not <ident>`, not at offset 0', () => {
+    // Regression: `\neg` renders as one `¬` glyph for the 3-char `not`
+    // keyword; before this was handled, the alignment stalled and clicks on
+    // the operand landed at offset 0 (or the end of the equation).
+    const eq = 'not running'; // indices: n0 o1 t2 _3 r4 u5 n6 n7 i8 n9 g10
+    const glyphs = lineOf([
+      ['¬', 0, 12],
+      ['r', 12, 10],
+      ['u', 22, 10],
+      ['n', 32, 10],
+      ['n', 42, 10],
+      ['i', 52, 10],
+      ['n', 62, 10],
+      ['g', 72, 10],
+    ]);
+    // clicking the `¬` glyph lands the caret right at the `not` keyword
+    expect(caretOffsetForClick(glyphs, 6, 6, eq)).toBe(0); // left/centre of `¬`
+    expect(caretOffsetForClick(glyphs, 11, 6, eq)).toBe(4); // right edge of `¬` -> after `not `
+    // clicking anywhere across "running" lands the caret inside (or at an edge of) it
+    for (const x of [13, 27, 47, 81]) {
+      const off = caretOffsetForClick(glyphs, x, 6, eq);
+      expect(off >= 4 && off <= 11).toBe(true);
     }
   });
 

--- a/src/diagram/tests/equation-caret.test.ts
+++ b/src/diagram/tests/equation-caret.test.ts
@@ -1,0 +1,204 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import { alignGlyphsToSource, caretOffsetForClick, glyphToAscii, RenderedGlyph } from '../equation-caret';
+
+// Build a single-line run of glyphs from a list of [char, left, width] tuples.
+// All glyphs share a vertical band so the 2D-nearest-boundary search reduces
+// to picking the nearest horizontal boundary.
+function lineOf(specs: Array<[string, number, number]>, top = 0, height = 12): RenderedGlyph[] {
+  return specs.map(([char, left, width]) => ({
+    char,
+    left,
+    right: left + width,
+    top,
+    bottom: top + height,
+  }));
+}
+
+// `Incidents*average_effort_required_to_remediate_an_incident`, the user's
+// example. KaTeX renders `*` as `\cdot` (a small `⋅` glyph) flanked by ~6px of
+// CSS spacing on each side, so a click "on the *" usually lands in that
+// spacing rather than on the tiny dot. The glyph layout below mimics that:
+// "Incidents" packed 10px/char ending at x=90, the `⋅` at x=98..102 (a 4px
+// dot centred in a ~16px slot), then "average..." starting at x=114.
+function incidentsTimesAverage(): { glyphs: RenderedGlyph[]; eq: string } {
+  const eq = 'Incidents*average_effort_required_to_remediate_an_incident';
+  const specs: Array<[string, number, number]> = [];
+  // "Incidents" -> indices 0..8 at x = 0..90
+  for (let i = 0; i < 9; i++) {
+    specs.push([eq[i], i * 10, 10]);
+  }
+  // `*` -> rendered as `⋅` at x = 98..102
+  specs.push(['⋅', 98, 4]);
+  // "average_effort_..." -> indices 10..eq.length-1 starting at x = 114
+  for (let i = 10; i < eq.length; i++) {
+    specs.push([eq[i], 114 + (i - 10) * 10, 10]);
+  }
+  return { glyphs: lineOf(specs), eq };
+}
+
+describe('glyphToAscii', () => {
+  it('maps the multiplication glyphs back to "*"', () => {
+    expect(glyphToAscii('⋅')).toBe('*'); // \cdot
+    expect(glyphToAscii('·')).toBe('*'); // middle dot
+    expect(glyphToAscii('×')).toBe('*'); // \times
+  });
+
+  it('maps the unary/binary minus sign back to "-"', () => {
+    expect(glyphToAscii('−')).toBe('-'); // U+2212
+  });
+
+  it('maps the negation sign back to "!"', () => {
+    expect(glyphToAscii('¬')).toBe('!'); // \neg
+  });
+
+  it('passes ordinary characters through unchanged', () => {
+    expect(glyphToAscii('a')).toBe('a');
+    expect(glyphToAscii('(')).toBe('(');
+    expect(glyphToAscii('+')).toBe('+');
+    expect(glyphToAscii('=')).toBe('=');
+  });
+});
+
+describe('alignGlyphsToSource', () => {
+  it('is the identity for a glyph stream that matches the source character-for-character', () => {
+    const eq = 'a+b';
+    const glyphs = lineOf([
+      ['a', 0, 10],
+      ['+', 10, 10],
+      ['b', 20, 10],
+    ]);
+    expect(alignGlyphsToSource(glyphs, eq)).toEqual([0, 1, 2, 3]);
+  });
+
+  it('maps the `\\cdot` glyph back onto the `*` in the source', () => {
+    const { glyphs, eq } = incidentsTimesAverage();
+    const m = alignGlyphsToSource(glyphs, eq);
+    // glyph 9 is the `⋅`; "caret before it" is offset 9 (right before the `*`),
+    // "caret before glyph 10" is offset 10 (right after the `*`).
+    expect(m[9]).toBe(9);
+    expect(m[10]).toBe(10);
+    expect(m[0]).toBe(0);
+    expect(m[m.length - 1]).toBe(eq.length);
+  });
+
+  it('matches case-insensitively (LaTeX lower-cases identifiers)', () => {
+    const eq = 'Foo*Bar';
+    const glyphs = lineOf([
+      ['f', 0, 10],
+      ['o', 10, 10],
+      ['o', 20, 10],
+      ['⋅', 30, 4],
+      ['b', 40, 10],
+      ['a', 50, 10],
+      ['r', 60, 10],
+    ]);
+    expect(alignGlyphsToSource(glyphs, eq)).toEqual([0, 1, 2, 3, 4, 5, 6, 7]);
+  });
+
+  it('skips source whitespace that the rendered math drops', () => {
+    const eq = 'a + b';
+    const glyphs = lineOf([
+      ['a', 0, 10],
+      ['+', 10, 10],
+      ['b', 20, 10],
+    ]);
+    // glyph 0 -> source 0 (a), glyph 1 -> source 2 (+), glyph 2 -> source 4 (b)
+    expect(alignGlyphsToSource(glyphs, eq)).toEqual([0, 2, 4, 5]);
+  });
+
+  it('resyncs across a `/` that rendered as a fraction bar', () => {
+    const eq = 'a/b';
+    // KaTeX stacks `a` over `b`; there is no `/` glyph.
+    const glyphs: RenderedGlyph[] = [
+      { char: 'a', left: 8, right: 12, top: 0, bottom: 10 },
+      { char: 'b', left: 8, right: 12, top: 12, bottom: 22 },
+    ];
+    // glyph 0 -> source 0 (a); glyph 1 -> source 2 (b, after skipping `/`)
+    expect(alignGlyphsToSource(glyphs, eq)).toEqual([0, 2, 3]);
+  });
+
+  it('resyncs across a `^` that rendered as a superscript', () => {
+    const eq = 'a^bc';
+    const glyphs: RenderedGlyph[] = [
+      { char: 'a', left: 0, right: 10, top: 4, bottom: 14 },
+      { char: 'b', left: 10, right: 16, top: 0, bottom: 8 },
+      { char: 'c', left: 16, right: 22, top: 0, bottom: 8 },
+    ];
+    // a -> 0, b -> 2 (after skipping `^`), c -> 3
+    expect(alignGlyphsToSource(glyphs, eq)).toEqual([0, 2, 3, 4]);
+  });
+
+  it('treats a glyph absent from the source as occupying no characters', () => {
+    // pretend KaTeX added a paren for precedence that the user did not type
+    const eq = 'a*b';
+    const glyphs = lineOf([
+      ['a', 0, 10],
+      ['(', 10, 6],
+      ['*', 16, 6],
+      ['b', 22, 10],
+    ]);
+    // the stray `(` maps to the position before the `*` and consumes nothing
+    expect(alignGlyphsToSource(glyphs, eq)).toEqual([0, 1, 1, 2, 3]);
+  });
+});
+
+describe('caretOffsetForClick', () => {
+  it('returns 0 when there are no glyphs (caller falls back proportionally)', () => {
+    expect(caretOffsetForClick([], 100, 50, 'anything')).toBe(0);
+  });
+
+  it('places the caret right at the `*` when clicking the rendered multiplication dot', () => {
+    const { glyphs, eq } = incidentsTimesAverage();
+    // dead-centre on the `⋅` (x in 98..102) -> just before the `*`
+    expect(caretOffsetForClick(glyphs, 100, 6, eq)).toBe(9);
+    // right edge of the `⋅` and into its right margin -> just after the `*`
+    expect(caretOffsetForClick(glyphs, 108, 6, eq)).toBe(10);
+    // left margin of the `⋅`, between "Incidents" and the dot -> just before
+    expect(caretOffsetForClick(glyphs, 94, 6, eq)).toBe(9);
+  });
+
+  it('does not snap a click near the `*` into the middle of the next identifier', () => {
+    const { glyphs, eq } = incidentsTimesAverage();
+    // The bug: clicking near the `*` used to land one character into
+    // "average...". The caret must stay adjacent to the `*` (offset 9 or 10).
+    for (const x of [92, 96, 100, 104, 108, 112]) {
+      const off = caretOffsetForClick(glyphs, x, 6, eq);
+      expect(off === 9 || off === 10).toBe(true);
+    }
+  });
+
+  it('places the caret before/after an identifier character based on which half was clicked', () => {
+    const eq = 'abc*d';
+    const glyphs = lineOf([
+      ['a', 0, 10],
+      ['b', 10, 10],
+      ['c', 20, 10],
+      ['⋅', 30, 4],
+      ['d', 38, 10],
+    ]);
+    expect(caretOffsetForClick(glyphs, 12, 6, eq)).toBe(1); // left half of `b` -> before it
+    expect(caretOffsetForClick(glyphs, 18, 6, eq)).toBe(2); // right half of `b` -> after it
+    expect(caretOffsetForClick(glyphs, -100, 6, eq)).toBe(0); // far left -> start
+    expect(caretOffsetForClick(glyphs, 9999, 6, eq)).toBe(eq.length); // far right -> end
+  });
+
+  it('uses the click Y to pick a wrapped line', () => {
+    // Two visual lines: "ab" on top, "cd" below, source "ab+cd".
+    const eq = 'ab+cd';
+    const glyphs: RenderedGlyph[] = [
+      { char: 'a', left: 0, right: 10, top: 0, bottom: 12 },
+      { char: 'b', left: 10, right: 20, top: 0, bottom: 12 },
+      { char: '+', left: 20, right: 30, top: 0, bottom: 12 },
+      { char: 'c', left: 0, right: 10, top: 20, bottom: 32 },
+      { char: 'd', left: 10, right: 20, top: 20, bottom: 32 },
+    ];
+    // Click near the start of the second line -> before `c` (source offset 3).
+    expect(caretOffsetForClick(glyphs, 2, 26, eq)).toBe(3);
+    // Click near the end of the first line -> after `b` (source offset 2),
+    // which the `+` glyph occupies, so this lands right before the `+`.
+    expect(caretOffsetForClick(glyphs, 18, 6, eq)).toBe(2);
+  });
+});

--- a/src/diagram/tests/equation-caret.test.ts
+++ b/src/diagram/tests/equation-caret.test.ts
@@ -2,7 +2,14 @@
 // Use of this source code is governed by the Apache License,
 // Version 2.0, that can be found in the LICENSE file.
 
-import { alignGlyphsToSource, caretOffsetForClick, glyphToAscii, RenderedGlyph } from '../equation-caret';
+import {
+  alignGlyphsToSource,
+  caretOffsetForClick,
+  caretOffsetWithinSpan,
+  glyphToAscii,
+  nearestGlyphBoundary,
+  RenderedGlyph,
+} from '../equation-caret';
 
 // Build a single-line run of glyphs from a list of [char, left, width] tuples.
 // All glyphs share a vertical band so the 2D-nearest-boundary search reduces
@@ -264,5 +271,92 @@ describe('caretOffsetForClick', () => {
     // Click near the end of the first line -> after `b` (source offset 2),
     // which the `+` glyph occupies, so this lands right before the `+`.
     expect(caretOffsetForClick(glyphs, 18, 6, eq)).toBe(2);
+  });
+});
+
+describe('nearestGlyphBoundary', () => {
+  it('returns 0 for no glyphs', () => {
+    expect(nearestGlyphBoundary([], 100, 50)).toBe(0);
+  });
+
+  it('picks the near side of a single glyph', () => {
+    const glyphs = lineOf([['x', 10, 10]], 0, 12); // box [10,20], centre x=15, centre y=6
+    expect(nearestGlyphBoundary(glyphs, 11, 6)).toBe(0); // left half -> before
+    expect(nearestGlyphBoundary(glyphs, 19, 6)).toBe(1); // right half -> after
+    expect(nearestGlyphBoundary(glyphs, 15, 6)).toBe(0); // dead centre -> before
+    expect(nearestGlyphBoundary(glyphs, -50, 6)).toBe(0);
+    expect(nearestGlyphBoundary(glyphs, 999, 6)).toBe(1);
+  });
+
+  it('uses the click Y to pick a wrapped line', () => {
+    const glyphs: RenderedGlyph[] = [
+      { char: 'a', left: 0, right: 10, top: 0, bottom: 12 },
+      { char: 'b', left: 0, right: 10, top: 20, bottom: 32 },
+    ];
+    // near the start of the second line -> the boundary between a and b
+    expect(nearestGlyphBoundary(glyphs, 2, 26)).toBe(1);
+    // near the end of the first line -> also the boundary between a and b
+    expect(nearestGlyphBoundary(glyphs, 8, 6)).toBe(1);
+  });
+});
+
+describe('caretOffsetWithinSpan', () => {
+  it('maps boundary to offset 1:1 within an identifier span', () => {
+    // source: "x = average + 1"; the identifier `average` is bytes [4,11)
+    const src = 'x = average + 1';
+    const glyphs = lineOf([
+      ['a', 0, 10],
+      ['v', 10, 10],
+      ['e', 20, 10],
+      ['r', 30, 10],
+      ['a', 40, 10],
+      ['g', 50, 10],
+      ['e', 60, 10],
+    ]);
+    expect(caretOffsetWithinSpan(glyphs, 5, 6, src, 4, 11)).toBe(4); // before `a`
+    expect(caretOffsetWithinSpan(glyphs, 15, 6, src, 4, 11)).toBe(5); // before `v`
+    expect(caretOffsetWithinSpan(glyphs, 35, 6, src, 4, 11)).toBe(7); // before `r`
+    expect(caretOffsetWithinSpan(glyphs, -50, 6, src, 4, 11)).toBe(4); // clamps to span start
+    expect(caretOffsetWithinSpan(glyphs, 999, 6, src, 4, 11)).toBe(11); // clamps to span end
+  });
+
+  it('trims surrounding whitespace from an operator-gap span to the operator', () => {
+    // source: "a   *  b"; the gap between operands `a` [0,1) and `b` [7,8) is
+    // bytes [1,7) = "   *  "; the `*` itself is at byte 4. KaTeX draws it as a
+    // single `⋅` glyph.
+    const src = 'a   *  b';
+    const glyphs = lineOf([['⋅', 20, 6]]); // box [20,26], centre x=23
+    expect(caretOffsetWithinSpan(glyphs, 21, 6, src, 1, 7)).toBe(4); // left half -> before `*`
+    expect(caretOffsetWithinSpan(glyphs, 25, 6, src, 1, 7)).toBe(5); // right half -> after `*`
+  });
+
+  it('returns the trimmed span start when there are no glyphs or the span is empty', () => {
+    expect(caretOffsetWithinSpan([], 100, 50, 'a + b', 1, 4)).toBe(2); // " + " trims to start at byte 2
+    const glyphs = lineOf([['x', 0, 10]]);
+    expect(caretOffsetWithinSpan(glyphs, 5, 6, '   ', 0, 3)).toBe(0); // all-whitespace span
+  });
+
+  it('interpolates when the glyph count and source-byte count differ, staying in bounds', () => {
+    // source: "min(a, b)" [0,9) but KaTeX renders 8 glyphs (the space after the
+    // comma is dropped); a click on the function name / parens lands roughly
+    // right and never escapes the span.
+    const src = 'min(a, b)';
+    const glyphs = lineOf([
+      ['m', 0, 10],
+      ['i', 10, 10],
+      ['n', 20, 10],
+      ['(', 30, 10],
+      ['a', 40, 10],
+      [',', 50, 10],
+      ['b', 60, 10],
+      [')', 70, 10],
+    ]);
+    expect(caretOffsetWithinSpan(glyphs, -1, 6, src, 0, 9)).toBe(0);
+    expect(caretOffsetWithinSpan(glyphs, 999, 6, src, 0, 9)).toBe(9);
+    for (const x of [5, 25, 45, 65, 79]) {
+      const off = caretOffsetWithinSpan(glyphs, x, 6, src, 0, 9);
+      expect(off).toBeGreaterThanOrEqual(0);
+      expect(off).toBeLessThanOrEqual(9);
+    }
   });
 });

--- a/src/libsimlin/src/model.rs
+++ b/src/libsimlin/src/model.rs
@@ -684,7 +684,10 @@ pub unsafe extern "C" fn simlin_model_get_latex_equation(
         None => return ptr::null_mut(),
     };
 
-    let latex = ast.to_latex();
+    // `to_latex_annotated` wraps each node in a `\htmlData{eqnloc=…}` source
+    // range annotation so the equation-preview UI can map a click back to a
+    // caret position; rendering it requires KaTeX's `trust` option.
+    let latex = ast.to_latex_annotated();
     match CString::new(latex) {
         Ok(s) => s.into_raw(),
         Err(_) => ptr::null_mut(),

--- a/src/simlin-engine/src/ast/mod.rs
+++ b/src/simlin-engine/src/ast/mod.rs
@@ -65,6 +65,17 @@ impl Ast<Expr0> {
             Ast::Arrayed(..) => "TODO(array)".to_owned(),
         }
     }
+
+    /// Render the equation as LaTeX with `\htmlData{eqnloc=…}` source-range
+    /// annotations on every node (see [`latex_eqn_expr0_annotated`]). Requires
+    /// KaTeX's `trust` option (scoped to `\htmlData`) to render.
+    pub fn to_latex_annotated(&self) -> String {
+        match self {
+            Ast::Scalar(expr) => latex_eqn_expr0_annotated(expr),
+            Ast::ApplyToAll(_, _expr) => "TODO(array)".to_owned(),
+            Ast::Arrayed(..) => "TODO(array)".to_owned(),
+        }
+    }
 }
 
 impl Ast<Expr2> {
@@ -782,6 +793,126 @@ pub fn latex_eqn_expr0(expr: &Expr0) -> String {
     }
 }
 
+/// Wrap `inner` in a KaTeX `\htmlData{eqnloc=START_END}` annotation. KaTeX
+/// renders this as a span carrying `data-eqnloc="START_END"`, giving the
+/// half-open byte range `[START, END)` of the source equation text that the
+/// span covers. The equation-preview click handler reads this back to place
+/// the caret precisely.
+fn latex_html_data(start: u16, end: u16, inner: &str) -> String {
+    format!("\\htmlData{{eqnloc={start}_{end}}}{{{inner}}}")
+}
+
+/// Like [`latex_eqn_expr0`], but every rendered node is wrapped in a
+/// `\htmlData{eqnloc=START_END}` annotation giving the byte range it covers
+/// in the source equation, and each binary/unary operator additionally gets
+/// an annotation spanning the gap between its operands -- the operator token
+/// plus any surrounding whitespace; the consumer trims that range to the
+/// operator itself. Exponentiation (superscript) and division (`\frac`) have
+/// no operator glyph, so they get only the whole-expression wrapper.
+///
+/// This is what the FFI's `simlin_model_get_latex_equation` returns; rendering
+/// the result requires enabling KaTeX's `trust` option, scoped to `\htmlData`.
+pub fn latex_eqn_expr0_annotated(expr: &Expr0) -> String {
+    let loc = expr.get_loc();
+    let inner = match expr {
+        Expr0::Const(s, n, _) => {
+            if n.is_nan() {
+                "\\mathrm{{NaN}}".to_owned()
+            } else {
+                s.clone()
+            }
+        }
+        Expr0::Var(raw, _) => {
+            let id = canonicalize(raw.as_str());
+            let id = str::replace(&id, "_", "\\_");
+            format!("\\mathrm{{{id}}}")
+        }
+        Expr0::App(UntypedBuiltinFn(name, args), _) => {
+            let rendered_args: Vec<String> = args.iter().map(latex_eqn_expr0_annotated).collect();
+            format!("\\operatorname{{{}}}({})", name, rendered_args.join(", "))
+        }
+        Expr0::Subscript(raw, indices, _) => {
+            let id = canonicalize(raw.as_str());
+            let rendered: Vec<String> = indices
+                .iter()
+                .map(|idx| match idx {
+                    IndexExpr0::Wildcard(_) => "*".to_string(),
+                    IndexExpr0::StarRange(id, _) => {
+                        format!("*:{}", canonicalize(id.as_str()))
+                    }
+                    IndexExpr0::Range(l, r, _) => {
+                        format!(
+                            "{}:{}",
+                            latex_eqn_expr0_annotated(l),
+                            latex_eqn_expr0_annotated(r)
+                        )
+                    }
+                    IndexExpr0::DimPosition(n, _) => format!("@{n}"),
+                    IndexExpr0::Expr(e) => latex_eqn_expr0_annotated(e),
+                })
+                .collect();
+            format!("{id}[{}]", rendered.join(", "))
+        }
+        Expr0::Op1(op, inner_expr, _) => {
+            let inner_rendered = latex_eqn_expr0_annotated(inner_expr);
+            match op {
+                UnaryOp::Transpose => format!("{inner_rendered}^T"),
+                _ => {
+                    let op_str: &str = match op {
+                        UnaryOp::Positive => "+",
+                        UnaryOp::Negative => "-",
+                        UnaryOp::Not => "\\neg ",
+                        UnaryOp::Transpose => unreachable!(), // handled above
+                    };
+                    // the operator token sits in [Op1.start, operand.start)
+                    let op_anno = latex_html_data(loc.start, inner_expr.get_loc().start, op_str);
+                    format!("{op_anno}{inner_rendered}")
+                }
+            }
+        }
+        Expr0::Op2(op, l, r, _) => {
+            let l_rendered = latex_eqn_expr0_annotated(l);
+            let r_rendered = latex_eqn_expr0_annotated(r);
+            match op {
+                BinaryOp::Exp => format!("{l_rendered}^{{{r_rendered}}}"),
+                BinaryOp::Div => format!("\\frac{{{l_rendered}}}{{{r_rendered}}}"),
+                _ => {
+                    let op_str: &str = match op {
+                        BinaryOp::Add => "+",
+                        BinaryOp::Sub => "-",
+                        BinaryOp::Mul => "\\cdot",
+                        BinaryOp::Mod => "%",
+                        BinaryOp::Gt => ">",
+                        BinaryOp::Lt => "<",
+                        BinaryOp::Gte => ">=",
+                        BinaryOp::Lte => "<=",
+                        BinaryOp::Eq => "=",
+                        BinaryOp::Neq => "!=",
+                        BinaryOp::And => "&&",
+                        BinaryOp::Or => "||",
+                        BinaryOp::Exp | BinaryOp::Div => unreachable!(), // handled above
+                    };
+                    // the operator token sits in [L.end, R.start)
+                    let op_anno = latex_html_data(l.get_loc().end, r.get_loc().start, op_str);
+                    format!("{l_rendered} {op_anno} {r_rendered}")
+                }
+            }
+        }
+        Expr0::If(cond, t, f, _) => {
+            let cond_r = latex_eqn_expr0_annotated(cond);
+            let t_r = latex_eqn_expr0_annotated(t);
+            let f_r = latex_eqn_expr0_annotated(f);
+            format!(
+                "\\begin{{cases}}
+                     {t_r} & \\text{{if }} {cond_r} \\\\
+                     {f_r} & \\text{{else}}
+                 \\end{{cases}}"
+            )
+        }
+    };
+    latex_html_data(loc.start, loc.end, &inner)
+}
+
 #[test]
 fn test_latex_eqn() {
     use crate::common::Ident;
@@ -879,6 +1010,40 @@ fn test_latex_eqn() {
             None,
             Loc::new(0, 14),
         ))
+    );
+}
+
+#[test]
+fn test_latex_eqn_expr0_annotated() {
+    use crate::lexer::LexerType;
+
+    let parse = |eqn: &str| Expr0::new(eqn, LexerType::Equation).unwrap().unwrap();
+
+    // `incidents * avg` -- identifiers `[0,9)` and `[12,15)`, the `*` operator
+    // annotation spans the gap " * " (`[9,12)`).
+    assert_eq!(
+        "\\htmlData{eqnloc=0_15}{\\htmlData{eqnloc=0_9}{\\mathrm{incidents}} \\htmlData{eqnloc=9_12}{\\cdot} \\htmlData{eqnloc=12_15}{\\mathrm{avg}}}",
+        latex_eqn_expr0_annotated(&parse("incidents * avg"))
+    );
+
+    // `not running` -- the `\neg` glyph's annotation spans `[0,4)` ("not ");
+    // the consumer trims that to "not" for caret placement.
+    assert_eq!(
+        "\\htmlData{eqnloc=0_11}{\\htmlData{eqnloc=0_4}{\\neg }\\htmlData{eqnloc=4_11}{\\mathrm{running}}}",
+        latex_eqn_expr0_annotated(&parse("not running"))
+    );
+
+    // identifier underscores are escaped as `\_` inside `\mathrm`; the `+`
+    // operator's annotation spans the gap " + " (`[3,6)`).
+    assert_eq!(
+        "\\htmlData{eqnloc=0_7}{\\htmlData{eqnloc=0_3}{\\mathrm{a\\_b}} \\htmlData{eqnloc=3_6}{+} \\htmlData{eqnloc=6_7}{\\mathrm{c}}}",
+        latex_eqn_expr0_annotated(&parse("a_b + c"))
+    );
+
+    // function call -- each argument is itself annotated.
+    assert_eq!(
+        "\\htmlData{eqnloc=0_9}{\\operatorname{min}(\\htmlData{eqnloc=4_5}{\\mathrm{a}}, \\htmlData{eqnloc=7_8}{\\mathrm{b}})}",
+        latex_eqn_expr0_annotated(&parse("min(a, b)"))
     );
 }
 

--- a/src/simlin-engine/src/ast/mod.rs
+++ b/src/simlin-engine/src/ast/mod.rs
@@ -335,6 +335,43 @@ fn paren_if_necessary1(parent: &Expr2, child: &Expr2, is_right_child: bool, eqn:
     if needs { format!("({eqn})") } else { eqn }
 }
 
+/// How a binary operator is laid out in LaTeX. Most are a simple infix token
+/// (`{l} <token> {r}`); exponentiation stacks the right operand as a
+/// superscript and division uses `\frac`, neither of which has a single
+/// operator glyph. Shared by every LaTeX-rendering path so the operator
+/// strings can't drift between them.
+enum BinaryOpLatex {
+    Infix(&'static str),
+    Superscript,
+    Fraction,
+}
+
+/// LaTeX rendering for a binary operator. The tokens are chosen to be valid in
+/// math mode and idiomatic: `mod` -> `\bmod` (`%` is the TeX comment
+/// character, so the previous rendering silently ate the right operand),
+/// `and`/`or` -> `\land`/`\lor` (`&` is an alignment tab outside an array
+/// environment; `||` renders as bare bars), and the comparisons use the
+/// proper relation symbols (`\neq`, `\geq`, `\leq`).
+fn binary_op_latex(op: BinaryOp) -> BinaryOpLatex {
+    use BinaryOpLatex::{Fraction, Infix, Superscript};
+    match op {
+        BinaryOp::Add => Infix("+"),
+        BinaryOp::Sub => Infix("-"),
+        BinaryOp::Mul => Infix("\\cdot"),
+        BinaryOp::Exp => Superscript,
+        BinaryOp::Div => Fraction,
+        BinaryOp::Mod => Infix("\\bmod"),
+        BinaryOp::Gt => Infix(">"),
+        BinaryOp::Lt => Infix("<"),
+        BinaryOp::Gte => Infix("\\geq"),
+        BinaryOp::Lte => Infix("\\leq"),
+        BinaryOp::Eq => Infix("="),
+        BinaryOp::Neq => Infix("\\neq"),
+        BinaryOp::And => Infix("\\land"),
+        BinaryOp::Or => Infix("\\lor"),
+    }
+}
+
 /// Check whether a canonicalized identifier needs double-quoting to be
 /// re-parseable.  Names containing characters outside XID_Start/XID_Continue
 /// (like `$`, `⁚`, `/`) must be quoted.
@@ -666,27 +703,11 @@ impl LatexVisitor {
             Expr2::Op2(op, l, r, _, _) => {
                 let l = paren_if_necessary1(expr, l, false, self.walk(l));
                 let r = paren_if_necessary1(expr, r, true, self.walk(r));
-                let op: &str = match op {
-                    BinaryOp::Add => "+",
-                    BinaryOp::Sub => "-",
-                    BinaryOp::Exp => {
-                        return format!("{l}^{{{r}}}");
-                    }
-                    BinaryOp::Mul => "\\cdot",
-                    BinaryOp::Div => {
-                        return format!("\\frac{{{l}}}{{{r}}}");
-                    }
-                    BinaryOp::Mod => "%",
-                    BinaryOp::Gt => ">",
-                    BinaryOp::Lt => "<",
-                    BinaryOp::Gte => ">=",
-                    BinaryOp::Lte => "<=",
-                    BinaryOp::Eq => "=",
-                    BinaryOp::Neq => "!=",
-                    BinaryOp::And => "&&",
-                    BinaryOp::Or => "||",
-                };
-                format!("{l} {op} {r}")
+                match binary_op_latex(*op) {
+                    BinaryOpLatex::Infix(token) => format!("{l} {token} {r}"),
+                    BinaryOpLatex::Superscript => format!("{l}^{{{r}}}"),
+                    BinaryOpLatex::Fraction => format!("\\frac{{{l}}}{{{r}}}"),
+                }
             }
             Expr2::If(cond, t, f, _, _) => {
                 let cond = self.walk(cond);
@@ -750,33 +771,26 @@ pub fn latex_eqn_expr0(expr: &Expr0) -> String {
                 .collect();
             format!("{id}[{}]", rendered.join(", "))
         }
-        Expr0::Op1(op, inner, _) => {
-            let inner = latex_eqn_expr0(inner);
-            match op {
-                UnaryOp::Positive => format!("+{inner}"),
-                UnaryOp::Negative => format!("-{inner}"),
-                UnaryOp::Not => format!("\\neg {inner}"),
-                UnaryOp::Transpose => format!("{inner}^T"),
+        Expr0::Op1(op, inner_expr, _) => match op {
+            UnaryOp::Transpose => format!("{}^T", latex_eqn_expr0(inner_expr)),
+            _ => {
+                let inner =
+                    paren_if_necessary(expr, inner_expr, false, latex_eqn_expr0(inner_expr));
+                match op {
+                    UnaryOp::Positive => format!("+{inner}"),
+                    UnaryOp::Negative => format!("-{inner}"),
+                    UnaryOp::Not => format!("\\neg {inner}"),
+                    UnaryOp::Transpose => unreachable!(), // handled above
+                }
             }
-        }
+        },
         Expr0::Op2(op, l, r, _) => {
-            let l = latex_eqn_expr0(l);
-            let r = latex_eqn_expr0(r);
-            match op {
-                BinaryOp::Add => format!("{l} + {r}"),
-                BinaryOp::Sub => format!("{l} - {r}"),
-                BinaryOp::Exp => format!("{l}^{{{r}}}"),
-                BinaryOp::Mul => format!("{l} \\cdot {r}"),
-                BinaryOp::Div => format!("\\frac{{{l}}}{{{r}}}"),
-                BinaryOp::Mod => format!("{l} % {r}"),
-                BinaryOp::Gt => format!("{l} > {r}"),
-                BinaryOp::Lt => format!("{l} < {r}"),
-                BinaryOp::Gte => format!("{l} >= {r}"),
-                BinaryOp::Lte => format!("{l} <= {r}"),
-                BinaryOp::Eq => format!("{l} = {r}"),
-                BinaryOp::Neq => format!("{l} != {r}"),
-                BinaryOp::And => format!("{l} && {r}"),
-                BinaryOp::Or => format!("{l} || {r}"),
+            let l = paren_if_necessary(expr, l, false, latex_eqn_expr0(l));
+            let r = paren_if_necessary(expr, r, true, latex_eqn_expr0(r));
+            match binary_op_latex(*op) {
+                BinaryOpLatex::Infix(token) => format!("{l} {token} {r}"),
+                BinaryOpLatex::Superscript => format!("{l}^{{{r}}}"),
+                BinaryOpLatex::Fraction => format!("\\frac{{{l}}}{{{r}}}"),
             }
         }
         Expr0::If(cond, t, f, _) => {
@@ -793,13 +807,28 @@ pub fn latex_eqn_expr0(expr: &Expr0) -> String {
     }
 }
 
-/// Wrap `inner` in a KaTeX `\htmlData{eqnloc=START_END}` annotation. KaTeX
-/// renders this as a span carrying `data-eqnloc="START_END"`, giving the
+/// Wrap `inner` in a KaTeX `\htmlData{<attr>=START_END}` annotation. KaTeX
+/// renders this as a span carrying `data-<attr>="START_END"`, giving the
 /// half-open byte range `[START, END)` of the source equation text that the
-/// span covers. The equation-preview click handler reads this back to place
-/// the caret precisely.
-fn latex_html_data(start: u16, end: u16, inner: &str) -> String {
-    format!("\\htmlData{{eqnloc={start}_{end}}}{{{inner}}}")
+/// span covers. `attr` is `eqnloc` for a syntax node (identifier, call,
+/// sub-expression …) or `oploc` for the gap around an operator token -- the
+/// distinction tells the equation-preview click handler whether the range may
+/// have grouping parentheses at its edges to trim past. See
+/// [`HtmlDataAttr`].
+enum HtmlDataAttr {
+    /// `data-eqnloc`: the byte range of a syntax node.
+    Node,
+    /// `data-oploc`: the byte range *between two operands*, holding an operator
+    /// token plus any surrounding whitespace and grouping parentheses.
+    Op,
+}
+
+fn latex_html_data(attr: HtmlDataAttr, start: u16, end: u16, inner: &str) -> String {
+    let name = match attr {
+        HtmlDataAttr::Node => "eqnloc",
+        HtmlDataAttr::Op => "oploc",
+    };
+    format!("\\htmlData{{{name}={start}_{end}}}{{{inner}}}")
 }
 
 /// Like [`latex_eqn_expr0`], but every rendered node is wrapped in a
@@ -853,47 +882,45 @@ pub fn latex_eqn_expr0_annotated(expr: &Expr0) -> String {
                 .collect();
             format!("{id}[{}]", rendered.join(", "))
         }
-        Expr0::Op1(op, inner_expr, _) => {
-            let inner_rendered = latex_eqn_expr0_annotated(inner_expr);
-            match op {
-                UnaryOp::Transpose => format!("{inner_rendered}^T"),
-                _ => {
-                    let op_str: &str = match op {
-                        UnaryOp::Positive => "+",
-                        UnaryOp::Negative => "-",
-                        UnaryOp::Not => "\\neg ",
-                        UnaryOp::Transpose => unreachable!(), // handled above
-                    };
-                    // the operator token sits in [Op1.start, operand.start)
-                    let op_anno = latex_html_data(loc.start, inner_expr.get_loc().start, op_str);
-                    format!("{op_anno}{inner_rendered}")
-                }
+        Expr0::Op1(op, inner_expr, _) => match op {
+            UnaryOp::Transpose => format!("{}^T", latex_eqn_expr0_annotated(inner_expr)),
+            _ => {
+                let op_str: &str = match op {
+                    UnaryOp::Positive => "+",
+                    UnaryOp::Negative => "-",
+                    UnaryOp::Not => "\\neg ",
+                    UnaryOp::Transpose => unreachable!(), // handled above
+                };
+                // the operator token sits somewhere in [Op1.start, operand.start)
+                let op_anno = latex_html_data(
+                    HtmlDataAttr::Op,
+                    loc.start,
+                    inner_expr.get_loc().start,
+                    op_str,
+                );
+                let inner_rendered = paren_if_necessary(
+                    expr,
+                    inner_expr,
+                    false,
+                    latex_eqn_expr0_annotated(inner_expr),
+                );
+                format!("{op_anno}{inner_rendered}")
             }
-        }
+        },
         Expr0::Op2(op, l, r, _) => {
-            let l_rendered = latex_eqn_expr0_annotated(l);
-            let r_rendered = latex_eqn_expr0_annotated(r);
-            match op {
-                BinaryOp::Exp => format!("{l_rendered}^{{{r_rendered}}}"),
-                BinaryOp::Div => format!("\\frac{{{l_rendered}}}{{{r_rendered}}}"),
-                _ => {
-                    let op_str: &str = match op {
-                        BinaryOp::Add => "+",
-                        BinaryOp::Sub => "-",
-                        BinaryOp::Mul => "\\cdot",
-                        BinaryOp::Mod => "%",
-                        BinaryOp::Gt => ">",
-                        BinaryOp::Lt => "<",
-                        BinaryOp::Gte => ">=",
-                        BinaryOp::Lte => "<=",
-                        BinaryOp::Eq => "=",
-                        BinaryOp::Neq => "!=",
-                        BinaryOp::And => "&&",
-                        BinaryOp::Or => "||",
-                        BinaryOp::Exp | BinaryOp::Div => unreachable!(), // handled above
-                    };
-                    // the operator token sits in [L.end, R.start)
-                    let op_anno = latex_html_data(l.get_loc().end, r.get_loc().start, op_str);
+            let l_rendered = paren_if_necessary(expr, l, false, latex_eqn_expr0_annotated(l));
+            let r_rendered = paren_if_necessary(expr, r, true, latex_eqn_expr0_annotated(r));
+            match binary_op_latex(*op) {
+                BinaryOpLatex::Superscript => format!("{l_rendered}^{{{r_rendered}}}"),
+                BinaryOpLatex::Fraction => format!("\\frac{{{l_rendered}}}{{{r_rendered}}}"),
+                BinaryOpLatex::Infix(token) => {
+                    // the operator token sits somewhere in [L.end, R.start)
+                    let op_anno = latex_html_data(
+                        HtmlDataAttr::Op,
+                        l.get_loc().end,
+                        r.get_loc().start,
+                        token,
+                    );
                     format!("{l_rendered} {op_anno} {r_rendered}")
                 }
             }
@@ -910,7 +937,64 @@ pub fn latex_eqn_expr0_annotated(expr: &Expr0) -> String {
             )
         }
     };
-    latex_html_data(loc.start, loc.end, &inner)
+    latex_html_data(HtmlDataAttr::Node, loc.start, loc.end, &inner)
+}
+
+#[test]
+fn test_latex_eqn_binary_op_strings() {
+    use crate::common::Ident;
+    // Every binary operator that lacks a clean source-syntax-equals-TeX token
+    // must render as something valid in math mode. Regression: `mod` used to
+    // render as `%` (the TeX comment character, which ate the right operand);
+    // `and`/`or` as `&&`/`||` (an alignment tab / bare bars).
+    let bin = |op| {
+        let l = Box::new(Expr2::Var(Ident::new("a"), None, Loc::new(0, 1)));
+        let r = Box::new(Expr2::Var(Ident::new("b"), None, Loc::new(2, 3)));
+        latex_eqn(&Expr2::Op2(op, l, r, None, Loc::new(0, 3)))
+    };
+    assert_eq!("\\mathrm{a} + \\mathrm{b}", bin(BinaryOp::Add));
+    assert_eq!("\\mathrm{a} - \\mathrm{b}", bin(BinaryOp::Sub));
+    assert_eq!("\\mathrm{a} \\cdot \\mathrm{b}", bin(BinaryOp::Mul));
+    assert_eq!("\\mathrm{a} \\bmod \\mathrm{b}", bin(BinaryOp::Mod));
+    assert_eq!("\\mathrm{a}^{\\mathrm{b}}", bin(BinaryOp::Exp));
+    assert_eq!("\\frac{\\mathrm{a}}{\\mathrm{b}}", bin(BinaryOp::Div));
+    assert_eq!("\\mathrm{a} > \\mathrm{b}", bin(BinaryOp::Gt));
+    assert_eq!("\\mathrm{a} < \\mathrm{b}", bin(BinaryOp::Lt));
+    assert_eq!("\\mathrm{a} \\geq \\mathrm{b}", bin(BinaryOp::Gte));
+    assert_eq!("\\mathrm{a} \\leq \\mathrm{b}", bin(BinaryOp::Lte));
+    assert_eq!("\\mathrm{a} = \\mathrm{b}", bin(BinaryOp::Eq));
+    assert_eq!("\\mathrm{a} \\neq \\mathrm{b}", bin(BinaryOp::Neq));
+    assert_eq!("\\mathrm{a} \\land \\mathrm{b}", bin(BinaryOp::And));
+    assert_eq!("\\mathrm{a} \\lor \\mathrm{b}", bin(BinaryOp::Or));
+}
+
+#[test]
+fn test_latex_eqn_expr0() {
+    use crate::lexer::LexerType;
+    let render =
+        |eqn: &str| latex_eqn_expr0(&Expr0::new(eqn, LexerType::Equation).unwrap().unwrap());
+
+    // the fixed operator tokens (same set as test_latex_eqn_binary_op_strings,
+    // but via the Expr0 path)
+    assert_eq!("\\mathrm{a} \\bmod \\mathrm{b}", render("a mod b"));
+    assert_eq!("\\mathrm{a} \\land \\mathrm{b}", render("a and b"));
+    assert_eq!("\\mathrm{a} \\lor \\mathrm{b}", render("a or b"));
+    assert_eq!("\\mathrm{a} \\neq \\mathrm{b}", render("a <> b"));
+    assert_eq!("\\mathrm{a} \\geq \\mathrm{b}", render("a >= b"));
+    assert_eq!("\\mathrm{a} \\leq \\mathrm{b}", render("a <= b"));
+
+    // precedence-preserving parentheses: a lower-precedence operand of a
+    // higher-precedence operator (or of a unary operator) must be parenthesized
+    // so the rendering means the same thing as the source.
+    assert_eq!(
+        "(\\mathrm{a} + \\mathrm{b}) \\cdot \\mathrm{c}",
+        render("(a + b) * c")
+    );
+    assert_eq!("-(\\mathrm{a} + \\mathrm{b})", render("-(a + b)"));
+    assert_eq!(
+        "\\mathrm{a} - (\\mathrm{b} - \\mathrm{c})",
+        render("a - (b - c)")
+    );
 }
 
 #[test]
@@ -1019,31 +1103,46 @@ fn test_latex_eqn_expr0_annotated() {
 
     let parse = |eqn: &str| Expr0::new(eqn, LexerType::Equation).unwrap().unwrap();
 
-    // `incidents * avg` -- identifiers `[0,9)` and `[12,15)`, the `*` operator
-    // annotation spans the gap " * " (`[9,12)`).
+    // `incidents * avg` -- identifiers get `eqnloc`; the `*` operator gap " * "
+    // (`[9,12)`) gets `oploc`, which the consumer trims to the `\cdot` itself.
     assert_eq!(
-        "\\htmlData{eqnloc=0_15}{\\htmlData{eqnloc=0_9}{\\mathrm{incidents}} \\htmlData{eqnloc=9_12}{\\cdot} \\htmlData{eqnloc=12_15}{\\mathrm{avg}}}",
+        "\\htmlData{eqnloc=0_15}{\\htmlData{eqnloc=0_9}{\\mathrm{incidents}} \\htmlData{oploc=9_12}{\\cdot} \\htmlData{eqnloc=12_15}{\\mathrm{avg}}}",
         latex_eqn_expr0_annotated(&parse("incidents * avg"))
     );
 
-    // `not running` -- the `\neg` glyph's annotation spans `[0,4)` ("not ");
-    // the consumer trims that to "not" for caret placement.
+    // `not running` -- the `\neg` glyph's `oploc` spans `[0,4)` ("not "); the
+    // consumer trims that to "not" for caret placement.
     assert_eq!(
-        "\\htmlData{eqnloc=0_11}{\\htmlData{eqnloc=0_4}{\\neg }\\htmlData{eqnloc=4_11}{\\mathrm{running}}}",
+        "\\htmlData{eqnloc=0_11}{\\htmlData{oploc=0_4}{\\neg }\\htmlData{eqnloc=4_11}{\\mathrm{running}}}",
         latex_eqn_expr0_annotated(&parse("not running"))
     );
 
     // identifier underscores are escaped as `\_` inside `\mathrm`; the `+`
-    // operator's annotation spans the gap " + " (`[3,6)`).
+    // operator gap " + " (`[3,6)`) gets `oploc`.
     assert_eq!(
-        "\\htmlData{eqnloc=0_7}{\\htmlData{eqnloc=0_3}{\\mathrm{a\\_b}} \\htmlData{eqnloc=3_6}{+} \\htmlData{eqnloc=6_7}{\\mathrm{c}}}",
+        "\\htmlData{eqnloc=0_7}{\\htmlData{eqnloc=0_3}{\\mathrm{a\\_b}} \\htmlData{oploc=3_6}{+} \\htmlData{eqnloc=6_7}{\\mathrm{c}}}",
         latex_eqn_expr0_annotated(&parse("a_b + c"))
     );
 
-    // function call -- each argument is itself annotated.
+    // function call -- each argument is itself annotated; the call's range
+    // (`eqnloc`, not `oploc`) includes the closing paren, which must not be
+    // trimmed.
     assert_eq!(
         "\\htmlData{eqnloc=0_9}{\\operatorname{min}(\\htmlData{eqnloc=4_5}{\\mathrm{a}}, \\htmlData{eqnloc=7_8}{\\mathrm{b}})}",
         latex_eqn_expr0_annotated(&parse("min(a, b)"))
+    );
+
+    // a fixed operator (`mod` -> `\bmod`); its `oploc` spans the gap " mod "
+    assert_eq!(
+        "\\htmlData{eqnloc=0_7}{\\htmlData{eqnloc=0_1}{\\mathrm{a}} \\htmlData{oploc=1_6}{\\bmod} \\htmlData{eqnloc=6_7}{\\mathrm{b}}}",
+        latex_eqn_expr0_annotated(&parse("a mod b"))
+    );
+
+    // precedence parentheses are added outside the inner node's annotation;
+    // the outer `*`'s `oploc` (`[6,10)` = ") * ") will be trimmed past the `)`.
+    assert_eq!(
+        "\\htmlData{eqnloc=1_11}{(\\htmlData{eqnloc=1_6}{\\htmlData{eqnloc=1_2}{\\mathrm{a}} \\htmlData{oploc=2_5}{+} \\htmlData{eqnloc=5_6}{\\mathrm{b}}}) \\htmlData{oploc=6_10}{\\cdot} \\htmlData{eqnloc=10_11}{\\mathrm{c}}}",
+        latex_eqn_expr0_annotated(&parse("(a + b) * c"))
     );
 }
 


### PR DESCRIPTION
## What & why

Clicking the rendered equation preview in the variable-details panel switches to the editable equation editor with the caret placed where you clicked. It worked well for clicks inside an identifier, but poorly *between* elements: for `Incidents*average_effort_required_to_remediate_an_incident`, clicking the rendered `·` (KaTeX's `\cdot` for `*`) landed the caret a character into `average_effort_…` instead of next to the `*`. The small `·` glyph sits in a few px of KaTeX spacing, so the click fell in that gap; the old heuristic then picked the nearest *text* glyph (the next identifier's first char) and placed the caret after it.

This PR rebuilds the mapping so it's **exact**, by recording the source↔rendered correspondence at LaTeX-generation time instead of reconstructing it from the DOM afterward — and along the way fixes a few related rendering bugs in the equation preview.

Fixes #535.

## How

**Engine (`src/simlin-engine/src/ast/mod.rs`).**

- `Ast::to_latex` (what the FFI's `simlin_model_get_latex_equation` returns, and thus what the preview renders) now wraps every rendered node in a `\htmlData{eqnloc=START_END}` annotation giving the half-open byte range `[START, END)` it covers in the source equation text (KaTeX renders this as a span carrying `data-eqnloc="START_END"`). Each binary/unary operator additionally gets a `\htmlData{oploc=START_END}` annotation spanning the *gap between its operands* — the operator token plus any surrounding whitespace and grouping parentheses; the consumer trims that to the operator itself. Exponentiation (rendered as a superscript) and division (`\frac`) have no operator glyph, so they get only the whole-expression wrapper. Array equations still render as `TODO(array)` as before.

- **#535: operators that aren't valid TeX.** `mod` rendered as `%` — the TeX comment character — so `a mod b` showed as just `a` (everything from `%` onward was eaten). `and`/`or` rendered as `&&`/`||`: `&` outside an array environment is an alignment tab (a KaTeX error), `||` renders as bare vertical bars. `<>` rendered as `!=`, which isn't valid Simlin input. These now render `\bmod`, `\land`/`\lor`, `\neq`, and the comparison operators use the proper relation symbols (`\geq`, `\leq`). A shared `binary_op_latex` helper is now the single source of truth for the operator strings, used by every LaTeX-rendering path so the Expr0 and Expr2 paths can't drift.

- **Precedence parentheses.** The Expr0 LaTeX paths (the plain `latex_eqn_expr0` and the annotated variant the FFI uses) weren't wrapping operands in precedence-preserving parentheses, so `(a + b) * c` rendered as `a + b \cdot c` — a *different* equation. They now use `paren_if_necessary`, matching what the Expr2 LaTeX path and the ASCII pretty-printer already did. (The annotated variant adds the parens outside the inner node's `\htmlData` wrapper.)

- The plain `to_latex` / `latex_eqn_expr0` / `latex_eqn` (Expr2) are still available for callers wanting unannotated LaTeX; only the FFI path moved to the annotated variant.

**Diagram (`src/diagram/equation-caret.ts`, `src/diagram/VariableDetails.tsx`).**

- KaTeX is now rendered with `trust` scoped to `\htmlData` — the only trusted command the engine emits, and it produces nothing but inert `data-*` attributes, so a user identifier that smuggled a `\href`/`\url`/etc. into the LaTeX is still rejected.
- On a preview click, the handler finds the innermost `[data-eqnloc]`/`[data-oploc]` span under the cursor and maps the click within it (`caretOffsetWithinSpan`): glyph-for-glyph for identifiers / numbers / single-character operators (so clicking mid-identifier still puts the caret mid-identifier), interpolated when the rendered glyph count and byte count differ (e.g. clicking a function name or parenthesis). For an `oploc` (operator-gap) span it trims whitespace *and* parentheses off the ends to home in on the operator token (`(a+b)*c` → the `*` gap is `)*`, trimmed to `*`); for an `eqnloc` (syntax-node) span it trims whitespace only — a function call's range legitimately ends with `)`.
- A heuristic **fallback** handles the case where the rendered LaTeX has no annotations — i.e. the engine produced no LaTeX and the preview rendered the raw equation text instead: it finds the nearest glyph boundary in 2D, then aligns the rendered glyph string to the source text character-for-character (with a little slack for `/`-as-fraction, `^`-as-superscript, lower-cased identifiers, etc.). A final coarse proportional mapping covers the case where KaTeX rendered nothing measurable.
- The `not` keyword renders as `\neg` (a `¬` glyph); `glyphToAscii` maps that glyph back to the string `'not'` and the aligner consumes multi-character glyph mappings, so caret placement for `not <expr>` works in both the annotated and fallback paths (`!` is not a token in Simlin's equation syntax — XMILE spells logical negation as the word `not` and not-equal as `<>` — so the glyph never maps to a literal `!`).
- Dropped the `insertBreaks` LaTeX post-processing: its regexes (`s/=/=\allowbreak{} /`, `s/,/,\allowbreak{} /`, …) would corrupt the `=`/`,` inside `\htmlData{eqnloc=…}`. Long equations still wrap — `.eqnPreview .katex` has `overflow-wrap: anywhere; word-break: break-word`.

Net: `VariableDetails.tsx` is ~300 lines smaller; the mapping logic lives in the pure, tested `equation-caret.ts`, and the DOM walk (collect glyph boxes, read `data-eqnloc`/`data-oploc`) is the only imperative-shell part left in `VariableDetails.tsx`.

## Notes

- Equations with errors never hit this path: the preview isn't shown for them (`showPreview = !errors && !unitErrors && !editingEquation`) — they go straight to the editable Slate editor with a red squiggle.
- `paren_if_necessary` adds (visually-redundant) parentheses to `\frac` numerators/denominators and to `^` exponents in the cases where the operand has lower precedence — this matches the pre-existing Expr2-path behavior; tightening `needs_parens_for_op` to know those operands are already visually grouped is a separate cleanup that should apply to all paths uniformly.
- The engine change means the WASM artifact needs a rebuild (`./scripts/dev-init.sh` / `pnpm build`) for a running app to pick up the new LaTeX; the diagram tests don't exercise that path.

## Testing

- `src/simlin-engine/src/ast/mod.rs`: `test_latex_eqn_binary_op_strings` pins the operator strings for every binary op (Expr2 path); `test_latex_eqn_expr0` covers the fixed operators and the precedence-parenthesis cases (`(a+b)*c`, `-(a+b)`, `a-(b-c)`) via the Expr0 path; `test_latex_eqn_expr0_annotated` pins the annotated output (`eqnloc`/`oploc` placement, `\neg`, escaped-underscore identifiers, function calls, a fixed operator, a parenthesized sub-expression). `cargo test --workspace` green; `libsimlin` model tests (including `test_model_get_latex_equation`) green.
- `src/diagram/tests/equation-caret.test.ts`: 27 cases across `glyphToAscii`, `alignGlyphsToSource` (identity / case-insensitive idents / dropped whitespace / `/`-fraction & `^`-superscript resync / extra glyphs / `not`-keyword), `nearestGlyphBoundary`, `caretOffsetForClick`, and `caretOffsetWithinSpan` (1:1 within identifiers, whitespace + paren trimming on operator gaps, a function call's trailing-paren kept on a node span, empty/degenerate spans, interpolation in bounds). Full diagram suite 865/865; tsc + lint clean.
- The whole pre-commit suite (Rust fmt/clippy/test, TS lint/typecheck/test, WASM build, pysimlin) passes.