### PR TITLE
pysimlin: fix schema path (doc/ -> docs/) and add missing ModelGroup dataclass

### DIFF
--- a/src/pysimlin/simlin/json_types.py
+++ b/src/pysimlin/simlin/json_types.py
@@ -314,6 +314,18 @@ class MacroSpec:
     additional_outputs: list[str] = field(default_factory=list)
 
 
+
+@dataclass
+class ModelGroup:
+    """Semantic/organizational group for categorizing model variables."""
+
+    name: str
+    doc: str | None = None
+    parent: str | None = None
+    members: list[str] = field(default_factory=list)
+    run_enabled: bool = False
+
+
 @dataclass
 class Model:
     """A model in the project."""
@@ -327,6 +339,7 @@ class Model:
     views: list[View] = field(default_factory=list)
     loop_metadata: list[LoopMetadata] = field(default_factory=list)
     macro_spec: MacroSpec | None = None
+    groups: list[ModelGroup] = field(default_factory=list)
 
 
 @dataclass

--- a/src/pysimlin/tests/test_json_types.py
+++ b/src/pysimlin/tests/test_json_types.py
@@ -43,7 +43,7 @@ from simlin.json_types import (
 )
 
 # Load the JSON schema
-SCHEMA_PATH = Path(__file__).parents[3] / "doc" / "simlin-project.schema.json"
+SCHEMA_PATH = Path(__file__).parents[3] / "docs" / "simlin-project.schema.json"
 if SCHEMA_PATH.exists():
     with open(SCHEMA_PATH) as f:
         PROJECT_SCHEMA = json.load(f)


### PR DESCRIPTION
Fixes #550 and fills the ModelGroup gap it revealed. Two changes:

1. Fix the schema path in test_json_types.py from `doc/` to `docs/`; activates the 4 schema-compliance tests that have been silently skipped.

2. Add the missing `ModelGroup` dataclass and `groups` field to the Python `Model` class. Rust `json::Model`, TS `JsonModel`, and the JSON schema all have it; Python was the only layer missing it. `groups` is optional in the schema so this is backward-compatible; existing serialized data without groups still deserializes fine.