### PR TITLE
engine: cut C-LEARN compile time 4.4x (2539ms to 579ms)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3860,6 +3860,7 @@ dependencies = [
  "rand 0.9.4",
  "rayon",
  "resvg",
+ "rustc-hash",
  "salsa",
  "schemars",
  "serde",

--- a/src/simlin-engine/Cargo.toml
+++ b/src/simlin-engine/Cargo.toml
@@ -28,6 +28,10 @@ prost = "0.14"
 float-cmp = "0.10"
 ordered-float = "5"
 smallvec = { version = "1", features = [ "union" ] }
+# Fast, deterministic (fixed-seed) hasher for hot internal maps in the
+# dependency-graph cycle gate. Wasm-safe (no getrandom). FxHash's fixed seed
+# keeps map iteration deterministic where it is intentionally not order-leaking.
+rustc-hash = "2"
 ed25519 = { version = "2", optional = true }
 base64 = { version = "0.22", optional = true }
 serde = { version = "1", features = ["derive"] }

--- a/src/simlin-engine/src/common.rs
+++ b/src/simlin-engine/src/common.rs
@@ -50,18 +50,26 @@ const INTERNER_SHARDS: usize = 64;
 /// One shard: a content-keyed map from string -> weak handle. A `Weak`
 /// (not `Arc`) is stored so the entry does not itself keep the payload alive;
 /// the payload is reclaimed when the last *external* `Arc` drops.
-type Shard = std::collections::HashMap<Box<str>, std::sync::Weak<Interned>>;
+///
+/// Keyed with `FxHashMap` (rustc's fixed-seed FxHash) rather than the std
+/// default SipHash: identifier strings are short and the interner is on the
+/// hottest compile path (`canonicalize`/`Ident::new` -> `intern`), so the
+/// per-shard get/insert hashing is a measurable share of compile self-time.
+/// The hasher is purely a performance detail here -- the map still de-dups by
+/// string CONTENT, so which strings share a payload is unaffected.
+type Shard = rustc_hash::FxHashMap<Box<str>, std::sync::Weak<Interned>>;
 
 /// The global interner: a fixed array of independently-locked shards.
 ///
-/// `hasher` is used only to pick a shard (the per-shard `HashMap` rehashes the
-/// key with its own hasher). It is created once and reused for the life of the
-/// process, so the shard chosen for a given string at insert is the same shard
-/// `Drop` recomputes for eviction. The seed value itself is irrelevant to
-/// correctness -- only its consistency within the process matters.
+/// Shard selection hashes the key with `FxBuildHasher` (the per-shard map
+/// rehashes the key with its own FxHash hasher). `FxBuildHasher` is a
+/// zero-size, fixed-seed unit type, so there is nothing to store: the shard
+/// chosen for a given string at insert is the same shard `hash_of` recomputes
+/// for `contains` and that `Drop` recomputes for eviction. The hasher being
+/// fixed-seed (vs the old `RandomState`'s per-process random seed) only makes
+/// shard selection deterministic across runs; dedup-by-content is unchanged.
 struct Interner {
     shards: [std::sync::Mutex<Shard>; INTERNER_SHARDS],
-    hasher: std::hash::RandomState,
 }
 
 impl Interner {
@@ -69,17 +77,16 @@ impl Interner {
         // `std::sync::OnceLock` (std-only) lazily initializes the global.
         static GLOBAL: std::sync::OnceLock<Interner> = std::sync::OnceLock::new();
         GLOBAL.get_or_init(|| Interner {
-            shards: std::array::from_fn(|_| std::sync::Mutex::new(Shard::new())),
-            // One `RandomState` instance, created once and reused for the life
-            // of the process so shard selection is self-consistent between
-            // insert and eviction.
-            hasher: std::hash::RandomState::new(),
+            shards: std::array::from_fn(|_| std::sync::Mutex::new(Shard::default())),
         })
     }
 
     fn hash_of(&self, s: &str) -> u64 {
         use std::hash::BuildHasher;
-        self.hasher.hash_one(s)
+        // `FxBuildHasher` is a fixed-seed zero-size unit type, so a fresh
+        // `default()` is the same hasher every call -- shard selection stays
+        // self-consistent between insert, `contains`, and eviction.
+        rustc_hash::FxBuildHasher.hash_one(s)
     }
 
     /// Total number of entries currently held across all shards. Test-only:

--- a/src/simlin-engine/src/common.rs
+++ b/src/simlin-engine/src/common.rs
@@ -14,6 +14,280 @@ use crate::ast::Loc;
 pub type DimensionName = String;
 pub type ElementName = String;
 
+// ===== Canonical-identifier string interner =====
+//
+// A global, thread-safe, de-duplicating, *non-leaking* string interner. It
+// backs all three canonical identifier newtypes so that constructing one for a
+// string that has already been seen is a hashmap probe plus an `Arc` clone --
+// no fresh `String` allocation -- and `Clone` is an atomic refcount bump.
+//
+// Why a hand-rolled interner rather than the `internment` crate: the obvious
+// choice (`internment::ArcIntern<str>`) is backed by `dashmap`, which pulls in
+// `ahash` -> `getrandom`. `getrandom` does not build for the
+// `wasm32-unknown-unknown` target without a `wasm_js` cfg, and the engine ships
+// in the libsimlin wasm bundle (`src/engine/build.sh`). The previous engine
+// dependency graph had no `getrandom` edge, so adopting `internment` would
+// break the wasm build (which is part of the pre-commit hook and CI). This
+// std-only interner avoids that entirely while preserving the same semantics
+// (dedup, O(1) clone, refcount-reclaim on last drop, thread-safe).
+
+/// The heap-allocated, refcounted payload of one interned canonical string.
+/// Held behind an `Arc`; when the last `Arc` drops, the `Drop` impl evicts the
+/// now-dead entry from the interner so the table does not grow without bound
+/// across the lifetime of a long-running process.
+struct Interned {
+    /// The shard this entry lives in, cached so `Drop` can re-lock the right
+    /// shard in O(1) without recomputing it from the hash.
+    shard: usize,
+    s: Box<str>,
+}
+
+/// Number of shards. A power of two so the shard index is a cheap mask of the
+/// hash. Compilation fans out across rayon threads, so sharding keeps lock
+/// contention low without a concurrent-map dependency.
+const INTERNER_SHARDS: usize = 64;
+
+/// One shard: a content-keyed map from string -> weak handle. A `Weak`
+/// (not `Arc`) is stored so the entry does not itself keep the payload alive;
+/// the payload is reclaimed when the last *external* `Arc` drops.
+type Shard = std::collections::HashMap<Box<str>, std::sync::Weak<Interned>>;
+
+/// The global interner: a fixed array of independently-locked shards.
+///
+/// `hasher` is used only to pick a shard (the per-shard `HashMap` rehashes the
+/// key with its own hasher). It is created once and reused for the life of the
+/// process, so the shard chosen for a given string at insert is the same shard
+/// `Drop` recomputes for eviction. The seed value itself is irrelevant to
+/// correctness -- only its consistency within the process matters.
+struct Interner {
+    shards: [std::sync::Mutex<Shard>; INTERNER_SHARDS],
+    hasher: std::hash::RandomState,
+}
+
+impl Interner {
+    fn global() -> &'static Interner {
+        // `std::sync::OnceLock` (std-only) lazily initializes the global.
+        static GLOBAL: std::sync::OnceLock<Interner> = std::sync::OnceLock::new();
+        GLOBAL.get_or_init(|| Interner {
+            shards: std::array::from_fn(|_| std::sync::Mutex::new(Shard::new())),
+            // One `RandomState` instance, created once and reused for the life
+            // of the process so shard selection is self-consistent between
+            // insert and eviction.
+            hasher: std::hash::RandomState::new(),
+        })
+    }
+
+    fn hash_of(&self, s: &str) -> u64 {
+        use std::hash::BuildHasher;
+        self.hasher.hash_one(s)
+    }
+
+    /// Total number of entries currently held across all shards. Test-only:
+    /// used to assert that dropping the last handle reclaims the entry (the
+    /// non-leaking invariant). Not exact under concurrency, but the unit tests
+    /// that call it use process-unique strings on a single thread.
+    #[cfg(test)]
+    fn live_entry_count(&self) -> usize {
+        self.shards.iter().map(|m| m.lock().unwrap().len()).sum()
+    }
+
+    /// Whether a specific string currently has a live interned entry.
+    /// Test-only reclaim probe.
+    #[cfg(test)]
+    fn contains(&self, s: &str) -> bool {
+        let hash = self.hash_of(s);
+        let shard_idx = (hash as usize) & (INTERNER_SHARDS - 1);
+        let shard = self.shards[shard_idx].lock().unwrap();
+        shard.get(s).map(|w| w.upgrade().is_some()).unwrap_or(false)
+    }
+
+    /// Intern `s`: return an `Arc<Interned>` shared with any live handle for the
+    /// same content, allocating a new payload only on the first sighting.
+    fn intern(&self, s: &str) -> std::sync::Arc<Interned> {
+        let hash = self.hash_of(s);
+        let shard_idx = (hash as usize) & (INTERNER_SHARDS - 1);
+        // `.unwrap()` on the shard lock: poisoning is unreachable here and in
+        // `Drop` -- the only work done while holding a shard lock is hashmap
+        // operations and the `Box`/`Arc` allocations below, none of which can
+        // unwind (allocation failure aborts), so the `Mutex` can never be
+        // poisoned.
+        let mut shard = self.shards[shard_idx].lock().unwrap();
+
+        if let Some(weak) = shard.get(s)
+            && let Some(arc) = weak.upgrade()
+        {
+            // Live entry: share it. (If `upgrade` fails the payload is mid-drop
+            // -- its `Drop` will remove the dead weak; we fall through and
+            // replace it below, which is safe because the guard in `Drop`
+            // only removes an entry whose weak still points at the dead payload.)
+            return arc;
+        }
+
+        let arc = std::sync::Arc::new(Interned {
+            shard: shard_idx,
+            s: Box::from(s),
+        });
+        // Insert (or overwrite a dead weak) keyed by an owned copy of the
+        // string. Overwriting a dead weak here is what makes the `Drop` guard
+        // (`std::ptr::eq` on the weak target) necessary for correctness.
+        //
+        // This allocates a second `Box<str>` for the map key (the payload owns
+        // the first). It is deliberately left simple: this is the cold
+        // first-sighting path (one distinct canonical string ever reaches it
+        // once), not the hot reuse path that the `upgrade()` fast path above
+        // serves, so the extra allocation does not show up in the compile
+        // profile. Sharing one allocation would mean keying the map on an
+        // `Arc<str>` cloned from the payload, trading the allocation for a
+        // second `Arc` indirection on every access -- not worth it here.
+        shard.insert(Box::from(s), std::sync::Arc::downgrade(&arc));
+        arc
+    }
+}
+
+impl Drop for Interned {
+    fn drop(&mut self) {
+        // Reclaim the table entry for this now-dead payload. Re-lock the same
+        // shard and remove the entry *only if* its weak still refers to this
+        // payload: a concurrent `intern` of the same string after our strong
+        // count hit zero may have installed a fresh `Arc` (and overwritten the
+        // weak); we must not evict that live replacement.
+        let interner = Interner::global();
+        let mut shard = interner.shards[self.shard].lock().unwrap();
+        if let Some(weak) = shard.get(self.s.as_ref()) {
+            // `Weak::as_ptr` is stable across upgrade/downgrade and identifies
+            // the payload. If it points at `self`, this entry is ours to evict.
+            if std::ptr::eq(weak.as_ptr(), self as *const Interned) {
+                shard.remove(self.s.as_ref());
+            }
+        }
+    }
+}
+
+/// Interned, de-duplicated storage for a canonical identifier string.
+///
+/// This is the single backing store for all three canonical identifier
+/// newtypes (`Ident<Canonical>`, `CanonicalElementName`,
+/// `CanonicalDimensionName`). Constructing one for a string that has already
+/// been interned is a hashmap hit plus an atomic refcount bump -- no new
+/// `String` allocation -- and `Clone` is likewise a refcount bump, so cloning
+/// identifiers (which the compiler does constantly) is O(1). Entries are
+/// reclaimed when the last handle drops (see `Drop for Interned`), so a
+/// long-lived process that compiles many distinct models does not leak.
+///
+/// The string stored here is assumed to already be in canonical form; callers
+/// canonicalize before constructing (see `Ident::new` / `from_raw`). The
+/// `_unchecked` constructors trust the caller, matching the previous
+/// `String`-backed contract.
+///
+/// ## Trait impls (and why they are manual)
+///
+/// We implement the comparison/hash traits deliberately and let the three
+/// public newtypes simply `#[derive(...)]` (which delegates to the impls here):
+/// - `Hash` is **value based** (`self.as_str().hash()`). This is required so
+///   `HashMap<Ident, _>` lookups via the `Borrow<str>` path stay sound: the map
+///   hashes the `&str` key with `str`'s hasher and must find the entry whose
+///   key hashes identically.
+/// - `PartialEq`/`Eq` use `Arc` pointer equality, which is value-correct
+///   precisely because the interner de-duplicates (one payload per distinct
+///   string), and is consistent with the value-based `Hash`.
+/// - `Ord`/`PartialOrd` are **lexicographic by string content**. Many
+///   `BTreeSet`/`BTreeMap` orderings and the deterministic byte-stable runlists
+///   depend on this; a pointer-address ordering would be non-deterministic
+///   across runs.
+/// - `salsa::Update`: interned values are immutable, so `maybe_update`
+///   overwrites and reports a change iff the new value differs from the old by
+///   string content. `Arc<Interned>`/`str` are not covered by salsa's blanket
+///   `Update` impls, so this is provided manually here; the public newtypes
+///   keep `#[derive(salsa::Update)]`, whose per-field dispatch finds this impl.
+#[derive(Clone)]
+pub(crate) struct CanonicalStorage(std::sync::Arc<Interned>);
+
+// `Debug` is unconditional (not gated on the `debug-derive` feature) because
+// `Ident<State>` derives `Debug` unconditionally (it predates the feature),
+// and a field type must be `Debug` for that derive to hold with the feature
+// off. Printing the canonical string is the useful representation anyway.
+impl fmt::Debug for CanonicalStorage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Debug::fmt(self.as_str(), f)
+    }
+}
+
+impl CanonicalStorage {
+    /// Intern a string that is already in canonical form. A hashmap hit plus an
+    /// `Arc` refcount bump when the string has been seen before; otherwise
+    /// allocates the backing payload once.
+    fn intern(canonical: &str) -> Self {
+        CanonicalStorage(Interner::global().intern(canonical))
+    }
+
+    /// Borrow the canonical string.
+    fn as_str(&self) -> &str {
+        &self.0.s
+    }
+}
+
+impl PartialEq for CanonicalStorage {
+    fn eq(&self, other: &Self) -> bool {
+        // De-duplication guarantees one payload per distinct string, so O(1)
+        // `Arc` pointer equality is exactly value equality. (Fast path; falls
+        // back to nothing -- distinct pointers always mean distinct strings.)
+        std::sync::Arc::ptr_eq(&self.0, &other.0)
+    }
+}
+
+impl Eq for CanonicalStorage {}
+
+impl std::hash::Hash for CanonicalStorage {
+    fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
+        // Value-based, consistent with `str`'s Hash so `Borrow<str>` HashMap
+        // lookups work (see the type-level docs). Must NOT hash the pointer.
+        self.as_str().hash(state);
+    }
+}
+
+impl PartialOrd for CanonicalStorage {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for CanonicalStorage {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        // Lexicographic by string content: runlist determinism and BTree
+        // ordering depend on this (NOT pointer address).
+        self.as_str().cmp(other.as_str())
+    }
+}
+
+// SAFETY: `CanonicalStorage` is an owned, immutable interned handle. It owns
+// its (refcounted) data, contains no borrowed `'db` references, and its `Eq`
+// is value equality (consistent with `Hash`), so comparing an old-revision
+// value with a new-revision value is well defined. `maybe_update` therefore
+// follows the standard owned-`Eq` pattern: overwrite and report a change iff
+// the values differ. This mirrors salsa's `update_fallback` but is written by
+// hand because neither `Arc<Interned>` nor `str` is covered by salsa's blanket
+// `Update` impls.
+//
+// The crate is `#![deny(unsafe_code)]`; this is the one opt-in here, mirroring
+// the precedent in `vm.rs`. The `unsafe` is confined to dereferencing the
+// `*mut Self` salsa hands us, under the documented `Update` contract.
+#[allow(unsafe_code)]
+unsafe impl salsa::Update for CanonicalStorage {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        // SAFETY: by the `Update` contract `old_pointer` points to a valid,
+        // fully-owned `CanonicalStorage` from a (possibly older) revision; an
+        // owned interned handle has no dangling borrows, so taking a `&mut` is
+        // sound.
+        let old = unsafe { &mut *old_pointer };
+        if *old != new_value {
+            *old = new_value;
+            true
+        } else {
+            false
+        }
+    }
+}
+
 /// A canonicalized identifier - guaranteed to be in canonical form (OLD - being replaced)
 ///
 /// Canonical form means:
@@ -28,9 +302,15 @@ pub type ElementName = String;
 pub struct RawIdent(String);
 
 /// A canonicalized dimension name
+///
+/// Backed by interned, de-duplicated storage (see [`CanonicalStorage`]): the
+/// derived `PartialEq`/`Eq`/`Hash`/`Ord`/`PartialOrd`/`salsa::Update` all
+/// delegate to that handle's manual impls (value equality + value hash +
+/// lexicographic order), so the observable behavior is identical to the old
+/// `String` backing while construction and clone avoid allocation.
 #[cfg_attr(feature = "debug-derive", derive(Debug))]
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, salsa::Update)]
-pub struct CanonicalDimensionName(String);
+pub struct CanonicalDimensionName(CanonicalStorage);
 
 /// A raw dimension name as it appears in source
 #[cfg_attr(feature = "debug-derive", derive(Debug))]
@@ -38,9 +318,13 @@ pub struct CanonicalDimensionName(String);
 pub struct RawDimensionName(String);
 
 /// A canonicalized element name (dimension element)
+///
+/// Backed by interned, de-duplicated storage (see [`CanonicalStorage`]); the
+/// derived trait impls delegate to that handle, matching the old `String`
+/// backing's behavior without per-construction allocation.
 #[cfg_attr(feature = "debug-derive", derive(Debug))]
 #[derive(Clone, PartialEq, Eq, Hash, PartialOrd, Ord, salsa::Update)]
-pub struct CanonicalElementName(String);
+pub struct CanonicalElementName(CanonicalStorage);
 
 /// A raw element name as it appears in source
 #[cfg_attr(feature = "debug-derive", derive(Debug))]
@@ -1025,6 +1309,413 @@ fn test_fmt_display_implementations() {
     assert_eq!(format!("{canonical_str}"), "model·var");
 }
 
+/// Tests for the interned storage backing the canonical identifier newtypes
+/// (`Ident<Canonical>`, `CanonicalElementName`, `CanonicalDimensionName`).
+///
+/// The behavioral contract these pin down:
+/// - lexicographic `Ord`/`PartialOrd` (determinism of runlists / `BTreeSet`
+///   ordering), which must equal sorting the equivalent `&str`s even though
+///   the interned handle's natural `Ord` could be pointer-based;
+/// - value equality + de-duplication: two values built from strings that
+///   canonicalize to the same form are `==`, hash equal, AND share one
+///   backing allocation (the whole point of interning);
+/// - `Clone` is a cheap handle copy that shares the backing allocation rather
+///   than re-allocating a `String`;
+/// - HashMap lookups keyed by these types still work both by value and via
+///   the `Borrow<str>` path, which requires the manual `Hash` to be value
+///   based (consistent with `str`'s `Hash`), not pointer based;
+/// - the canonicalization edge cases (idempotency, the `LITERAL_PERIOD_SENTINEL`
+///   quoted-period idents) and source round-trip continue to hold.
+#[cfg(test)]
+mod interned_identifier_tests {
+    use super::*;
+    use std::collections::{BTreeSet, HashMap};
+
+    /// The data pointer behind a canonical `&str`. Two interned handles that
+    /// dedup to the same string share this pointer; two independent `String`
+    /// allocations of the same content do not.
+    fn data_ptr(s: &str) -> *const u8 {
+        s.as_ptr()
+    }
+
+    // ----- Constraint 2: lexicographic Ord / PartialOrd -----
+
+    #[test]
+    fn ident_sort_order_matches_str_sort_order() {
+        // Deliberately includes the `·` module separator and unicode so the
+        // ordering exercises more than ASCII; the canonical forms are stable.
+        let raws = [
+            "zebra",
+            "apple",
+            "model·variable",
+            "model·alpha",
+            "café",
+            "a_b_c",
+            "Apple", // canonicalizes to "apple" -> dedups with index 1
+            "MODEL·Variable",
+        ];
+        let idents: Vec<Ident<Canonical>> = raws.iter().map(|s| Ident::new(s)).collect();
+
+        let mut by_ident = idents.clone();
+        by_ident.sort();
+
+        let mut by_str: Vec<Ident<Canonical>> = idents.clone();
+        by_str.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+
+        let ident_order: Vec<&str> = by_ident.iter().map(|i| i.as_str()).collect();
+        let str_order: Vec<&str> = by_str.iter().map(|i| i.as_str()).collect();
+        assert_eq!(
+            ident_order, str_order,
+            "Ident sort order must equal &str sort order"
+        );
+
+        // And explicit pairwise lexicographic checks (independent of the sort).
+        let a = Ident::new("apple");
+        let z = Ident::new("zebra");
+        assert!(a < z);
+        assert!(z > a);
+        assert_eq!(a.cmp(&z), std::cmp::Ordering::Less);
+        assert_eq!(a.cmp(&a.clone()), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn element_name_sort_order_matches_str_sort_order() {
+        let raws = ["Boston", "atlanta", "nyc", "Chicago", "denver"];
+        let names: Vec<CanonicalElementName> = raws
+            .iter()
+            .map(|s| CanonicalElementName::from_raw(s))
+            .collect();
+
+        let mut by_name = names.clone();
+        by_name.sort();
+        let mut by_str = names.clone();
+        by_str.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        assert_eq!(
+            by_name.iter().map(|n| n.as_str()).collect::<Vec<_>>(),
+            by_str.iter().map(|n| n.as_str()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn dimension_name_sort_order_matches_str_sort_order() {
+        let raws = ["Region", "age_group", "scenario", "Cohort"];
+        let names: Vec<CanonicalDimensionName> = raws
+            .iter()
+            .map(|s| CanonicalDimensionName::from_raw(s))
+            .collect();
+
+        let mut by_name = names.clone();
+        by_name.sort();
+        let mut by_str = names.clone();
+        by_str.sort_by(|a, b| a.as_str().cmp(b.as_str()));
+        assert_eq!(
+            by_name.iter().map(|n| n.as_str()).collect::<Vec<_>>(),
+            by_str.iter().map(|n| n.as_str()).collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn btreeset_of_idents_is_lexicographically_ordered() {
+        // BTreeSet ordering is the runlist-determinism-critical case.
+        let set: BTreeSet<Ident<Canonical>> = ["gamma", "alpha", "beta", "Alpha"]
+            .iter()
+            .map(|s| Ident::new(s))
+            .collect();
+        // "Alpha" dedups with "alpha", so 3 distinct elements.
+        let ordered: Vec<&str> = set.iter().map(|i| i.as_str()).collect();
+        assert_eq!(ordered, vec!["alpha", "beta", "gamma"]);
+    }
+
+    // ----- Constraint 3: value equality + de-duplication -----
+
+    #[test]
+    fn equal_inputs_are_equal_and_dedup_to_one_allocation() {
+        // Two independent constructions of an equal canonical value.
+        let a = Ident::new("Hello World");
+        let b = Ident::new("hello world"); // canonicalizes identically
+        assert_eq!(a, b, "values that canonicalize equally must be ==");
+        assert_eq!(
+            data_ptr(a.as_str()),
+            data_ptr(b.as_str()),
+            "equal interned idents must share one backing allocation"
+        );
+
+        // A distinct value must NOT share the allocation.
+        let c = Ident::new("different");
+        assert_ne!(a, c);
+        assert_ne!(data_ptr(a.as_str()), data_ptr(c.as_str()));
+    }
+
+    #[test]
+    fn clone_shares_backing_allocation() {
+        let a = Ident::new("some_variable_name");
+        let b = a.clone();
+        assert_eq!(a, b);
+        assert_eq!(
+            data_ptr(a.as_str()),
+            data_ptr(b.as_str()),
+            "Clone must be a cheap handle copy sharing the allocation, not a fresh String"
+        );
+    }
+
+    #[test]
+    fn element_and_dimension_names_dedup() {
+        let e1 = CanonicalElementName::from_raw("New York");
+        let e2 = CanonicalElementName::from_raw("new_york");
+        assert_eq!(e1, e2);
+        assert_eq!(data_ptr(e1.as_str()), data_ptr(e2.as_str()));
+
+        let d1 = CanonicalDimensionName::from_raw("Region");
+        let d2 = CanonicalDimensionName::from_raw("region");
+        assert_eq!(d1, d2);
+        assert_eq!(data_ptr(d1.as_str()), data_ptr(d2.as_str()));
+    }
+
+    #[test]
+    fn from_unchecked_paths_dedup_with_new() {
+        // The *_unchecked constructors assume canonical input; they must still
+        // route through the interner so they dedup with Ident::new.
+        let canonical = "already_canonical_ident";
+        let a = Ident::new(canonical);
+        let b = Ident::<Canonical>::from_unchecked(canonical.to_string());
+        let c = Ident::<Canonical>::from_str_unchecked(canonical);
+        assert_eq!(a, b);
+        assert_eq!(a, c);
+        assert_eq!(data_ptr(a.as_str()), data_ptr(b.as_str()));
+        assert_eq!(data_ptr(a.as_str()), data_ptr(c.as_str()));
+    }
+
+    // ----- Constraint 3: Hash consistent with Eq AND the Borrow<str> path -----
+
+    #[test]
+    fn hashmap_lookup_by_value_and_by_borrowed_str() {
+        let mut map: HashMap<Ident<Canonical>, i32> = HashMap::new();
+        map.insert(Ident::new("Population"), 42);
+
+        // Look up with an independently-constructed equal key (value path).
+        assert_eq!(map.get(&Ident::new("population")), Some(&42));
+
+        // Look up via Borrow<str> with the canonical string slice.
+        assert_eq!(map.get("population"), Some(&42));
+
+        // A non-present key.
+        assert_eq!(map.get("nonexistent"), None);
+    }
+
+    #[test]
+    fn hash_is_value_based_consistent_with_str() {
+        use std::hash::{BuildHasher, RandomState};
+        let state = RandomState::new();
+        let ident = Ident::new("hello world");
+        // Hashing the Ident must equal hashing its canonical &str, otherwise
+        // the Borrow<str> HashMap lookup path is unsound.
+        let h_ident = state.hash_one(&ident);
+        let h_str = state.hash_one(ident.as_str());
+        assert_eq!(
+            h_ident, h_str,
+            "Ident Hash must be value-based and match str Hash"
+        );
+    }
+
+    // ----- Constraint 1: idempotency, sentinel, round-trip preserved -----
+
+    #[test]
+    fn canonicalization_is_idempotent_through_idents() {
+        for raw in [
+            "Hello World",
+            "a.b",
+            "\"a.b\"",
+            "\"Goal 1.5 for Temperature\"",
+            "model.sub.variable",
+        ] {
+            let once = Ident::new(raw);
+            let twice = Ident::new(once.as_str());
+            assert_eq!(once, twice, "Ident::new not idempotent for {raw:?}");
+            assert_eq!(once.as_str(), twice.as_str());
+        }
+    }
+
+    #[test]
+    fn quoted_literal_period_sentinel_survives_through_ident() {
+        // The U+2024 sentinel must be preserved in canonical form and reverse
+        // back to a literal `.` for source output (#559).
+        let ident = Ident::new("\"a.b\"");
+        assert_eq!(ident.as_str(), "a\u{2024}b");
+        assert!(!ident.as_str().contains('.'));
+        assert!(!ident.as_str().contains('·'));
+        assert_eq!(ident.to_source_repr(), "a.b");
+
+        // Re-interning the canonical sentinel form is a no-op and dedups.
+        let again = Ident::new(ident.as_str());
+        assert_eq!(ident, again);
+        assert_eq!(data_ptr(ident.as_str()), data_ptr(again.as_str()));
+    }
+
+    #[test]
+    fn source_round_trip_via_as_str_and_to_source_repr() {
+        let cases = [
+            ("model.variable", "model·variable", "model.variable"),
+            ("\"a.b\"", "a\u{2024}b", "a.b"),
+            ("plain_name", "plain_name", "plain_name"),
+        ];
+        for (raw, canonical, source) in cases {
+            let ident = Ident::new(raw);
+            assert_eq!(ident.as_str(), canonical);
+            assert_eq!(ident.to_source_repr(), source);
+        }
+    }
+
+    // ----- Constraint 6: non-leaking (refcount reclaim) -----
+
+    #[test]
+    fn dropping_all_handles_reclaims_the_interned_entry() {
+        // Use a process-unique string so no other test/global holds a reference
+        // and the reclaim assertion is deterministic on this single thread.
+        let unique = "interner_reclaim_probe_\u{2024}_unique_value_xyz_42";
+        let interner = Interner::global();
+        assert!(!interner.contains(unique), "precondition: not yet interned");
+
+        {
+            let a = Ident::new(unique);
+            let b = Ident::new(unique);
+            assert!(interner.contains(unique), "entry must be live while held");
+            // While both live, they share the allocation.
+            assert_eq!(data_ptr(a.as_str()), data_ptr(b.as_str()));
+        }
+
+        // After both handles drop, the entry MUST be reclaimed (non-leaking).
+        assert!(
+            !interner.contains(unique),
+            "interner leaked: entry survived after all handles dropped"
+        );
+
+        // Re-interning works and is observable again.
+        let c = Ident::new(unique);
+        assert_eq!(c.as_str(), unique);
+        assert!(interner.contains(unique));
+    }
+
+    #[test]
+    fn many_distinct_strings_are_all_reclaimed_after_drop() {
+        // The global interner is shared across the whole test binary, so we
+        // can't assert an exact global count (other tests intern concurrently).
+        // Instead probe a batch of process-unique strings: all present while
+        // held, all reclaimed once dropped. `live_entry_count` is exercised
+        // here only as a coarse monotonicity sanity check.
+        let interner = Interner::global();
+        let words: Vec<String> = (0..50)
+            .map(|i| format!("batch_reclaim_probe_unique_\u{2024}_{i}"))
+            .collect();
+        for w in &words {
+            assert!(!interner.contains(w), "precondition: {w:?} not interned");
+        }
+
+        let names: Vec<Ident<Canonical>> = words.iter().map(|w| Ident::new(w)).collect();
+        let count_with_batch = interner.live_entry_count();
+        for w in &words {
+            assert!(interner.contains(w), "{w:?} must be live while held");
+        }
+        assert!(
+            count_with_batch >= 50,
+            "the batch contributes at least its own entries"
+        );
+
+        drop(names);
+        for w in &words {
+            assert!(
+                !interner.contains(w),
+                "{w:?} leaked after all handles dropped"
+            );
+        }
+    }
+
+    #[test]
+    fn concurrent_intern_and_drop_is_consistent_and_reclaims() {
+        // Stress the drop/intern race across rayon-like contention: many
+        // threads repeatedly intern and drop a small shared set of strings.
+        // Afterwards every string must be reclaimed (no live entry remains)
+        // and equality must remain pointer-shared for concurrent live handles.
+        use std::sync::Arc as StdArc;
+        use std::thread;
+
+        let interner = Interner::global();
+        let words: StdArc<Vec<String>> = StdArc::new(
+            (0..16)
+                .map(|i| format!("concurrent_interner_probe_word_{i}"))
+                .collect(),
+        );
+        // Ensure clean baseline for these specific words.
+        for w in words.iter() {
+            assert!(!interner.contains(w));
+        }
+
+        let mut handles = Vec::new();
+        for _ in 0..8 {
+            let words = StdArc::clone(&words);
+            handles.push(thread::spawn(move || {
+                for _ in 0..2000 {
+                    for w in words.iter() {
+                        let a = Ident::new(w);
+                        let b = Ident::new(w);
+                        // Concurrent live handles of equal content always share
+                        // the backing payload (dedup holds under contention).
+                        assert_eq!(a, b);
+                        assert_eq!(a.as_str(), w.as_str());
+                    }
+                }
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+
+        // All transient handles are gone -> every word must be reclaimed.
+        for w in words.iter() {
+            assert!(
+                !interner.contains(w),
+                "word {w:?} leaked after concurrent stress"
+            );
+        }
+    }
+
+    // ----- Constraint 4: salsa::Update semantics on the handle -----
+
+    #[test]
+    fn salsa_update_reports_change_only_on_value_difference() {
+        use salsa::Update;
+
+        // Different value -> overwrite and report changed.
+        let mut slot = CanonicalStorage::intern("old_value");
+        let changed = {
+            // SAFETY (test): `&mut slot` is a valid, owned `CanonicalStorage`;
+            // we pass its pointer and a fresh owned value, matching the
+            // `Update::maybe_update` contract.
+            #[allow(unsafe_code)]
+            unsafe {
+                CanonicalStorage::maybe_update(
+                    &mut slot as *mut _,
+                    CanonicalStorage::intern("new_value"),
+                )
+            }
+        };
+        assert!(changed, "differing values must report a change");
+        assert_eq!(slot.as_str(), "new_value");
+
+        // Equal value -> no overwrite, report unchanged.
+        let unchanged = {
+            #[allow(unsafe_code)]
+            unsafe {
+                CanonicalStorage::maybe_update(
+                    &mut slot as *mut _,
+                    CanonicalStorage::intern("new_value"),
+                )
+            }
+        };
+        assert!(!unchanged, "equal values must report no change");
+        assert_eq!(slot.as_str(), "new_value");
+    }
+}
+
 // Implementations for identifier types
 
 impl RawIdent {
@@ -1053,22 +1744,22 @@ impl CanonicalDimensionName {
     /// Create from an already-canonicalized string (internal use only)
     #[allow(dead_code)]
     pub(crate) fn from_canonical_unchecked(s: String) -> Self {
-        CanonicalDimensionName(s)
+        CanonicalDimensionName(CanonicalStorage::intern(&s))
     }
 
     /// Create from a raw string, canonicalizing it
     pub fn from_raw(s: &str) -> Self {
-        CanonicalDimensionName(canonicalize(s).into_owned())
+        CanonicalDimensionName(CanonicalStorage::intern(&canonicalize(s)))
     }
 
     /// Get the underlying canonical string
     pub fn as_str(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 
     /// Convert to the legacy DimensionName type (for gradual migration)
     pub fn to_dimension_name(&self) -> DimensionName {
-        self.0.clone()
+        self.0.as_str().to_owned()
     }
 }
 
@@ -1080,7 +1771,7 @@ impl RawDimensionName {
 
     /// Canonicalize this dimension name
     pub fn canonicalize(&self) -> CanonicalDimensionName {
-        CanonicalDimensionName(canonicalize(&self.0).into_owned())
+        CanonicalDimensionName(CanonicalStorage::intern(&canonicalize(&self.0)))
     }
 
     /// Get the underlying raw string
@@ -1093,22 +1784,22 @@ impl CanonicalElementName {
     /// Create from an already-canonicalized string (internal use only)
     #[allow(dead_code)]
     pub(crate) fn from_canonical_unchecked(s: String) -> Self {
-        CanonicalElementName(s)
+        CanonicalElementName(CanonicalStorage::intern(&s))
     }
 
     /// Create from a raw string, canonicalizing it
     pub fn from_raw(s: &str) -> Self {
-        CanonicalElementName(canonicalize(s).into_owned())
+        CanonicalElementName(CanonicalStorage::intern(&canonicalize(s)))
     }
 
     /// Get the underlying canonical string
     pub fn as_str(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 
     /// Convert to the legacy ElementName type (for gradual migration)
     pub fn to_element_name(&self) -> ElementName {
-        self.0.clone()
+        self.0.as_str().to_owned()
     }
 }
 
@@ -1120,7 +1811,7 @@ impl RawElementName {
 
     /// Canonicalize this element name
     pub fn canonicalize(&self) -> CanonicalElementName {
-        CanonicalElementName(canonicalize(&self.0).into_owned())
+        CanonicalElementName(CanonicalStorage::intern(&canonicalize(&self.0)))
     }
 
     /// Get the underlying raw string
@@ -1139,7 +1830,7 @@ impl fmt::Display for RawIdent {
 
 impl fmt::Display for CanonicalDimensionName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.0.as_str())
     }
 }
 
@@ -1151,7 +1842,7 @@ impl fmt::Display for RawDimensionName {
 
 impl fmt::Display for CanonicalElementName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.0)
+        write!(f, "{}", self.0.as_str())
     }
 }
 
@@ -1163,13 +1854,13 @@ impl fmt::Display for RawElementName {
 
 impl From<CanonicalDimensionName> for DimensionName {
     fn from(canonical: CanonicalDimensionName) -> Self {
-        canonical.0
+        canonical.0.as_str().to_owned()
     }
 }
 
 impl From<CanonicalElementName> for ElementName {
     fn from(canonical: CanonicalElementName) -> Self {
-        canonical.0
+        canonical.0.as_str().to_owned()
     }
 }
 
@@ -1183,7 +1874,7 @@ impl AsRef<str> for RawIdent {
 
 impl AsRef<str> for CanonicalDimensionName {
     fn as_ref(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 }
 
@@ -1195,7 +1886,7 @@ impl AsRef<str> for RawDimensionName {
 
 impl AsRef<str> for CanonicalElementName {
     fn as_ref(&self) -> &str {
-        &self.0
+        self.0.as_str()
     }
 }
 
@@ -1217,10 +1908,18 @@ pub struct Canonical;
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
 pub struct Raw;
 
-/// An owned identifier with state tracking (canonical or raw)
+/// An owned identifier with state tracking (canonical or raw).
+///
+/// In practice the inner string is always canonical (`Ident<Raw>` is never
+/// instantiated), so the storage is the interned [`CanonicalStorage`] handle:
+/// constructing an `Ident` for an already-seen identifier is allocation-free
+/// and `Clone` is a refcount bump. The derived `PartialEq`/`Eq`/`Hash`/`Ord`/
+/// `PartialOrd`/`salsa::Update` delegate to that handle's manual impls (value
+/// equality, value-based hash consistent with `Borrow<str>`, lexicographic
+/// ordering), preserving the previous `String`-backed semantics.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, salsa::Update)]
 pub struct Ident<State = Canonical> {
-    inner: String,
+    inner: CanonicalStorage,
     _phantom: PhantomData<State>,
 }
 
@@ -1297,7 +1996,10 @@ impl Ident<Canonical> {
     /// avoids allocation when the input is already canonical.
     pub fn new(s: &str) -> Self {
         Ident {
-            inner: canonicalize(s).into_owned(),
+            // `canonicalize` borrows when already canonical; the interner takes
+            // a `&str` either way, allocating the backing storage only on the
+            // first sighting of this canonical form.
+            inner: CanonicalStorage::intern(&canonicalize(s)),
             _phantom: PhantomData,
         }
     }
@@ -1307,7 +2009,7 @@ impl Ident<Canonical> {
     /// Note: Caller must guarantee the string is already canonical
     pub fn from_unchecked(s: String) -> Self {
         Ident {
-            inner: s,
+            inner: CanonicalStorage::intern(&s),
             _phantom: PhantomData,
         }
     }
@@ -1317,7 +2019,7 @@ impl Ident<Canonical> {
     /// Note: Caller must guarantee the string is already canonical
     pub fn from_str_unchecked(s: &str) -> Self {
         Ident {
-            inner: s.to_string(),
+            inner: CanonicalStorage::intern(s),
             _phantom: PhantomData,
         }
     }
@@ -1325,20 +2027,20 @@ impl Ident<Canonical> {
     /// Get a borrowed reference to this identifier
     pub fn as_ref(&self) -> IdentRef<'_, Canonical> {
         IdentRef {
-            inner: &self.inner,
+            inner: self.inner.as_str(),
             _phantom: PhantomData,
         }
     }
 
     /// Get as a CanonicalStr
     pub fn as_canonical_str(&self) -> CanonicalStr<'_> {
-        CanonicalStr::from_canonical_unchecked(&self.inner)
+        CanonicalStr::from_canonical_unchecked(self.inner.as_str())
     }
 
     /// Join two canonical identifiers with a middle dot separator
     pub fn join(module: &CanonicalStr, var: &CanonicalStr) -> Self {
         Ident {
-            inner: format!("{}·{}", module.as_str(), var.as_str()),
+            inner: CanonicalStorage::intern(&format!("{}·{}", module.as_str(), var.as_str())),
             _phantom: PhantomData,
         }
     }
@@ -1346,19 +2048,19 @@ impl Ident<Canonical> {
     /// Create an identifier with array subscript notation
     pub fn with_subscript(&self, subscript: &str) -> Self {
         Ident {
-            inner: format!("{}[{}]", self.to_source_repr(), subscript),
+            inner: CanonicalStorage::intern(&format!("{}[{}]", self.to_source_repr(), subscript)),
             _phantom: PhantomData,
         }
     }
 
     /// Get the underlying canonical string
     pub fn as_str(&self) -> &str {
-        &self.inner
+        self.inner.as_str()
     }
 
     /// Consume self and return the underlying String
     pub fn into_string(self) -> String {
-        self.inner
+        self.inner.as_str().to_owned()
     }
 
     /// Convert canonical identifier to source code representation.
@@ -1374,12 +2076,12 @@ impl Ident<Canonical> {
     /// periods to middle dots to distinguish module separators from literal
     /// periods in quoted identifiers.
     pub fn to_source_repr(&self) -> String {
-        canonical_to_source(&self.inner).into_owned()
+        canonical_to_source(self.inner.as_str()).into_owned()
     }
 
     /// Strip a prefix, returning a borrowed view if successful
     pub fn strip_prefix<'a>(&'a self, prefix: &str) -> Option<IdentRef<'a, Canonical>> {
-        self.inner.strip_prefix(prefix).map(|s| IdentRef {
+        self.inner.as_str().strip_prefix(prefix).map(|s| IdentRef {
             inner: s,
             _phantom: PhantomData,
         })
@@ -1410,7 +2112,7 @@ impl<'a> IdentRef<'a, Canonical> {
     /// Convert to an owned Ident
     pub fn to_owned(&self) -> Ident<Canonical> {
         Ident {
-            inner: self.inner.to_string(),
+            inner: CanonicalStorage::intern(self.inner),
             _phantom: PhantomData,
         }
     }
@@ -1435,14 +2137,19 @@ impl<'a> IdentRef<'a, Canonical> {
 // Implement AsRef for convenient usage
 impl AsRef<str> for Ident<Canonical> {
     fn as_ref(&self) -> &str {
-        &self.inner
+        self.inner.as_str()
     }
 }
 
-// Implement Borrow for HashMap lookups
+// Implement Borrow for HashMap lookups.
+//
+// NB: this is what makes the value-based `Hash` on `CanonicalStorage`
+// mandatory -- a `HashMap<Ident<Canonical>, V>` can be probed with a `&str`
+// key, which is hashed with `str`'s hasher; the stored key's hash (delegated
+// through the derive to `CanonicalStorage::hash`) must match it.
 impl std::borrow::Borrow<str> for Ident<Canonical> {
     fn borrow(&self) -> &str {
-        &self.inner
+        self.inner.as_str()
     }
 }
 
@@ -1461,7 +2168,7 @@ impl<'a> AsRef<str> for CanonicalStr<'a> {
 // Display implementations
 impl fmt::Display for Ident<Canonical> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.inner)
+        write!(f, "{}", self.inner.as_str())
     }
 }
 

--- a/src/simlin-engine/src/db.rs
+++ b/src/simlin-engine/src/db.rs
@@ -1249,8 +1249,17 @@ pub struct ResolvedScc {
 
 #[derive(Clone, Debug, PartialEq, Eq, salsa::Update)]
 pub struct ModelDepGraphResult {
-    pub dt_dependencies: HashMap<String, BTreeSet<String>>,
-    pub initial_dependencies: HashMap<String, BTreeSet<String>>,
+    /// Interned-ident-keyed dependency maps. `Ident<Canonical>` derives
+    /// `salsa::Update`, and salsa's blanket impls cover
+    /// `std::collections::HashMap<K,V>` / `BTreeSet<K>` for `K,V: Update`, so
+    /// these stay on the std `HashMap` (default hasher) -- only the hot
+    /// internal working maps in `model_dependency_graph_impl` use FxHash.
+    /// `Ident<Canonical>` keys/values are cheap Arc-refcount clones and the
+    /// `BTreeSet`s iterate in the same lexicographic order the former
+    /// `BTreeSet<String>` did, so a consumer probing by `&str` (via
+    /// `Borrow<str>`) sees byte-identical behavior.
+    pub dt_dependencies: HashMap<Ident<Canonical>, BTreeSet<Ident<Canonical>>>,
+    pub initial_dependencies: HashMap<Ident<Canonical>, BTreeSet<Ident<Canonical>>>,
     pub runlist_initials: Vec<String>,
     pub runlist_flows: Vec<String>,
     pub runlist_stocks: Vec<String>,

--- a/src/simlin-engine/src/db.rs
+++ b/src/simlin-engine/src/db.rs
@@ -3769,7 +3769,7 @@ fn compile_implicit_var_fragment(
     // the per-phase compile returns (absent implicit index / equation
     // errors).
     let module_ident_context =
-        module_ident_context_for_model(db, model, project, module_input_names);
+        model_module_ident_context(db, model, project, module_input_names.to_vec());
     let (implicit_name, _lowered) =
         lower_implicit_var(db, meta, model, project, module_ident_context)?;
     let var_ident_str = canonicalize(&implicit_name).into_owned();
@@ -3863,7 +3863,7 @@ fn compile_implicit_var_phase_bytecodes(
     use crate::compiler::symbolic::{ReverseOffsetMap, VariableLayout};
 
     let module_ident_context =
-        module_ident_context_for_model(db, model, project, module_input_names);
+        model_module_ident_context(db, model, project, module_input_names.to_vec());
 
     // Shared parent→implicit→parse→lower prefix (the single relation, also
     // consumed by `compile_implicit_var_fragment`). `ModuleIdentContext`

--- a/src/simlin-engine/src/db.rs
+++ b/src/simlin-engine/src/db.rs
@@ -782,6 +782,50 @@ pub fn project_datamodel_dims(db: &dyn Db, project: SourceProject) -> Vec<datamo
     source_dims_to_datamodel(project.dimensions(db))
 }
 
+/// Cached project-global dimension context -- computed once per project.
+///
+/// This is the project's immutable `DimensionsContext`, the same value the
+/// per-variable compile sites used to rebuild on every variable via
+/// `DimensionsContext::from(project_datamodel_dims(..))`. Building it
+/// canonicalizes every dimension element name, so doing it once per project
+/// (instead of once per explicit-and-implicit variable compilation) removes a
+/// dominant allocation cost on large models. Keyed only on `project` -- and
+/// reading `project_datamodel_dims`, which depends solely on the project's
+/// dimensions input -- so it recomputes exactly when the dimensions change, the
+/// SAME dependency granularity the inline rebuild took. The shared context's
+/// only interior mutability is its `relationship_cache` `Mutex`, so it is safe
+/// to share across the rayon-parallel variable compilations (and the
+/// subdimension-relationship memo is now computed once and reused rather than
+/// discarded per variable).
+#[salsa::tracked(returns(ref))]
+pub fn project_dimensions_context(
+    db: &dyn Db,
+    project: SourceProject,
+) -> crate::dimensions::DimensionsContext {
+    crate::dimensions::DimensionsContext::from(project_datamodel_dims(db, project).as_slice())
+}
+
+/// Cached project-global converted dimensions -- computed once per project.
+///
+/// The `Vec<crate::dimensions::Dimension>` form of `project_datamodel_dims`,
+/// previously rebuilt per variable via
+/// `project_datamodel_dims(..).iter().map(Dimension::from).collect()`. Each
+/// `Dimension::from` re-canonicalizes the dimension's element names, so caching
+/// it once per project removes that repeated work. Same input dependency
+/// (`project_datamodel_dims`) and hence same invalidation granularity as the
+/// inline rebuild. The interned-backed `Dimension`s clone cheaply, so a
+/// consumer that genuinely needs an owned `Vec` can still `.to_vec()` the slice.
+#[salsa::tracked(returns(ref))]
+pub fn project_converted_dimensions(
+    db: &dyn Db,
+    project: SourceProject,
+) -> Vec<crate::dimensions::Dimension> {
+    project_datamodel_dims(db, project)
+        .iter()
+        .map(crate::dimensions::Dimension::from)
+        .collect()
+}
+
 fn parse_source_variable_impl(
     db: &dyn Db,
     var: SourceVariable,
@@ -942,37 +986,36 @@ fn variable_direct_dependencies_impl(
         _ => {
             let parsed =
                 parse_source_variable_with_module_context(db, var, project, module_ident_context);
-            let dims = source_dims_to_datamodel(project.dimensions(db));
-            let dim_context = crate::dimensions::DimensionsContext::from(dims.as_slice());
+            // The datamodel-form dims are still needed for the implicit-var
+            // parse below; the canonicalized context + converted dims come from
+            // the project-global salsa-cached queries (no per-variable rebuild).
+            let dims = project_datamodel_dims(db, project);
+            let dim_context = project_dimensions_context(db, project);
+            let converted_dims = project_converted_dimensions(db, project);
             let models = HashMap::new();
             let scope = crate::model::ScopeStage0 {
                 models: &models,
-                dimensions: &dim_context,
+                dimensions: dim_context,
                 model_name: "",
             };
             let lowered = crate::model::lower_variable(&scope, &parsed.variable);
 
-            let converted_dims: Vec<crate::dimensions::Dimension> = dims
-                .iter()
-                .map(crate::dimensions::Dimension::from)
-                .collect();
-
             // Two calls to classify_dependencies replace 7 separate walker calls.
             let dt_classification = match lowered.ast() {
                 Some(ast) => {
-                    crate::variable::classify_dependencies(ast, &converted_dims, module_inputs)
+                    crate::variable::classify_dependencies(ast, converted_dims, module_inputs)
                 }
                 None => crate::variable::DepClassification::default(),
             };
             let init_classification = match lowered.init_ast() {
                 Some(ast) => {
-                    crate::variable::classify_dependencies(ast, &converted_dims, module_inputs)
+                    crate::variable::classify_dependencies(ast, converted_dims, module_inputs)
                 }
                 None => crate::variable::DepClassification::default(),
             };
 
             let implicit_vars =
-                extract_implicit_var_deps(parsed, &dims, &dim_context, module_inputs);
+                extract_implicit_var_deps(parsed, dims, dim_context, converted_dims, module_inputs);
 
             VariableDeps {
                 dt_deps: dt_classification
@@ -2541,8 +2584,7 @@ pub fn compute_layout(
     // depend on compute_layout.
     if project.ltm_enabled(db) {
         let ltm_vars = model_ltm_variables(db, model, project);
-        let dims = project_datamodel_dims(db, project);
-        let dim_context = crate::dimensions::DimensionsContext::from(dims.as_slice());
+        let dim_context = project_dimensions_context(db, project);
 
         let mut sorted_ltm_vars: Vec<&LtmSyntheticVar> = ltm_vars.vars.iter().collect();
         sorted_ltm_vars.sort_unstable_by_key(|v| &v.name);
@@ -3090,15 +3132,11 @@ pub(crate) fn var_phase_symbolic_fragment_prod(
     };
     let var_ident_canonical: Ident<Canonical> = Ident::new(var_name);
 
-    // Caller-owned, lowering-independent context, built EXACTLY as
-    // `compile_var_fragment` builds it (mirror byte-for-byte; same
-    // helpers, same order).
-    let dm_dims = source_dims_to_datamodel(project.dimensions(db));
-    let dim_context = crate::dimensions::DimensionsContext::from(dm_dims.as_slice());
-    let converted_dims: Vec<crate::dimensions::Dimension> = dm_dims
-        .iter()
-        .map(crate::dimensions::Dimension::from)
-        .collect();
+    // Caller-owned, lowering-independent context, read EXACTLY as
+    // `compile_var_fragment` reads it (mirror byte-for-byte): the
+    // salsa-cached project-global dimension context and converted dims.
+    let dim_context = project_dimensions_context(db, project);
+    let converted_dims = project_converted_dimensions(db, project);
     let model_name_ident = Ident::new(model.name(db));
     let inputs: BTreeSet<Ident<Canonical>> = BTreeSet::new();
     let module_models = model_module_map(db, model, project).clone();
@@ -3110,8 +3148,8 @@ pub(crate) fn var_phase_symbolic_fragment_prod(
         project,
         true,
         &[],
-        &converted_dims,
-        &dim_context,
+        converted_dims,
+        dim_context,
         &model_name_ident,
         &module_models,
         &inputs,
@@ -3156,8 +3194,8 @@ pub(crate) fn var_phase_symbolic_fragment_prod(
         &tables,
         &module_refs,
         mini_offset,
-        &converted_dims,
-        &dim_context,
+        converted_dims,
+        dim_context,
         &model_name_ident,
         &var_ident_canonical,
         &inputs,
@@ -3413,16 +3451,14 @@ pub fn compile_var_fragment(
     let var_ident_canonical: Ident<Canonical> = Ident::new(&var_ident);
 
     // Caller-owned, lowering-independent context (built only from
-    // project/variable data, never from the lowered equation). Use the
-    // salsa-cached project dims (returns(ref)) rather than re-running
-    // source_dims_to_datamodel on every variable -- this fragment compiler is
-    // invoked once per variable, and the datamodel dims are project-global.
-    let dm_dims = project_datamodel_dims(db, project);
-    let dim_context = crate::dimensions::DimensionsContext::from(dm_dims.as_slice());
-    let converted_dims: Vec<crate::dimensions::Dimension> = dm_dims
-        .iter()
-        .map(crate::dimensions::Dimension::from)
-        .collect();
+    // project/variable data, never from the lowered equation). Read the
+    // salsa-cached project-global dimension context and converted dims
+    // (returns(ref)) rather than rebuilding them on every variable -- this
+    // fragment compiler is invoked once per variable, and the context is
+    // project-global and immutable. Building it canonicalizes every dimension
+    // element name, so caching it removes a dominant per-variable allocation.
+    let dim_context = project_dimensions_context(db, project);
+    let converted_dims = project_converted_dimensions(db, project);
     let model_name_ident = Ident::new(model.name(db));
     let inputs = canonical_module_input_set(&module_input_names);
     let module_models = model_module_map(db, model, project).clone();
@@ -3434,8 +3470,8 @@ pub fn compile_var_fragment(
         project,
         is_root,
         &module_input_names,
-        &converted_dims,
-        &dim_context,
+        converted_dims,
+        dim_context,
         &model_name_ident,
         &module_models,
         &inputs,
@@ -3512,8 +3548,8 @@ pub fn compile_var_fragment(
             &tables,
             &module_refs,
             mini_offset,
-            &converted_dims,
-            &dim_context,
+            converted_dims,
+            dim_context,
             &model_name_ident,
             &var_ident_canonical,
             &inputs,
@@ -3639,7 +3675,7 @@ fn lower_implicit_var<'db>(
     let implicit_name = canonicalize(implicit_dm_var.get_ident()).into_owned();
 
     let dm_dims = project_datamodel_dims(db, project);
-    let dim_context = crate::dimensions::DimensionsContext::from(dm_dims.as_slice());
+    let dim_context = project_dimensions_context(db, project);
 
     let units_ctx = project_units_context(db, project);
 
@@ -3700,7 +3736,7 @@ fn lower_implicit_var<'db>(
         let models = HashMap::new();
         let scope = crate::model::ScopeStage0 {
             models: &models,
-            dimensions: &dim_context,
+            dimensions: dim_context,
             model_name: "",
         };
         let lowered = crate::model::lower_variable(&scope, &parsed_implicit);
@@ -3885,12 +3921,10 @@ fn compile_implicit_var_phase_bytecodes(
     );
     let implicit_dm_var = parsed.implicit_vars.get(meta.index_in_parent)?;
 
-    let dm_dims = project_datamodel_dims(db, project);
-    let dim_context = crate::dimensions::DimensionsContext::from(dm_dims.as_slice());
-    let converted_dims: Vec<crate::dimensions::Dimension> = dm_dims
-        .iter()
-        .map(crate::dimensions::Dimension::from)
-        .collect();
+    // Project-global dimension context + converted dims, read from the
+    // salsa-cached queries rather than rebuilt per implicit variable.
+    let dim_context = project_dimensions_context(db, project);
+    let converted_dims = project_converted_dimensions(db, project);
 
     let model_name_ident = Ident::new(model.name(db));
     let var_ident_canonical: Ident<Canonical> = Ident::new(&implicit_name);
@@ -4333,8 +4367,8 @@ fn compile_implicit_var_phase_bytecodes(
     module_refs.extend(extra_module_refs);
 
     let core = crate::compiler::ContextCore {
-        dimensions: &converted_dims,
-        dimensions_ctx: &dim_context,
+        dimensions: converted_dims,
+        dimensions_ctx: dim_context,
         model_name: &model_name_ident,
         metadata: &all_metadata,
         module_models: &module_models,
@@ -4372,8 +4406,8 @@ fn compile_implicit_var_phase_bytecodes(
         &tables,
         &module_refs,
         mini_offset,
-        &converted_dims,
-        &dim_context,
+        converted_dims,
+        dim_context,
         &model_name_ident,
         &var_ident_canonical,
         &inputs,
@@ -4961,12 +4995,10 @@ pub fn assemble_module(
             );
         })?;
 
-    // Build dimension metadata from project dimensions (mirrors Compiler::populate_dimension_metadata)
-    let dm_dims = source_dims_to_datamodel(project.dimensions(db));
-    let converted_dims: Vec<crate::dimensions::Dimension> = dm_dims
-        .iter()
-        .map(crate::dimensions::Dimension::from)
-        .collect();
+    // Build dimension metadata from project dimensions (mirrors
+    // Compiler::populate_dimension_metadata). Read the project-global converted
+    // dims from the salsa-cached query instead of rebuilding them here.
+    let converted_dims = project_converted_dimensions(db, project);
 
     let mut dim_names: Vec<String> = Vec::new();
     let mut dim_infos: Vec<crate::bytecode::DimensionInfo> = Vec::new();
@@ -4980,7 +5012,7 @@ pub fn assemble_module(
         id
     };
 
-    for dim in &converted_dims {
+    for dim in converted_dims {
         match dim {
             crate::dimensions::Dimension::Indexed(dim_name, size) => {
                 let name_id = intern_name(&mut dim_names, dim_name.as_str());
@@ -5604,6 +5636,9 @@ mod db_diagnostic_tests;
 #[cfg(test)]
 #[path = "db_differential_tests.rs"]
 mod db_differential_tests;
+#[cfg(test)]
+#[path = "db_dimension_context_cache_tests.rs"]
+mod db_dimension_context_cache_tests;
 #[cfg(test)]
 #[path = "db_dimension_invalidation_tests.rs"]
 mod db_dimension_invalidation_tests;

--- a/src/simlin-engine/src/db.rs
+++ b/src/simlin-engine/src/db.rs
@@ -1125,7 +1125,7 @@ pub fn model_implicit_var_info(
     project: SourceProject,
 ) -> HashMap<String, ImplicitVarMeta> {
     let source_vars = model.variables(db);
-    let module_ident_context = module_ident_context_for_model(db, model, project, &[]);
+    let module_ident_context = model_module_ident_context(db, model, project, vec![]);
     let mut result = HashMap::new();
 
     for source_var in source_vars.values() {
@@ -5290,7 +5290,7 @@ fn enumerate_module_instances_inner(
                 name, sub_model_name,
             ));
         }
-        let module_ident_context = module_ident_context_for_model(db, *source_model, project, &[]);
+        let module_ident_context = model_module_ident_context(db, *source_model, project, vec![]);
         let parsed = parse_source_variable_with_module_context(
             db,
             meta.parent_source_var,

--- a/src/simlin-engine/src/db_analysis.rs
+++ b/src/simlin-engine/src/db_analysis.rs
@@ -26,8 +26,8 @@ use crate::datamodel;
 
 use super::{
     Db, SourceModel, SourceProject, SourceVariableKind, build_module_inputs,
-    model_module_ident_context, parse_source_variable_with_module_context,
-    source_dims_to_datamodel, variable_direct_dependencies,
+    model_module_ident_context, parse_source_variable_with_module_context, project_datamodel_dims,
+    project_dimensions_context, variable_direct_dependencies,
 };
 
 /// Causal edge structure for a model, built from variable dependency sets
@@ -2127,12 +2127,14 @@ pub(crate) fn reconstruct_model_variables(
 
     let source_vars = model.variables(db);
     let module_ctx = model_module_ident_context(db, model, project, vec![]);
-    let dims = source_dims_to_datamodel(project.dimensions(db));
-    let dim_context = crate::dimensions::DimensionsContext::from(dims.as_slice());
+    // The datamodel dims are needed by `reconstruct_implicit_variable`; the
+    // canonicalized context comes from the project-global salsa-cached query.
+    let dims = project_datamodel_dims(db, project);
+    let dim_context = project_dimensions_context(db, project);
     let models = HashMap::new();
     let scope = crate::model::ScopeStage0 {
         models: &models,
-        dimensions: &dim_context,
+        dimensions: dim_context,
         model_name: "",
     };
 
@@ -2148,7 +2150,7 @@ pub(crate) fn reconstruct_model_variables(
         for implicit_dm_var in &parsed.implicit_vars {
             let imp_name = canonicalize(implicit_dm_var.get_ident()).into_owned();
             let lowered_imp =
-                reconstruct_implicit_variable(db, model, &dims, &scope, implicit_dm_var);
+                reconstruct_implicit_variable(db, model, dims, &scope, implicit_dm_var);
             variables.insert(Ident::new(&imp_name), lowered_imp);
         }
     }
@@ -2171,12 +2173,14 @@ pub(super) fn reconstruct_single_variable(
 
     let source_vars = model.variables(db);
     let module_ctx = model_module_ident_context(db, model, project, vec![]);
-    let dims = source_dims_to_datamodel(project.dimensions(db));
-    let dim_context = crate::dimensions::DimensionsContext::from(dims.as_slice());
+    // The datamodel dims are needed by `reconstruct_implicit_variable`; the
+    // canonicalized context comes from the project-global salsa-cached query.
+    let dims = project_datamodel_dims(db, project);
+    let dim_context = project_dimensions_context(db, project);
     let models = HashMap::new();
     let scope = crate::model::ScopeStage0 {
         models: &models,
-        dimensions: &dim_context,
+        dimensions: dim_context,
         model_name: "",
     };
 
@@ -2198,7 +2202,7 @@ pub(super) fn reconstruct_single_variable(
             let imp_name = canonicalize(implicit_dm_var.get_ident()).into_owned();
             if Ident::<Canonical>::new(&imp_name) == canonical_target {
                 let lowered_imp =
-                    reconstruct_implicit_variable(db, model, &dims, &scope, implicit_dm_var);
+                    reconstruct_implicit_variable(db, model, dims, &scope, implicit_dm_var);
                 return Some(lowered_imp);
             }
         }

--- a/src/simlin-engine/src/db_dep_graph.rs
+++ b/src/simlin-engine/src/db_dep_graph.rs
@@ -1474,14 +1474,11 @@ pub(crate) fn var_noninitial_lowered_exprs(
         );
     };
 
-    // Caller-owned, lowering-independent context, built EXACTLY as
-    // `crate::db::compile_var_fragment` builds it.
-    let dm_dims = crate::db::source_dims_to_datamodel(project.dimensions(db));
-    let dim_context = crate::dimensions::DimensionsContext::from(dm_dims.as_slice());
-    let converted_dims: Vec<crate::dimensions::Dimension> = dm_dims
-        .iter()
-        .map(crate::dimensions::Dimension::from)
-        .collect();
+    // Caller-owned, lowering-independent context, read EXACTLY as
+    // `crate::db::compile_var_fragment` reads it (the salsa-cached
+    // project-global dimension context + converted dims).
+    let dim_context = crate::db::project_dimensions_context(db, project);
+    let converted_dims = crate::db::project_converted_dimensions(db, project);
     let model_name_ident = Ident::new(model.name(db));
     let inputs: BTreeSet<Ident<Canonical>> = BTreeSet::new();
     let module_models = crate::db::model_module_map(db, model, project).clone();
@@ -1493,8 +1490,8 @@ pub(crate) fn var_noninitial_lowered_exprs(
         project,
         true,
         &[],
-        &converted_dims,
-        &dim_context,
+        converted_dims,
+        dim_context,
         &model_name_ident,
         &module_models,
         &inputs,

--- a/src/simlin-engine/src/db_dep_graph.rs
+++ b/src/simlin-engine/src/db_dep_graph.rs
@@ -30,8 +30,9 @@
 //! `db_macro_registry`) rather than a submodule of `db.rs` purely to keep
 //! `db.rs` under the per-file line cap.
 
-use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 
+use rustc_hash::{FxHashMap, FxHashSet};
 use salsa::Accumulator;
 
 use crate::canonicalize;
@@ -65,8 +66,14 @@ pub(crate) struct VarInfo {
     /// saved output, because it is a static table indexed by callers, not a
     /// value-bearing variable (issue #606).
     pub(crate) is_table_only: bool,
-    pub(crate) dt_deps: BTreeSet<String>,
-    pub(crate) initial_deps: BTreeSet<String>,
+    /// Interned canonical dt-phase deps. `Ident<Canonical>` `Ord` is
+    /// lexicographic, so this `BTreeSet` iterates in the SAME order as the
+    /// former `BTreeSet<String>` (byte-stability preserved), while `Clone`
+    /// is an Arc-refcount bump (the O(V^2) transitive-closure clones become
+    /// cheap) and `Hash`/`Eq` are value-based.
+    pub(crate) dt_deps: BTreeSet<Ident<Canonical>>,
+    /// Interned canonical init-phase deps (same rationale as `dt_deps`).
+    pub(crate) initial_deps: BTreeSet<Ident<Canonical>>,
 }
 
 /// The dt-phase cycle-successor set of `name`: exactly the deps
@@ -98,13 +105,17 @@ pub(crate) struct VarInfo {
 /// matching `compute_inner` exactly (its `!dep_info.is_module` guard
 /// governs only transitive *absorption*, not which deps the loop
 /// iterates). Lagged deps are already absent (pruned when
-/// `var_info.dt_deps` is built). Returned slices borrow `var_info`'s
-/// `dt_deps` keys and iterate in `BTreeSet` (sorted) order, so the
-/// relation is byte-stable across runs.
+/// `var_info.dt_deps` is built). The returned references borrow
+/// `var_info`'s interned `dt_deps` keys and iterate in `BTreeSet`
+/// (lexicographic) order -- the same order the former `BTreeSet<String>`
+/// produced -- so the relation is byte-stable across runs. Returning
+/// `&Ident<Canonical>` (not `&str`) lets `compute_inner` Arc-clone a
+/// successor into the transitive set instead of allocating a fresh
+/// `String`.
 pub(crate) fn dt_walk_successors<'a>(
-    var_info: &'a HashMap<String, VarInfo>,
+    var_info: &'a FxHashMap<Ident<Canonical>, VarInfo>,
     name: &str,
-) -> Vec<&'a str> {
+) -> Vec<&'a Ident<Canonical>> {
     let Some(info) = var_info.get(name) else {
         return Vec::new();
     };
@@ -119,7 +130,6 @@ pub(crate) fn dt_walk_successors<'a>(
                 .map(|d| !d.is_stock)
                 .unwrap_or(false)
         })
-        .map(|dep| dep.as_str())
         .collect()
 }
 
@@ -159,13 +169,16 @@ pub(crate) fn dt_walk_successors<'a>(
 /// (`info.initial_deps.iter().filter(|dep|
 /// var_info.contains_key(dep))`). `initial_previous_referenced_vars` are
 /// already absent (stripped when `var_info.initial_deps` is built in
-/// `build_var_info`). Returned slices borrow `var_info`'s `initial_deps`
-/// keys and iterate in `BTreeSet` (sorted) order, so the relation is
-/// byte-stable across runs.
+/// `build_var_info`). The returned references borrow `var_info`'s interned
+/// `initial_deps` keys and iterate in `BTreeSet` (lexicographic) order --
+/// the same order the former `BTreeSet<String>` produced -- so the relation
+/// is byte-stable across runs. Returning `&Ident<Canonical>` (not `&str`)
+/// lets `compute_inner` Arc-clone a successor into the transitive set
+/// instead of allocating a fresh `String`.
 pub(crate) fn init_walk_successors<'a>(
-    var_info: &'a HashMap<String, VarInfo>,
+    var_info: &'a FxHashMap<Ident<Canonical>, VarInfo>,
     name: &str,
-) -> Vec<&'a str> {
+) -> Vec<&'a Ident<Canonical>> {
     let Some(info) = var_info.get(name) else {
         return Vec::new();
     };
@@ -177,7 +190,6 @@ pub(crate) fn init_walk_successors<'a>(
     info.initial_deps
         .iter()
         .filter(|dep| var_info.contains_key(dep.as_str()))
-        .map(|dep| dep.as_str())
         .collect()
 }
 
@@ -193,24 +205,34 @@ pub(crate) fn build_var_info(
     model: SourceModel,
     project: SourceProject,
     module_input_names: &[String],
-) -> (HashMap<String, VarInfo>, HashSet<String>) {
+) -> (
+    FxHashMap<Ident<Canonical>, VarInfo>,
+    FxHashSet<Ident<Canonical>>,
+) {
     let source_vars = model.variables(db);
     let module_input_names = module_input_names.to_vec();
     let module_ident_context =
         model_module_ident_context(db, model, project, module_input_names.clone());
 
-    let mut var_info: HashMap<String, VarInfo> = HashMap::new();
-    let mut all_init_referenced: HashSet<String> = HashSet::new();
+    let mut var_info: FxHashMap<Ident<Canonical>, VarInfo> = FxHashMap::default();
+    let mut all_init_referenced: FxHashSet<Ident<Canonical>> = FxHashSet::default();
 
-    let normalize_dep = |dep: &str| -> String {
+    // Normalize a raw dep string to the bare variable/module ident it
+    // imposes an ordering edge on, then intern it. A `submodel·subvar`
+    // dependency collapses to its leading `submodel` module name (the dt
+    // chain-break filter `keep_dt_dep` runs first); a leading `·` separator
+    // is stripped. Both the prefix slice and the whole string are canonical
+    // substrings of an already-canonical dep, so `from_str_unchecked`
+    // (intern, no re-canonicalization scan) is sound.
+    let normalize_dep = |dep: &str| -> Ident<Canonical> {
         let effective = dep.strip_prefix('\u{00B7}').unwrap_or(dep);
         if let Some(dot_pos) = effective.find('\u{00B7}') {
-            effective[..dot_pos].to_string()
+            Ident::from_str_unchecked(&effective[..dot_pos])
         } else {
-            effective.to_string()
+            Ident::from_str_unchecked(effective)
         }
     };
-    let normalize_deps = |deps: &BTreeSet<String>| -> BTreeSet<String> {
+    let normalize_deps = |deps: &BTreeSet<String>| -> BTreeSet<Ident<Canonical>> {
         deps.iter().map(|d| normalize_dep(d)).collect()
     };
 
@@ -324,7 +346,9 @@ pub(crate) fn build_var_info(
         initial_deps.retain(|dep| !lagged_initial_previous.contains(dep));
 
         var_info.insert(
-            (*name).clone(),
+            // `source_vars` keys are canonical (canonicalized at sync time),
+            // so interning unchecked is sound.
+            Ident::from_str_unchecked(name),
             VarInfo {
                 is_stock: kind == SourceVariableKind::Stock,
                 is_module: kind == SourceVariableKind::Module,
@@ -333,7 +357,11 @@ pub(crate) fn build_var_info(
                 initial_deps: normalize_deps(&initial_deps),
             },
         );
-        all_init_referenced.extend(deps.init_referenced_vars.iter().cloned());
+        all_init_referenced.extend(
+            deps.init_referenced_vars
+                .iter()
+                .map(|d| Ident::from_str_unchecked(d)),
+        );
 
         // Include implicit variables from this variable's deps result.
         // Since we read this from variable_direct_dependencies (not
@@ -354,7 +382,8 @@ pub(crate) fn build_var_info(
             let mut initial_deps = implicit.initial_deps.clone();
             initial_deps.retain(|dep| !implicit.initial_previous_referenced_vars.contains(dep));
             var_info.insert(
-                implicit.name.clone(),
+                // `implicit.name` is canonicalized in `extract_implicit_var_deps`.
+                Ident::from_str_unchecked(&implicit.name),
                 VarInfo {
                     is_stock: implicit.is_stock,
                     is_module: implicit.is_module,
@@ -415,17 +444,13 @@ pub(crate) fn dt_cycle_sccs(
         HashMap::with_capacity(var_info.len());
     let mut self_loops: BTreeSet<Ident<Canonical>> = BTreeSet::new();
     for name in var_info.keys() {
-        let succ = dt_walk_successors(&var_info, name);
-        if succ.contains(&name.as_str()) {
-            self_loops.insert(Ident::from_str_unchecked(name));
+        let succ = dt_walk_successors(&var_info, name.as_str());
+        // `succ` is now `Vec<&Ident<Canonical>>`; an `Ident` `==` is pointer
+        // equality on the interned handle, so this self-edge check is exact.
+        if succ.contains(&name) {
+            self_loops.insert(name.clone());
         }
-        edges.insert(
-            Ident::from_str_unchecked(name),
-            succ.iter()
-                .copied()
-                .map(Ident::from_str_unchecked)
-                .collect(),
-        );
+        edges.insert(name.clone(), succ.iter().map(|s| (*s).clone()).collect());
     }
 
     let multi: Vec<BTreeSet<Ident<Canonical>>> = crate::ltm::scc_components(&edges)
@@ -1300,19 +1325,15 @@ pub(crate) fn resolve_recurrence_sccs(
     let mut self_loops: BTreeSet<Ident<Canonical>> = BTreeSet::new();
     for name in var_info.keys() {
         let succ = match phase {
-            SccPhase::Dt => dt_walk_successors(&var_info, name),
-            SccPhase::Initial => init_walk_successors(&var_info, name),
+            SccPhase::Dt => dt_walk_successors(&var_info, name.as_str()),
+            SccPhase::Initial => init_walk_successors(&var_info, name.as_str()),
         };
-        if succ.contains(&name.as_str()) {
-            self_loops.insert(Ident::from_str_unchecked(name));
+        // `succ` is `Vec<&Ident<Canonical>>`; `Ident` `==` is pointer
+        // equality on the interned handle, so this self-edge check is exact.
+        if succ.contains(&name) {
+            self_loops.insert(name.clone());
         }
-        edges.insert(
-            Ident::from_str_unchecked(name),
-            succ.iter()
-                .copied()
-                .map(Ident::from_str_unchecked)
-                .collect(),
-        );
+        edges.insert(name.clone(), succ.iter().map(|s| (*s).clone()).collect());
     }
 
     // The offending SCCs, in sorted/byte-stable order: every multi-var
@@ -1418,9 +1439,9 @@ pub(crate) fn array_producing_vars(
 
     let mut out: BTreeSet<Ident<Canonical>> = BTreeSet::new();
     for name in var_info.keys() {
-        let exprs = var_noninitial_lowered_exprs(db, model, project, name);
+        let exprs = var_noninitial_lowered_exprs(db, model, project, name.as_str());
         if crate::compiler::exprs_contain_array_producing_builtin(&exprs) {
-            out.insert(Ident::from_str_unchecked(name));
+            out.insert(name.clone());
         }
     }
     out
@@ -1636,12 +1657,14 @@ pub(crate) fn cycle_diagnostic(db: &dyn Db, model: SourceModel, var_name: String
 pub(crate) fn scc_map_from_resolved(
     resolved: &[ResolvedScc],
     base_id: usize,
-    map: &mut BTreeMap<String, usize>,
+    map: &mut BTreeMap<Ident<Canonical>, usize>,
 ) {
     for (i, scc) in resolved.iter().enumerate() {
         let id = base_id + i;
         for m in &scc.members {
-            map.insert(m.as_str().to_string(), id);
+            // `scc.members` is a `BTreeSet<Ident<Canonical>>`; clone is an
+            // Arc-refcount bump.
+            map.insert(m.clone(), id);
         }
     }
 }
@@ -1658,7 +1681,13 @@ pub(crate) fn scc_map_from_resolved(
 /// resolved SCCs -- is still a fatal `CircularDependency` (loud-safe: a
 /// back-edge is suppressed only with positive proof both endpoints share
 /// one resolved, element-acyclic SCC).
-pub(crate) fn same_resolved_scc(scc_map: &BTreeMap<String, usize>, a: &str, b: &str) -> bool {
+pub(crate) fn same_resolved_scc(
+    scc_map: &BTreeMap<Ident<Canonical>, usize>,
+    a: &str,
+    b: &str,
+) -> bool {
+    // `BTreeMap<Ident<Canonical>, _>` probes by `&str` via `Borrow<str>`, so
+    // callers can keep passing the bare canonical names they already hold.
     matches!(
         (scc_map.get(a), scc_map.get(b)),
         (Some(x), Some(y)) if x == y
@@ -1709,254 +1738,274 @@ pub(crate) fn model_dependency_graph_impl(
     //     within one resolved SCC (a genuine cycle, a partially-resolved
     //     SCC, a cross-SCC edge) is still a fatal `CircularDependency`
     //     (loud-safe).
-    let compute_transitive = |is_initial: bool,
-                              scc_map: &BTreeMap<String, usize>|
-     -> Result<HashMap<String, BTreeSet<String>>, String> {
-        let mut all_deps: HashMap<String, Option<BTreeSet<String>>> =
-            var_info.keys().map(|k| (k.clone(), None)).collect();
-        let mut processing: BTreeSet<String> = BTreeSet::new();
+    let compute_transitive =
+        |is_initial: bool,
+         scc_map: &BTreeMap<Ident<Canonical>, usize>|
+         -> Result<HashMap<Ident<Canonical>, BTreeSet<Ident<Canonical>>>, String> {
+            // Hot working maps use FxHash (fixed-seed, deterministic) and
+            // interned `Ident<Canonical>` keys: the O(V^2) transitive-closure
+            // clones are Arc-refcount bumps and map ops stop paying SipHash.
+            // `all_deps` insertion/lookup order does not leak into output --
+            // every dependency *set* is a `BTreeSet` (lexicographic), and the
+            // runlist sort tie-breaks by `topo_sort_str`'s visit order over a
+            // pre-sorted `names` list -- so the FxHash iteration order is never
+            // observable. `processing` is membership-only (DFS-stack back-edge
+            // detection); its order is irrelevant.
+            let mut all_deps: FxHashMap<Ident<Canonical>, Option<BTreeSet<Ident<Canonical>>>> =
+                var_info.keys().map(|k| (k.clone(), None)).collect();
+            let mut processing: FxHashSet<Ident<Canonical>> = FxHashSet::default();
 
-        fn compute_inner(
-            var_info: &HashMap<String, VarInfo>,
-            all_deps: &mut HashMap<String, Option<BTreeSet<String>>>,
-            processing: &mut BTreeSet<String>,
-            name: &str,
-            is_initial: bool,
-            scc_map: &BTreeMap<String, usize>,
-        ) -> Result<(), String> {
-            if all_deps.get(name).and_then(|d| d.as_ref()).is_some() {
-                return Ok(());
-            }
-
-            let info = match var_info.get(name) {
-                Some(info) => info,
-                None => return Ok(()), // unknown variable handled at model level
-            };
-
-            // Stocks break the dependency chain in dt phase
-            if info.is_stock && !is_initial {
-                all_deps.insert(name.to_string(), Some(BTreeSet::new()));
-                return Ok(());
-            }
-
-            // Skip modules -- cross-model deps handled at the orchestrator level
-            if info.is_module {
-                let direct = if is_initial {
-                    &info.initial_deps
-                } else {
-                    &info.dt_deps
-                };
-                all_deps.insert(name.to_string(), Some(direct.clone()));
-                return Ok(());
-            }
-
-            // ── SCC-as-collapsed-node transitive accumulation ──────────
-            //
-            // If `name` is a member of a resolved recurrence SCC, treat
-            // the WHOLE SCC as one condensed node: compute its collapsed
-            // EXTERNAL transitive set once and assign the identical set to
-            // every member. Every member therefore ends with the SAME
-            // member-free transitive set = the union, over every member's
-            // successors that are NOT in this SCC, of `{dep} U
-            // transitive(dep)`. Intra-SCC successors are skipped entirely
-            // (not inserted, not recursed, not absorbed): their order is
-            // resolved inside the combined per-element fragment, so they
-            // impose no whole-variable ordering and -- crucially -- must
-            // not leak into any member's transitive set (else the
-            // topological sort would re-see the cycle). This unifies N=1
-            // (1-member SCC: the lone member's self-edge is the only
-            // intra-SCC successor, skipped -- runlist byte-identical to
-            // the Phase 1 self-edge mechanism, since a set containing only
-            // `name` itself vs. empty produces the identical
-            // `topo_sort_str` output) and N>=2.
-            //
-            // Soundness: a resolved SCC is a *maximal* SCC of the
-            // whole-variable relation (`scc_components`) AND its induced
-            // element graph was proven acyclic. By maximality no external
-            // successor can transitively reach back into the SCC, so the
-            // external recursion never re-enters the SCC and the collapsed
-            // set is well-defined and member-free. A genuine cycle is
-            // absent from `scc_map` (loud-safe verdict), so its back-edge
-            // is still caught by the normal `processing` check below.
-            if let Some(&scc_id) = scc_map.get(name) {
-                // Already being collapsed (re-entered via an external
-                // recursion). This cannot happen for a correctly
-                // identified maximal SCC (no external successor reaches a
-                // member); guarding it makes a mis-identified SCC
-                // loud-safe (no infinite recursion, conservative empty
-                // contribution) rather than a panic.
-                if processing.contains(name) {
+            fn compute_inner(
+                var_info: &FxHashMap<Ident<Canonical>, VarInfo>,
+                all_deps: &mut FxHashMap<Ident<Canonical>, Option<BTreeSet<Ident<Canonical>>>>,
+                processing: &mut FxHashSet<Ident<Canonical>>,
+                name: &Ident<Canonical>,
+                is_initial: bool,
+                scc_map: &BTreeMap<Ident<Canonical>, usize>,
+            ) -> Result<(), String> {
+                if all_deps.get(name).and_then(|d| d.as_ref()).is_some() {
                     return Ok(());
                 }
-                let members: BTreeSet<&str> = scc_map
-                    .iter()
-                    .filter(|&(_, &id)| id == scc_id)
-                    .map(|(m, _)| m.as_str())
-                    .collect();
-                // Mark every member processing so a (maximality-
-                // impossible) external dep that referenced a member is a
-                // loud-safe condition, never a silent miss.
-                for m in &members {
-                    processing.insert((*m).to_string());
+
+                let info = match var_info.get(name) {
+                    Some(info) => info,
+                    None => return Ok(()), // unknown variable handled at model level
+                };
+
+                // Stocks break the dependency chain in dt phase
+                if info.is_stock && !is_initial {
+                    all_deps.insert(name.clone(), Some(BTreeSet::new()));
+                    return Ok(());
                 }
-                let mut external: BTreeSet<String> = BTreeSet::new();
-                // `members` is a BTreeSet => sorted iteration; the
-                // external set is order-independent (a BTreeSet), so the
-                // collapsed result is byte-stable.
-                for m in &members {
-                    let succ: Vec<&str> = if is_initial {
-                        init_walk_successors(var_info, m)
+
+                // Skip modules -- cross-model deps handled at the orchestrator level
+                if info.is_module {
+                    let direct = if is_initial {
+                        &info.initial_deps
                     } else {
-                        dt_walk_successors(var_info, m)
+                        &info.dt_deps
                     };
-                    for dep in succ {
-                        // Intra-SCC successor: resolved inside the
-                        // combined fragment, contributes no whole-variable
-                        // ordering and must not enter any member's set.
-                        if members.contains(dep) {
-                            continue;
-                        }
-                        external.insert(dep.to_string());
-                        if processing.contains(dep) {
-                            // `dep` is external (not in `members`) yet on
-                            // the DFS stack: a genuine cycle through an
-                            // external var. It cannot share this SCC
-                            // (`members` is the entire SCC), and two
-                            // distinct resolved SCCs cannot form a cycle
-                            // (they would be one SCC), so
-                            // `same_resolved_scc` is necessarily false
-                            // here -- still fatal (loud-safe).
-                            if same_resolved_scc(scc_map, dep, m) {
+                    all_deps.insert(name.clone(), Some(direct.clone()));
+                    return Ok(());
+                }
+
+                // ── SCC-as-collapsed-node transitive accumulation ──────────
+                //
+                // If `name` is a member of a resolved recurrence SCC, treat
+                // the WHOLE SCC as one condensed node: compute its collapsed
+                // EXTERNAL transitive set once and assign the identical set to
+                // every member. Every member therefore ends with the SAME
+                // member-free transitive set = the union, over every member's
+                // successors that are NOT in this SCC, of `{dep} U
+                // transitive(dep)`. Intra-SCC successors are skipped entirely
+                // (not inserted, not recursed, not absorbed): their order is
+                // resolved inside the combined per-element fragment, so they
+                // impose no whole-variable ordering and -- crucially -- must
+                // not leak into any member's transitive set (else the
+                // topological sort would re-see the cycle). This unifies N=1
+                // (1-member SCC: the lone member's self-edge is the only
+                // intra-SCC successor, skipped -- runlist byte-identical to
+                // the Phase 1 self-edge mechanism, since a set containing only
+                // `name` itself vs. empty produces the identical
+                // `topo_sort_str` output) and N>=2.
+                //
+                // Soundness: a resolved SCC is a *maximal* SCC of the
+                // whole-variable relation (`scc_components`) AND its induced
+                // element graph was proven acyclic. By maximality no external
+                // successor can transitively reach back into the SCC, so the
+                // external recursion never re-enters the SCC and the collapsed
+                // set is well-defined and member-free. A genuine cycle is
+                // absent from `scc_map` (loud-safe verdict), so its back-edge
+                // is still caught by the normal `processing` check below.
+                if let Some(&scc_id) = scc_map.get(name) {
+                    // Already being collapsed (re-entered via an external
+                    // recursion). This cannot happen for a correctly
+                    // identified maximal SCC (no external successor reaches a
+                    // member); guarding it makes a mis-identified SCC
+                    // loud-safe (no infinite recursion, conservative empty
+                    // contribution) rather than a panic.
+                    if processing.contains(name) {
+                        return Ok(());
+                    }
+                    // Borrow the SCC's interned member idents from `scc_map`
+                    // (no clone). `scc_map` is a `BTreeMap`, so this iterates in
+                    // lexicographic order.
+                    let members: BTreeSet<&Ident<Canonical>> = scc_map
+                        .iter()
+                        .filter(|&(_, &id)| id == scc_id)
+                        .map(|(m, _)| m)
+                        .collect();
+                    // Mark every member processing so a (maximality-
+                    // impossible) external dep that referenced a member is a
+                    // loud-safe condition, never a silent miss.
+                    for m in &members {
+                        processing.insert((*m).clone());
+                    }
+                    let mut external: BTreeSet<Ident<Canonical>> = BTreeSet::new();
+                    // `members` is a BTreeSet => sorted iteration; the
+                    // external set is order-independent (a BTreeSet), so the
+                    // collapsed result is byte-stable.
+                    for m in &members {
+                        let succ: Vec<&Ident<Canonical>> = if is_initial {
+                            init_walk_successors(var_info, m.as_str())
+                        } else {
+                            dt_walk_successors(var_info, m.as_str())
+                        };
+                        for dep in succ {
+                            // Intra-SCC successor: resolved inside the
+                            // combined fragment, contributes no whole-variable
+                            // ordering and must not enter any member's set.
+                            if members.contains(&dep) {
                                 continue;
                             }
-                            return Err(m.to_string());
-                        }
-                        if all_deps.get(dep).and_then(|d| d.as_ref()).is_none() {
-                            compute_inner(
-                                var_info, all_deps, processing, dep, is_initial, scc_map,
-                            )?;
-                        }
-                        // Same `!is_module` non-absorption guard as the
-                        // normal path: a module's transitive set is not
-                        // absorbed (cross-model deps handled upstream).
-                        if var_info.get(dep).map(|d| !d.is_module).unwrap_or(false)
-                            && let Some(Some(dep_deps)) = all_deps.get(dep)
-                        {
-                            external.extend(dep_deps.iter().cloned());
+                            external.insert(dep.clone());
+                            if processing.contains(dep) {
+                                // `dep` is external (not in `members`) yet on
+                                // the DFS stack: a genuine cycle through an
+                                // external var. It cannot share this SCC
+                                // (`members` is the entire SCC), and two
+                                // distinct resolved SCCs cannot form a cycle
+                                // (they would be one SCC), so
+                                // `same_resolved_scc` is necessarily false
+                                // here -- still fatal (loud-safe).
+                                if same_resolved_scc(scc_map, dep.as_str(), m.as_str()) {
+                                    continue;
+                                }
+                                return Err(m.as_str().to_string());
+                            }
+                            if all_deps.get(dep).and_then(|d| d.as_ref()).is_none() {
+                                compute_inner(
+                                    var_info, all_deps, processing, dep, is_initial, scc_map,
+                                )?;
+                            }
+                            // Same `!is_module` non-absorption guard as the
+                            // normal path: a module's transitive set is not
+                            // absorbed (cross-model deps handled upstream).
+                            if var_info.get(dep).map(|d| !d.is_module).unwrap_or(false)
+                                && let Some(Some(dep_deps)) = all_deps.get(dep)
+                            {
+                                external.extend(dep_deps.iter().cloned());
+                            }
                         }
                     }
-                }
-                for m in &members {
-                    processing.remove(*m);
-                }
-                // Assign the identical member-free set to EVERY member so
-                // the SCC is one condensed node in the topological sort.
-                for m in &members {
-                    all_deps.insert((*m).to_string(), Some(external.clone()));
-                }
-                return Ok(());
-            }
-
-            processing.insert(name.to_string());
-
-            // The successor set this normal node contributes to cycle
-            // detection AND the `all_deps` transitive/ordering map. It
-            // is sourced from the SINGLE shared cycle relation for the
-            // phase: `dt_walk_successors` (dt) or `init_walk_successors`
-            // (init). In the init phase stocks do NOT break the chain
-            // (that filter is dt-only -- `compute_inner`'s
-            // `info.is_stock && !is_initial` sink does not fire here),
-            // so `init_walk_successors` is the init deps filtered only
-            // to known vars. Either way this is exactly the effective
-            // set the original `for dep in direct { if
-            // !var_info.contains_key {continue} if !is_initial &&
-            // dep_info.is_stock {continue} ... }` loop iterated, in the
-            // same `BTreeSet`-sorted order, so cycle detection (first
-            // back-edge) and the `all_deps` transitive map are
-            // byte-identical. `init_walk_successors`'s defensive
-            // absent/module guards never fire here -- the stock/module
-            // early-returns above already handled those before this
-            // point (the same way `dt_walk_successors`'s guards are
-            // redundant at this call site). Sharing the init relation by
-            // construction means the init-phase per-element recurrence
-            // resolution observes the engine's actual init relation, not
-            // a re-derivation. Only the iteration set is factored out;
-            // the stock/module early-returns above and the `transitive`
-            // accumulation below are untouched.
-            let successors: Vec<&str> = if is_initial {
-                init_walk_successors(var_info, name)
-            } else {
-                dt_walk_successors(var_info, name)
-            };
-
-            let mut transitive = BTreeSet::new();
-            for dep in successors {
-                transitive.insert(dep.to_string());
-
-                if processing.contains(dep) {
-                    // An intra-SCC back-edge of a resolved recurrence SCC
-                    // (`dep` and `name` share a resolved SCC) is resolved
-                    // internally via the SCC's verified per-element order
-                    // and is NOT a fatal cycle. This uniformly covers the
-                    // N=1 self-edge (`dep == name`, 1-member SCC) and the
-                    // N>=2 cross-edge (`dep != name`, same SCC). Resolved
-                    // SCC members are normally handled by the collapsed-
-                    // node block above and never reach this loop, so for a
-                    // resolved SCC this is defense-in-depth; every OTHER
-                    // back-edge -- a genuine cycle, a partially-resolved
-                    // SCC, or a cross-SCC edge between two distinct
-                    // resolved SCCs -- still returns the
-                    // circular-dependency error (loud-safe).
-                    if same_resolved_scc(scc_map, dep, name) {
-                        continue;
+                    for m in &members {
+                        processing.remove(*m);
                     }
-                    return Err(name.to_string()); // circular dependency
+                    // Assign the identical member-free set to EVERY member so
+                    // the SCC is one condensed node in the topological sort.
+                    for m in &members {
+                        all_deps.insert((*m).clone(), Some(external.clone()));
+                    }
+                    return Ok(());
                 }
 
-                if all_deps.get(dep).and_then(|d| d.as_ref()).is_none() {
-                    compute_inner(var_info, all_deps, processing, dep, is_initial, scc_map)?;
+                processing.insert(name.clone());
+
+                // The successor set this normal node contributes to cycle
+                // detection AND the `all_deps` transitive/ordering map. It
+                // is sourced from the SINGLE shared cycle relation for the
+                // phase: `dt_walk_successors` (dt) or `init_walk_successors`
+                // (init). In the init phase stocks do NOT break the chain
+                // (that filter is dt-only -- `compute_inner`'s
+                // `info.is_stock && !is_initial` sink does not fire here),
+                // so `init_walk_successors` is the init deps filtered only
+                // to known vars. Either way this is exactly the effective
+                // set the original `for dep in direct { if
+                // !var_info.contains_key {continue} if !is_initial &&
+                // dep_info.is_stock {continue} ... }` loop iterated, in the
+                // same `BTreeSet`-sorted order, so cycle detection (first
+                // back-edge) and the `all_deps` transitive map are
+                // byte-identical. `init_walk_successors`'s defensive
+                // absent/module guards never fire here -- the stock/module
+                // early-returns above already handled those before this
+                // point (the same way `dt_walk_successors`'s guards are
+                // redundant at this call site). Sharing the init relation by
+                // construction means the init-phase per-element recurrence
+                // resolution observes the engine's actual init relation, not
+                // a re-derivation. Only the iteration set is factored out;
+                // the stock/module early-returns above and the `transitive`
+                // accumulation below are untouched.
+                let successors: Vec<&Ident<Canonical>> = if is_initial {
+                    init_walk_successors(var_info, name.as_str())
+                } else {
+                    dt_walk_successors(var_info, name.as_str())
+                };
+
+                let mut transitive: BTreeSet<Ident<Canonical>> = BTreeSet::new();
+                for dep in successors {
+                    transitive.insert(dep.clone());
+
+                    if processing.contains(dep) {
+                        // An intra-SCC back-edge of a resolved recurrence SCC
+                        // (`dep` and `name` share a resolved SCC) is resolved
+                        // internally via the SCC's verified per-element order
+                        // and is NOT a fatal cycle. This uniformly covers the
+                        // N=1 self-edge (`dep == name`, 1-member SCC) and the
+                        // N>=2 cross-edge (`dep != name`, same SCC). Resolved
+                        // SCC members are normally handled by the collapsed-
+                        // node block above and never reach this loop, so for a
+                        // resolved SCC this is defense-in-depth; every OTHER
+                        // back-edge -- a genuine cycle, a partially-resolved
+                        // SCC, or a cross-SCC edge between two distinct
+                        // resolved SCCs -- still returns the
+                        // circular-dependency error (loud-safe).
+                        if same_resolved_scc(scc_map, dep.as_str(), name.as_str()) {
+                            continue;
+                        }
+                        return Err(name.as_str().to_string()); // circular dependency
+                    }
+
+                    if all_deps.get(dep).and_then(|d| d.as_ref()).is_none() {
+                        compute_inner(var_info, all_deps, processing, dep, is_initial, scc_map)?;
+                    }
+
+                    // `successors` only contains known vars (dt: filtered
+                    // inside `dt_walk_successors`; init: the `contains_key`
+                    // filter above), so this lookup never misses. The
+                    // `!dep_info.is_module` transitive non-absorption guard
+                    // is preserved exactly -- it governs only whether
+                    // `dep`'s transitive set is absorbed, never iteration.
+                    if var_info.get(dep).map(|d| !d.is_module).unwrap_or(false)
+                        && let Some(Some(dep_deps)) = all_deps.get(dep)
+                    {
+                        transitive.extend(dep_deps.iter().cloned());
+                    }
                 }
 
-                // `successors` only contains known vars (dt: filtered
-                // inside `dt_walk_successors`; init: the `contains_key`
-                // filter above), so this lookup never misses. The
-                // `!dep_info.is_module` transitive non-absorption guard
-                // is preserved exactly -- it governs only whether
-                // `dep`'s transitive set is absorbed, never iteration.
-                if var_info.get(dep).map(|d| !d.is_module).unwrap_or(false)
-                    && let Some(Some(dep_deps)) = all_deps.get(dep)
-                {
-                    transitive.extend(dep_deps.iter().cloned());
-                }
+                processing.remove(name);
+                all_deps.insert(name.clone(), Some(transitive));
+                Ok(())
             }
 
-            processing.remove(name);
-            all_deps.insert(name.to_string(), Some(transitive));
-            Ok(())
-        }
+            // Iterate every node once. The keys (interned idents) are cloned
+            // (Arc bumps) so the borrow of `var_info` is released before the
+            // mutable `all_deps`/`processing` recursion.
+            let names: Vec<Ident<Canonical>> = var_info.keys().cloned().collect();
+            for name in &names {
+                compute_inner(
+                    &var_info,
+                    &mut all_deps,
+                    &mut processing,
+                    name,
+                    is_initial,
+                    scc_map,
+                )?;
+            }
 
-        let names: Vec<String> = var_info.keys().cloned().collect();
-        for name in &names {
-            compute_inner(
-                &var_info,
-                &mut all_deps,
-                &mut processing,
-                name,
-                is_initial,
-                scc_map,
-            )?;
-        }
-
-        Ok(all_deps
-            .into_iter()
-            .map(|(k, v)| (k, v.unwrap_or_default()))
-            .collect())
-    };
+            // Materialize the std `HashMap` (default hasher) the salsa return
+            // type uses; the FxHash working map's iteration order is irrelevant
+            // (each value is a `BTreeSet`, and downstream consumers either probe
+            // by key or re-sort).
+            Ok(all_deps
+                .into_iter()
+                .map(|(k, v)| (k, v.unwrap_or_default()))
+                .collect())
+        };
 
     let mut has_cycle = false;
     let mut resolved_sccs: Vec<ResolvedScc> = Vec::new();
 
-    let no_scc: BTreeMap<String, usize> = BTreeMap::new();
+    let no_scc: BTreeMap<Ident<Canonical>, usize> = BTreeMap::new();
 
     // First pass with NO resolved SCCs: the acyclic happy path returns
     // `Ok` here with zero refinement work (byte-identical to the pre-
@@ -1977,7 +2026,7 @@ pub(crate) fn model_dependency_graph_impl(
     // case of the SAME map. `dt_scc_map` is empty unless the dt gate
     // actually found a fully-resolvable back-edge (acyclic happy path /
     // loud-safe fallback => zero extra work).
-    let dt_scc_map: BTreeMap<String, usize> = if dt_first.is_err() {
+    let dt_scc_map: BTreeMap<Ident<Canonical>, usize> = if dt_first.is_err() {
         let resolution =
             crate::db_dep_graph::resolve_recurrence_sccs(db, model, project, SccPhase::Dt);
         if !resolution.has_unresolved && !resolution.resolved.is_empty() {
@@ -2104,9 +2153,12 @@ pub(crate) fn model_dependency_graph_impl(
         }
     };
 
-    // Build runlists via topological sort
+    // Build runlists via topological sort. The runlists themselves stay
+    // `Vec<String>` (O(V), many `&str`-keyed consumers in db.rs/tests), so
+    // we materialize the interned `var_info` keys back to owned `String`s at
+    // this boundary. The hot O(V^2) transitive closure above stays interned.
     let var_names: Vec<String> = {
-        let mut names: Vec<String> = var_info.keys().cloned().collect();
+        let mut names: Vec<String> = var_info.keys().map(|k| k.as_str().to_string()).collect();
         names.sort_unstable();
         names
     };
@@ -2151,7 +2203,7 @@ pub(crate) fn model_dependency_graph_impl(
     let (init_scc_of, init_scc_members) = build_scc_grouping(false);
 
     let topo_sort_str = |names: Vec<&String>,
-                         deps: &HashMap<String, BTreeSet<String>>,
+                         deps: &HashMap<Ident<Canonical>, BTreeSet<Ident<Canonical>>>,
                          scc_of: &HashMap<&str, usize>,
                          scc_members: &HashMap<usize, Vec<&str>>|
      -> Vec<String> {
@@ -2163,8 +2215,13 @@ pub(crate) fn model_dependency_graph_impl(
         let mut result: Vec<String> = Vec::new();
         let mut used: HashSet<String> = HashSet::new();
 
+        // `deps` is now interned-keyed, but this sort still works in `&str`
+        // space: probes go through `Borrow<str>` and each dep-set iteration
+        // hands `add` the dep's `as_str()`. The output is byte-identical to
+        // the former `String`-keyed map (same visit order over a pre-sorted
+        // `names`, same `BTreeSet` dep order).
         fn add(
-            deps: &HashMap<String, BTreeSet<String>>,
+            deps: &HashMap<Ident<Canonical>, BTreeSet<Ident<Canonical>>>,
             allowed: &HashSet<&str>,
             scc_of: &HashMap<&str, usize>,
             scc_members: &HashMap<usize, Vec<&str>>,
@@ -2194,7 +2251,15 @@ pub(crate) fn model_dependency_graph_impl(
                 for m in members {
                     if let Some(d) = deps.get(*m) {
                         for dep in d.iter() {
-                            add(deps, allowed, scc_of, scc_members, result, used, dep);
+                            add(
+                                deps,
+                                allowed,
+                                scc_of,
+                                scc_members,
+                                result,
+                                used,
+                                dep.as_str(),
+                            );
                         }
                     }
                 }
@@ -2208,7 +2273,15 @@ pub(crate) fn model_dependency_graph_impl(
             used.insert(name.to_string());
             if let Some(d) = deps.get(name) {
                 for dep in d.iter() {
-                    add(deps, allowed, scc_of, scc_members, result, used, dep);
+                    add(
+                        deps,
+                        allowed,
+                        scc_of,
+                        scc_members,
+                        result,
+                        used,
+                        dep.as_str(),
+                    );
                 }
             }
             // Only include variables that were in the original filtered list
@@ -2269,7 +2342,13 @@ pub(crate) fn model_dependency_graph_impl(
     // the transitive closure below).
     let runlist_initials = {
         use std::collections::HashSet;
-        let needed: HashSet<&String> = var_names
+        // `needed` borrows `var_names` (owned `String`s). `init_set` works in
+        // `&str` space because `initial_dependencies` is now interned-keyed:
+        // its dep iterator yields `&Ident<Canonical>` (taken as `.as_str()`),
+        // while the seed members are `var_names`' `&str`. All entries borrow
+        // strings that outlive the block (`var_names` for seeds,
+        // `initial_dependencies`' interned keys for deps).
+        let needed: HashSet<&str> = var_names
             .iter()
             .filter(|n| {
                 var_info
@@ -2285,27 +2364,28 @@ pub(crate) fn model_dependency_graph_impl(
                     .unwrap_or(false)
                     || all_init_referenced.contains(n.as_str())
             })
+            .map(|n| n.as_str())
             .collect();
-        let mut init_set: HashSet<&String> = needed
+        let mut init_set: HashSet<&str> = needed
             .iter()
             .flat_map(|n| {
                 initial_dependencies
-                    .get(n.as_str())
+                    .get(*n)
                     .into_iter()
-                    .flat_map(|deps| deps.iter())
+                    .flat_map(|deps| deps.iter().map(|d| d.as_str()))
             })
             .collect();
         init_set.extend(needed);
         // Transitively close: each item added to init_set may itself
         // have deps that also need to be in the initials runlist.
         loop {
-            let additional: HashSet<&String> = init_set
+            let additional: HashSet<&str> = init_set
                 .iter()
                 .flat_map(|n| {
                     initial_dependencies
-                        .get(n.as_str())
+                        .get(*n)
                         .into_iter()
-                        .flat_map(|deps| deps.iter())
+                        .flat_map(|deps| deps.iter().map(|d| d.as_str()))
                 })
                 .filter(|d| !init_set.contains(d))
                 .collect();
@@ -2326,10 +2406,15 @@ pub(crate) fn model_dependency_graph_impl(
         // Stocks runlists already filter the pre-sorted `var_names`, so they
         // are deterministic by construction; this matches that contract for
         // the initials phase.
-        let mut init_list: Vec<&String> = init_set.into_iter().collect();
+        let mut init_list: Vec<&str> = init_set.into_iter().collect();
         init_list.sort_unstable();
+        // `topo_sort_str` takes `Vec<&String>`; materialize the sorted
+        // candidate names as owned `String`s (this is the init phase, O(V),
+        // not the hot transitive-closure path).
+        let init_list_owned: Vec<String> = init_list.iter().map(|s| (*s).to_string()).collect();
+        let init_list_refs: Vec<&String> = init_list_owned.iter().collect();
         topo_sort_str(
-            init_list,
+            init_list_refs,
             &initial_dependencies,
             &init_scc_of,
             &init_scc_members,

--- a/src/simlin-engine/src/db_dep_graph_tests.rs
+++ b/src/simlin-engine/src/db_dep_graph_tests.rs
@@ -32,22 +32,39 @@ use crate::test_common::TestProject;
 //   absent => empty (no panic).
 
 /// Build a bare `VarInfo` for the pure-unit `dt_walk_successors` tests.
+/// The dep names are already canonical (lowercase, underscore-joined), so
+/// `from_str_unchecked` (intern, no re-canonicalization) is sound.
 fn vi_for_test(is_stock: bool, is_module: bool, dt_deps: &[&str]) -> VarInfo {
     VarInfo {
         is_stock,
         is_module,
         is_table_only: false,
-        dt_deps: dt_deps.iter().map(|s| (*s).to_string()).collect(),
+        dt_deps: dt_deps
+            .iter()
+            .map(|s| Ident::from_str_unchecked(s))
+            .collect(),
         initial_deps: BTreeSet::new(),
     }
 }
 
+/// Insert a `VarInfo` keyed by the interned canonical `name`.
+fn vi_insert(map: &mut FxHashMap<Ident<Canonical>, VarInfo>, name: &str, info: VarInfo) {
+    map.insert(Ident::from_str_unchecked(name), info);
+}
+
+/// Compare a `dt_walk_successors`/`init_walk_successors` result (now
+/// `Vec<&Ident<Canonical>>`) against the expected canonical names, preserving
+/// the exact ordered-equality assertions the tests had against `Vec<&str>`.
+fn succ_strs<'a>(succ: &[&'a Ident<Canonical>]) -> Vec<&'a str> {
+    succ.iter().map(|i| i.as_str()).collect()
+}
+
 #[test]
 fn dt_walk_successors_stock_is_dt_sink() {
-    let mut vinfo: HashMap<String, VarInfo> = HashMap::new();
-    vinfo.insert("s".to_string(), vi_for_test(true, false, &["a", "b"]));
-    vinfo.insert("a".to_string(), vi_for_test(false, false, &[]));
-    vinfo.insert("b".to_string(), vi_for_test(false, false, &[]));
+    let mut vinfo: FxHashMap<Ident<Canonical>, VarInfo> = FxHashMap::default();
+    vi_insert(&mut vinfo, "s", vi_for_test(true, false, &["a", "b"]));
+    vi_insert(&mut vinfo, "a", vi_for_test(false, false, &[]));
+    vi_insert(&mut vinfo, "b", vi_for_test(false, false, &[]));
     // A Stock breaks the dt dependency chain: no cycle successors even
     // though its dt_deps are non-empty.
     assert!(dt_walk_successors(&vinfo, "s").is_empty());
@@ -55,9 +72,9 @@ fn dt_walk_successors_stock_is_dt_sink() {
 
 #[test]
 fn dt_walk_successors_module_has_no_cycle_successors() {
-    let mut vinfo: HashMap<String, VarInfo> = HashMap::new();
-    vinfo.insert("m".to_string(), vi_for_test(false, true, &["a"]));
-    vinfo.insert("a".to_string(), vi_for_test(false, false, &[]));
+    let mut vinfo: FxHashMap<Ident<Canonical>, VarInfo> = FxHashMap::default();
+    vi_insert(&mut vinfo, "m", vi_for_test(false, true, &["a"]));
+    vi_insert(&mut vinfo, "a", vi_for_test(false, false, &[]));
     // A Module returns before `processing.insert`, so it is never on the
     // DFS stack and can never carry a cycle: empty cycle-successor set.
     assert!(dt_walk_successors(&vinfo, "m").is_empty());
@@ -65,14 +82,15 @@ fn dt_walk_successors_module_has_no_cycle_successors() {
 
 #[test]
 fn dt_walk_successors_aux_filters_stock_and_unknown_keeps_module() {
-    let mut vinfo: HashMap<String, VarInfo> = HashMap::new();
-    vinfo.insert(
-        "x".to_string(),
+    let mut vinfo: FxHashMap<Ident<Canonical>, VarInfo> = FxHashMap::default();
+    vi_insert(
+        &mut vinfo,
+        "x",
         vi_for_test(false, false, &["aux2", "the_stock", "the_mod", "ghost"]),
     );
-    vinfo.insert("aux2".to_string(), vi_for_test(false, false, &[]));
-    vinfo.insert("the_stock".to_string(), vi_for_test(true, false, &[]));
-    vinfo.insert("the_mod".to_string(), vi_for_test(false, true, &[]));
+    vi_insert(&mut vinfo, "aux2", vi_for_test(false, false, &[]));
+    vi_insert(&mut vinfo, "the_stock", vi_for_test(true, false, &[]));
+    vi_insert(&mut vinfo, "the_mod", vi_for_test(false, true, &[]));
     // "ghost" is intentionally absent from var_info (an unknown dep).
     let succ = dt_walk_successors(&vinfo, "x");
     // Stock-targeted dep dropped (a stock breaks the dt chain), unknown
@@ -80,12 +98,12 @@ fn dt_walk_successors_aux_filters_stock_and_unknown_keeps_module() {
     // successors so Tarjan cannot route a cycle through it -- this
     // matches `compute_inner`, whose `!dep_info.is_module` guard only
     // controls transitive absorption, not iteration).
-    assert_eq!(succ, vec!["aux2", "the_mod"]);
+    assert_eq!(succ_strs(&succ), vec!["aux2", "the_mod"]);
 }
 
 #[test]
 fn dt_walk_successors_absent_name_is_empty() {
-    let vinfo: HashMap<String, VarInfo> = HashMap::new();
+    let vinfo: FxHashMap<Ident<Canonical>, VarInfo> = FxHashMap::default();
     // A malformed/absent var_info entry must not panic; it yields no
     // successors.
     assert!(dt_walk_successors(&vinfo, "nope").is_empty());
@@ -93,19 +111,20 @@ fn dt_walk_successors_absent_name_is_empty() {
 
 #[test]
 fn dt_walk_successors_order_is_btreeset_sorted() {
-    let mut vinfo: HashMap<String, VarInfo> = HashMap::new();
-    vinfo.insert(
-        "x".to_string(),
+    let mut vinfo: FxHashMap<Ident<Canonical>, VarInfo> = FxHashMap::default();
+    vi_insert(
+        &mut vinfo,
+        "x",
         vi_for_test(false, false, &["zeta", "alpha", "mid"]),
     );
-    vinfo.insert("zeta".to_string(), vi_for_test(false, false, &[]));
-    vinfo.insert("alpha".to_string(), vi_for_test(false, false, &[]));
-    vinfo.insert("mid".to_string(), vi_for_test(false, false, &[]));
+    vi_insert(&mut vinfo, "zeta", vi_for_test(false, false, &[]));
+    vi_insert(&mut vinfo, "alpha", vi_for_test(false, false, &[]));
+    vi_insert(&mut vinfo, "mid", vi_for_test(false, false, &[]));
     // dt_deps is a BTreeSet; the successor list preserves its sorted
     // iteration order. This is what makes the cycle-detection
     // first-back-edge and the SCC adjacency byte-stable across runs.
     assert_eq!(
-        dt_walk_successors(&vinfo, "x"),
+        succ_strs(&dt_walk_successors(&vinfo, "x")),
         vec!["alpha", "mid", "zeta"]
     );
 }
@@ -138,15 +157,18 @@ fn vi_init_for_test(is_stock: bool, is_module: bool, initial_deps: &[&str]) -> V
         is_module,
         is_table_only: false,
         dt_deps: BTreeSet::new(),
-        initial_deps: initial_deps.iter().map(|s| (*s).to_string()).collect(),
+        initial_deps: initial_deps
+            .iter()
+            .map(|s| Ident::from_str_unchecked(s))
+            .collect(),
     }
 }
 
 #[test]
 fn init_walk_successors_module_has_no_cycle_successors() {
-    let mut vinfo: HashMap<String, VarInfo> = HashMap::new();
-    vinfo.insert("m".to_string(), vi_init_for_test(false, true, &["a"]));
-    vinfo.insert("a".to_string(), vi_init_for_test(false, false, &[]));
+    let mut vinfo: FxHashMap<Ident<Canonical>, VarInfo> = FxHashMap::default();
+    vi_insert(&mut vinfo, "m", vi_init_for_test(false, true, &["a"]));
+    vi_insert(&mut vinfo, "a", vi_init_for_test(false, false, &[]));
     // The module early-return in `compute_inner` fires before
     // `processing.insert` in BOTH phases, so a module is never on the
     // DFS stack and can never carry a cycle in the init phase either:
@@ -156,9 +178,9 @@ fn init_walk_successors_module_has_no_cycle_successors() {
 
 #[test]
 fn init_walk_successors_stock_is_not_an_init_sink() {
-    let mut vinfo: HashMap<String, VarInfo> = HashMap::new();
-    vinfo.insert("s".to_string(), vi_init_for_test(true, false, &["s", "a"]));
-    vinfo.insert("a".to_string(), vi_init_for_test(false, false, &[]));
+    let mut vinfo: FxHashMap<Ident<Canonical>, VarInfo> = FxHashMap::default();
+    vi_insert(&mut vinfo, "s", vi_init_for_test(true, false, &["s", "a"]));
+    vi_insert(&mut vinfo, "a", vi_init_for_test(false, false, &[]));
     // A Stock is NOT an init-phase sink: the dt stock sink in
     // `compute_inner` is `!is_initial`-gated, so in the init phase a
     // stock's `initial_deps` ARE its cycle successors. A stock whose
@@ -166,44 +188,52 @@ fn init_walk_successors_stock_is_not_an_init_sink() {
     // genuine init self-loop, so `s` MUST appear in its own successor
     // set (this is exactly what an init-phase recurrence behind a stock
     // relies on).
-    assert_eq!(init_walk_successors(&vinfo, "s"), vec!["a", "s"]);
+    assert_eq!(
+        succ_strs(&init_walk_successors(&vinfo, "s")),
+        vec!["a", "s"]
+    );
 }
 
 #[test]
 fn init_walk_successors_keeps_stock_targeted_deps() {
-    let mut vinfo: HashMap<String, VarInfo> = HashMap::new();
-    vinfo.insert(
-        "x".to_string(),
+    let mut vinfo: FxHashMap<Ident<Canonical>, VarInfo> = FxHashMap::default();
+    vi_insert(
+        &mut vinfo,
+        "x",
         vi_init_for_test(false, false, &["the_stock", "aux2"]),
     );
-    vinfo.insert("the_stock".to_string(), vi_init_for_test(true, false, &[]));
-    vinfo.insert("aux2".to_string(), vi_init_for_test(false, false, &[]));
+    vi_insert(&mut vinfo, "the_stock", vi_init_for_test(true, false, &[]));
+    vi_insert(&mut vinfo, "aux2", vi_init_for_test(false, false, &[]));
     // Unlike `dt_walk_successors` (which drops stock-targeted deps
     // because a stock breaks the dt chain), the init relation KEEPS a
     // stock-targeted dep: a stock's initial value is a real init-phase
     // dependency. NO stock filter on the deps.
-    assert_eq!(init_walk_successors(&vinfo, "x"), vec!["aux2", "the_stock"]);
+    assert_eq!(
+        succ_strs(&init_walk_successors(&vinfo, "x")),
+        vec!["aux2", "the_stock"]
+    );
 }
 
 #[test]
 fn init_walk_successors_filters_unknown_deps() {
-    let mut vinfo: HashMap<String, VarInfo> = HashMap::new();
-    vinfo.insert(
-        "x".to_string(),
+    let mut vinfo: FxHashMap<Ident<Canonical>, VarInfo> = FxHashMap::default();
+    vi_insert(
+        &mut vinfo,
+        "x",
         vi_init_for_test(false, false, &["known", "ghost"]),
     );
-    vinfo.insert("known".to_string(), vi_init_for_test(false, false, &[]));
+    vi_insert(&mut vinfo, "known", vi_init_for_test(false, false, &[]));
     // "ghost" is intentionally absent from var_info.
     // This is exactly the inlined `compute_inner` init semantics
     // (`info.initial_deps.iter().filter(|dep|
     // var_info.contains_key(dep))`): unknown deps dropped, no other
     // filter.
-    assert_eq!(init_walk_successors(&vinfo, "x"), vec!["known"]);
+    assert_eq!(succ_strs(&init_walk_successors(&vinfo, "x")), vec!["known"]);
 }
 
 #[test]
 fn init_walk_successors_absent_name_is_empty() {
-    let vinfo: HashMap<String, VarInfo> = HashMap::new();
+    let vinfo: FxHashMap<Ident<Canonical>, VarInfo> = FxHashMap::default();
     // A malformed/absent var_info entry must not panic; it yields no
     // successors (mirrors `dt_walk_successors`; `compute_inner` likewise
     // early-returns `Ok(())` for an unknown name).
@@ -212,20 +242,21 @@ fn init_walk_successors_absent_name_is_empty() {
 
 #[test]
 fn init_walk_successors_order_is_btreeset_sorted() {
-    let mut vinfo: HashMap<String, VarInfo> = HashMap::new();
-    vinfo.insert(
-        "x".to_string(),
+    let mut vinfo: FxHashMap<Ident<Canonical>, VarInfo> = FxHashMap::default();
+    vi_insert(
+        &mut vinfo,
+        "x",
         vi_init_for_test(false, false, &["zeta", "alpha", "mid"]),
     );
-    vinfo.insert("zeta".to_string(), vi_init_for_test(false, false, &[]));
-    vinfo.insert("alpha".to_string(), vi_init_for_test(false, false, &[]));
-    vinfo.insert("mid".to_string(), vi_init_for_test(false, false, &[]));
+    vi_insert(&mut vinfo, "zeta", vi_init_for_test(false, false, &[]));
+    vi_insert(&mut vinfo, "alpha", vi_init_for_test(false, false, &[]));
+    vi_insert(&mut vinfo, "mid", vi_init_for_test(false, false, &[]));
     // initial_deps is a BTreeSet; the successor list preserves its
     // sorted iteration order, so init cycle detection and the init SCC
     // adjacency are byte-stable across runs (same discipline as
     // `dt_walk_successors`).
     assert_eq!(
-        init_walk_successors(&vinfo, "x"),
+        succ_strs(&init_walk_successors(&vinfo, "x")),
         vec!["alpha", "mid", "zeta"]
     );
 }
@@ -3188,7 +3219,10 @@ fn initials_runlist_is_sorted_topological_order() {
     // order, not this helper.
     fn emit(
         name: &str,
-        deps: &std::collections::HashMap<String, std::collections::BTreeSet<String>>,
+        deps: &std::collections::HashMap<
+            Ident<Canonical>,
+            std::collections::BTreeSet<Ident<Canonical>>,
+        >,
         members: &std::collections::BTreeSet<String>,
         emitted: &mut std::collections::BTreeSet<String>,
         out: &mut Vec<String>,
@@ -3197,10 +3231,13 @@ fn initials_runlist_is_sorted_topological_order() {
             return;
         }
         emitted.insert(name.to_string());
+        // `deps` is interned-keyed now; probe by `&str` (Borrow) and recurse
+        // on each dep's `as_str()`. Behavior is unchanged from the former
+        // `String`-keyed map (same `BTreeSet` lexicographic dep order).
         if let Some(ds) = deps.get(name) {
             for d in ds.iter() {
                 if members.contains(d.as_str()) {
-                    emit(d, deps, members, emitted, out);
+                    emit(d.as_str(), deps, members, emitted, out);
                 }
             }
         }

--- a/src/simlin-engine/src/db_dimension_context_cache_tests.rs
+++ b/src/simlin-engine/src/db_dimension_context_cache_tests.rs
@@ -1,0 +1,173 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+//! Tests for the project-global dimension-context salsa queries.
+//!
+//! `project_dimensions_context` and `project_converted_dimensions` compute the
+//! project's `DimensionsContext` and converted `Vec<Dimension>` once per
+//! project (keyed on the `SourceProject` dimensions input), so the per-variable
+//! compile sites can read the cached value instead of rebuilding it on every
+//! variable. These tests verify:
+//!   - the cached values equal the freshly-built ones (oracle), and
+//!   - the queries are memoized across calls / recompute when a dimension
+//!     changes (mirroring `db_dimension_invalidation_tests.rs`).
+
+use super::*;
+use crate::datamodel;
+
+/// Build a two-dimension project with a single scalar variable.
+fn two_dim_project() -> datamodel::Project {
+    datamodel::Project {
+        name: "dim_ctx_cache".to_string(),
+        sim_specs: datamodel::SimSpecs::default(),
+        dimensions: vec![
+            datamodel::Dimension::named(
+                "DimA".to_string(),
+                vec!["a1".to_string(), "a2".to_string()],
+            ),
+            datamodel::Dimension::named(
+                "DimB".to_string(),
+                vec!["b1".to_string(), "b2".to_string(), "b3".to_string()],
+            ),
+        ],
+        units: vec![],
+        models: vec![datamodel::Model {
+            name: "main".to_string(),
+            sim_specs: None,
+            variables: vec![datamodel::Variable::Aux(datamodel::Aux {
+                ident: "x".to_string(),
+                equation: datamodel::Equation::Scalar("10".to_string()),
+                documentation: String::new(),
+                units: None,
+                gf: None,
+                ai_state: None,
+                uid: None,
+                compat: datamodel::Compat::default(),
+            })],
+            views: vec![],
+            loop_metadata: vec![],
+            groups: vec![],
+            macro_spec: None,
+        }],
+        source: None,
+        ai_information: None,
+    }
+}
+
+/// The cached `project_dimensions_context` must equal a context built fresh
+/// from `project_datamodel_dims` (the exact computation the per-variable sites
+/// used to do inline).
+#[test]
+fn test_cached_dimensions_context_equals_fresh() {
+    let mut db = SimlinDb::default();
+    let project = two_dim_project();
+    let state = sync_from_datamodel_incremental(&mut db, &project, None);
+    let sync = state.to_sync_result();
+
+    let cached = project_dimensions_context(&db, sync.project);
+    let fresh = crate::dimensions::DimensionsContext::from(
+        project_datamodel_dims(&db, sync.project).as_slice(),
+    );
+
+    assert_eq!(
+        *cached, fresh,
+        "cached project_dimensions_context must equal the freshly-built context"
+    );
+}
+
+/// The cached `project_converted_dimensions` must equal the per-`Dimension`
+/// conversion the sites used to do inline.
+#[test]
+fn test_cached_converted_dimensions_equals_fresh() {
+    let mut db = SimlinDb::default();
+    let project = two_dim_project();
+    let state = sync_from_datamodel_incremental(&mut db, &project, None);
+    let sync = state.to_sync_result();
+
+    let cached = project_converted_dimensions(&db, sync.project);
+    let fresh: Vec<crate::dimensions::Dimension> = project_datamodel_dims(&db, sync.project)
+        .iter()
+        .map(crate::dimensions::Dimension::from)
+        .collect();
+
+    assert_eq!(
+        *cached, fresh,
+        "cached project_converted_dimensions must equal the freshly-built vec"
+    );
+}
+
+/// Both queries are `returns(ref)` and keyed only on the project's dimensions,
+/// so two calls without an intervening dimension change return the SAME cached
+/// allocation (pointer-equal) -- proving memoization (no per-call rebuild).
+#[test]
+fn test_dimension_context_queries_are_memoized() {
+    let mut db = SimlinDb::default();
+    let project = two_dim_project();
+    let state = sync_from_datamodel_incremental(&mut db, &project, None);
+    let sync = state.to_sync_result();
+
+    let ctx_ptr_a = project_dimensions_context(&db, sync.project)
+        as *const crate::dimensions::DimensionsContext;
+    let ctx_ptr_b = project_dimensions_context(&db, sync.project)
+        as *const crate::dimensions::DimensionsContext;
+    assert_eq!(
+        ctx_ptr_a, ctx_ptr_b,
+        "project_dimensions_context must be memoized (cache hit, pointer-equal)"
+    );
+
+    let conv_ptr_a =
+        project_converted_dimensions(&db, sync.project) as *const Vec<crate::dimensions::Dimension>;
+    let conv_ptr_b =
+        project_converted_dimensions(&db, sync.project) as *const Vec<crate::dimensions::Dimension>;
+    assert_eq!(
+        conv_ptr_a, conv_ptr_b,
+        "project_converted_dimensions must be memoized (cache hit, pointer-equal)"
+    );
+}
+
+/// Changing a dimension recomputes the context queries to the new value
+/// (the same input-dependency the per-variable sites already took by reading
+/// `project_datamodel_dims`).
+#[test]
+fn test_dimension_context_recomputes_on_dimension_change() {
+    let mut db = SimlinDb::default();
+    let project = two_dim_project();
+    let state1 = sync_from_datamodel_incremental(&mut db, &project, None);
+    let sync1 = state1.to_sync_result();
+
+    let dim_a = crate::common::CanonicalDimensionName::from_raw("DimA");
+    let len_before = project_dimensions_context(&db, sync1.project)
+        .get(&dim_a)
+        .map(|d| d.len());
+    assert_eq!(len_before, Some(2), "DimA starts with 2 elements");
+    assert_eq!(
+        project_converted_dimensions(&db, sync1.project).len(),
+        2,
+        "two dimensions before the change"
+    );
+
+    // Add an element to DimA.
+    let mut project2 = project.clone();
+    project2.dimensions[0] = datamodel::Dimension::named(
+        "DimA".to_string(),
+        vec!["a1".to_string(), "a2".to_string(), "a3".to_string()],
+    );
+    let state2 = sync_from_datamodel_incremental(&mut db, &project2, Some(&state1));
+    let sync2 = state2.to_sync_result();
+
+    let len_after = project_dimensions_context(&db, sync2.project)
+        .get(&dim_a)
+        .map(|d| d.len());
+    assert_eq!(
+        len_after,
+        Some(3),
+        "project_dimensions_context must recompute after DimA grows"
+    );
+
+    // Cross-check against a freshly-built context to pin behavior-preservation.
+    let fresh = crate::dimensions::DimensionsContext::from(
+        project_datamodel_dims(&db, sync2.project).as_slice(),
+    );
+    assert_eq!(*project_dimensions_context(&db, sync2.project), fresh);
+}

--- a/src/simlin-engine/src/db_implicit_deps.rs
+++ b/src/simlin-engine/src/db_implicit_deps.rs
@@ -23,10 +23,16 @@ pub struct ImplicitVarDeps {
     pub referenced_tables: BTreeSet<String>,
 }
 
+/// `dims`, `dim_context`, and `converted_dims` are three views of the *same*
+/// project dimension list (datamodel form, context form, and converted form);
+/// the caller sources all three from the per-project salsa caches, so they are
+/// consistent by construction. Passing inconsistent slices would silently
+/// misclassify dependencies.
 pub(super) fn extract_implicit_var_deps(
     parsed: &ParsedVariableResult,
     dims: &[datamodel::Dimension],
     dim_context: &crate::dimensions::DimensionsContext,
+    converted_dims: &[crate::dimensions::Dimension],
     module_inputs: Option<&BTreeSet<Ident<Canonical>>>,
 ) -> Vec<ImplicitVarDeps> {
     if parsed.implicit_vars.is_empty() {
@@ -34,10 +40,6 @@ pub(super) fn extract_implicit_var_deps(
     }
 
     let units_ctx = crate::units::Context::new(&[], &Default::default()).0;
-    let converted_dims: Vec<crate::dimensions::Dimension> = dims
-        .iter()
-        .map(crate::dimensions::Dimension::from)
-        .collect();
 
     parsed
         .implicit_vars
@@ -93,13 +95,13 @@ pub(super) fn extract_implicit_var_deps(
             // Two calls to classify_dependencies replace 5 separate walker calls.
             let dt_classification = match lowered.ast() {
                 Some(ast) => {
-                    crate::variable::classify_dependencies(ast, &converted_dims, module_inputs)
+                    crate::variable::classify_dependencies(ast, converted_dims, module_inputs)
                 }
                 None => crate::variable::DepClassification::default(),
             };
             let init_classification = match lowered.init_ast() {
                 Some(ast) => {
-                    crate::variable::classify_dependencies(ast, &converted_dims, module_inputs)
+                    crate::variable::classify_dependencies(ast, converted_dims, module_inputs)
                 }
                 None => crate::variable::DepClassification::default(),
             };

--- a/src/simlin-engine/src/db_ltm.rs
+++ b/src/simlin-engine/src/db_ltm.rs
@@ -22,8 +22,9 @@ use super::{
     SourceModel, SourceProject, SourceVariableKind, VarFragmentResult, build_module_inputs,
     build_stub_variable, build_submodel_metadata, canonical_module_input_set, compute_layout,
     link_score_equation_text, model_implicit_var_info, model_module_ident_context,
-    model_module_map, parse_source_variable_with_module_context, project_datamodel_dims,
-    project_units_context, variable_dimensions, variable_size,
+    model_module_map, parse_source_variable_with_module_context, project_converted_dimensions,
+    project_datamodel_dims, project_dimensions_context, project_units_context, variable_dimensions,
+    variable_size,
 };
 
 pub(super) fn ltm_module_idents(
@@ -143,8 +144,7 @@ pub(super) fn reconstruct_ltm_var_lowered(
     model: SourceModel,
     project: SourceProject,
 ) -> Option<crate::variable::Variable> {
-    let dims = project_datamodel_dims(db, project);
-    let dim_context = crate::dimensions::DimensionsContext::from(dims.as_slice());
+    let dim_context = project_dimensions_context(db, project);
     let module_idents = ltm_module_idents(db, model, project);
     let parsed =
         parse_ltm_equation_for_model_with_ids(db, var_name, equation, project, &module_idents);
@@ -158,7 +158,7 @@ pub(super) fn reconstruct_ltm_var_lowered(
     let models = HashMap::new();
     let scope = crate::model::ScopeStage0 {
         models: &models,
-        dimensions: &dim_context,
+        dimensions: dim_context,
         model_name: "",
     };
     Some(crate::model::lower_variable(&scope, &parsed.variable))
@@ -426,10 +426,10 @@ pub fn link_score_equation_text_shaped<'db>(
     // The project's `DimensionsContext` is threaded into the GH #511
     // iterated-dimension recognition for the mapped-dimension case
     // (`x[State]` over a source declared with `Region`, `State` maps to
-    // `Region`); the datamodel dim list is salsa-tracked, so this fn is
-    // recomputed when a dimension's mappings change.
-    let dm_dims = project_datamodel_dims(db, project);
-    let dim_ctx = crate::dimensions::DimensionsContext::from(dm_dims.as_slice());
+    // `Region`); the cached context depends only on the salsa-tracked
+    // dimensions input, so this fn is recomputed when a dimension's
+    // mappings change.
+    let dim_ctx = project_dimensions_context(db, project);
     // The generator returns the equation already tagged with the target's
     // dimensionality (`Scalar`, `ApplyToAll`, or `Arrayed`). `dimensions`
     // and `compile_directly` are left at defaults here; the emission loop
@@ -443,7 +443,7 @@ pub fn link_score_equation_text_shaped<'db>(
         &source_dim_elements,
         &to_var,
         &all_vars,
-        Some(&dim_ctx),
+        Some(dim_ctx),
     );
 
     Some(LtmSyntheticVar {
@@ -570,12 +570,12 @@ pub(super) fn compile_ltm_equation_fragment(
         CompiledVarFragment, PerVarBytecodes, ReverseOffsetMap, VariableLayout,
     };
 
+    // Project-global dims (datamodel form needed by `parse_ltm_equation`) plus
+    // the canonicalized context + converted dims, all from the salsa-cached
+    // queries rather than rebuilt per LTM fragment.
     let dims = project_datamodel_dims(db, project);
-    let dim_context = crate::dimensions::DimensionsContext::from(dims.as_slice());
-    let converted_dims: Vec<crate::dimensions::Dimension> = dims
-        .iter()
-        .map(crate::dimensions::Dimension::from)
-        .collect();
+    let dim_context = project_dimensions_context(db, project);
+    let converted_dims = project_converted_dimensions(db, project);
 
     let units_ctx = project_units_context(db, project);
     let module_idents = ltm_module_idents(db, model, project);
@@ -599,7 +599,7 @@ pub(super) fn compile_ltm_equation_fragment(
     let models = HashMap::new();
     let scope = crate::model::ScopeStage0 {
         models: &models,
-        dimensions: &dim_context,
+        dimensions: dim_context,
         model_name: "",
     };
     let lowered = crate::model::lower_variable(&scope, &parsed.variable);
@@ -1189,8 +1189,8 @@ pub(super) fn compile_ltm_equation_fragment(
     }
 
     let core = crate::compiler::ContextCore {
-        dimensions: &converted_dims,
-        dimensions_ctx: &dim_context,
+        dimensions: converted_dims,
+        dimensions_ctx: dim_context,
         model_name: &model_name_ident,
         metadata: &all_metadata,
         module_models: &module_models,
@@ -1233,8 +1233,13 @@ pub(super) fn compile_ltm_equation_fragment(
                 .collect(),
             runlist_order: vec![var_ident_canonical.clone()],
             tables: tables.clone(),
-            dimensions: converted_dims.clone(),
-            dimensions_ctx: dim_context.clone(),
+            // Owned Module fields: the slice/context come from the cached
+            // queries by reference, so materialize owned copies here. The
+            // interned-backed `Dimension`s clone cheaply -- the expensive
+            // rebuild (re-canonicalizing every element) is what the cache
+            // removes; only the relationship-cache memo is rebuilt cold.
+            dimensions: converted_dims.to_vec(),
+            dimensions_ctx: (*dim_context).clone(),
             module_refs: implicit_module_refs.clone(),
         };
 
@@ -1503,12 +1508,11 @@ pub(super) fn compile_ltm_implicit_var_fragment(
     let implicit_dm_var = parsed.implicit_vars.get(idx)?;
     let implicit_name = canonicalize(implicit_dm_var.get_ident()).into_owned();
 
+    // Project-global dims (datamodel form needed by `parse_var`) plus the
+    // canonicalized context + converted dims, from the salsa-cached queries.
     let dims = project_datamodel_dims(db, project);
-    let dim_context = crate::dimensions::DimensionsContext::from(dims.as_slice());
-    let converted_dims: Vec<crate::dimensions::Dimension> = dims
-        .iter()
-        .map(crate::dimensions::Dimension::from)
-        .collect();
+    let dim_context = project_dimensions_context(db, project);
+    let converted_dims = project_converted_dimensions(db, project);
 
     let units_ctx = project_units_context(db, project);
 
@@ -1568,7 +1572,7 @@ pub(super) fn compile_ltm_implicit_var_fragment(
         let models = HashMap::new();
         let scope = crate::model::ScopeStage0 {
             models: &models,
-            dimensions: &dim_context,
+            dimensions: dim_context,
             model_name: "",
         };
         crate::model::lower_variable(&scope, &parsed_implicit)
@@ -1975,8 +1979,8 @@ pub(super) fn compile_ltm_implicit_var_fragment(
     }
 
     let core = crate::compiler::ContextCore {
-        dimensions: &converted_dims,
-        dimensions_ctx: &dim_context,
+        dimensions: converted_dims,
+        dimensions_ctx: dim_context,
         model_name: &model_name_ident,
         metadata: &all_metadata,
         module_models: &module_models,
@@ -2019,8 +2023,13 @@ pub(super) fn compile_ltm_implicit_var_fragment(
                 .collect(),
             runlist_order: vec![var_ident_canonical.clone()],
             tables: tables.clone(),
-            dimensions: converted_dims.clone(),
-            dimensions_ctx: dim_context.clone(),
+            // Owned Module fields: the slice/context come from the cached
+            // queries by reference, so materialize owned copies here. The
+            // interned-backed `Dimension`s clone cheaply -- the expensive
+            // rebuild (re-canonicalizing every element) is what the cache
+            // removes; only the relationship-cache memo is rebuilt cold.
+            dimensions: converted_dims.to_vec(),
+            dimensions_ctx: (*dim_context).clone(),
             module_refs: module_refs.clone(),
         };
 

--- a/src/simlin-engine/src/db_ltm_ir.rs
+++ b/src/simlin-engine/src/db_ltm_ir.rs
@@ -555,11 +555,11 @@ pub(crate) fn model_ltm_reference_sites(
 
     // Dimension context for the #511 iterated-subscript recognition: the
     // mapped-dimension case (`State[i]` over a source declared with
-    // `Region[i]`, `State` maps to `Region`) needs `has_mapping_to`. The
-    // datamodel dim list (and hence this context) is salsa-tracked, so the
-    // IR is recomputed when a dimension's mappings change.
-    let dm_dims = crate::db::project_datamodel_dims(db, project);
-    let dim_ctx = crate::dimensions::DimensionsContext::from(dm_dims.as_slice());
+    // `Region[i]`, `State` maps to `Region`) needs `has_mapping_to`. Read the
+    // project-global context from the salsa-cached query; it depends only on
+    // the salsa-tracked dimensions input, so the IR is recomputed when a
+    // dimension's mappings change.
+    let dim_ctx = crate::db::project_dimensions_context(db, project);
 
     // Per-source dimension lookup, cached: a source's dims are needed to
     // resolve literal subscripts and are reused across many edges.
@@ -590,7 +590,7 @@ pub(crate) fn model_ltm_reference_sites(
         let to_name_str = to_name.as_str();
 
         let raw_by_source =
-            collect_all_reference_sites(to_var, &variables, &dim_ctx, &mut lookup_dims);
+            collect_all_reference_sites(to_var, &variables, dim_ctx, &mut lookup_dims);
         if raw_by_source.is_empty() {
             continue;
         }

--- a/src/simlin-engine/src/db_prev_init_tests.rs
+++ b/src/simlin-engine/src/db_prev_init_tests.rs
@@ -53,7 +53,7 @@ fn test_model_dependency_graph_prunes_lagged_deps_for_implicit_helpers() {
     let helper = graph
         .dt_dependencies
         .iter()
-        .find(|(name, _)| name.contains("arg0"))
+        .find(|(name, _)| name.as_str().contains("arg0"))
         .expect("nested PREVIOUS should create an implicit arg helper");
 
     assert!(

--- a/src/simlin-engine/src/db_units.rs
+++ b/src/simlin-engine/src/db_units.rs
@@ -36,7 +36,7 @@ use crate::datamodel;
 use crate::db::{
     CompilationDiagnostic, Db, Diagnostic, DiagnosticError, DiagnosticSeverity, SourceModel,
     SourceProject, model_module_ident_context, parse_source_variable_with_module_context,
-    project_datamodel_dims, project_units_context,
+    project_datamodel_dims, project_dimensions_context, project_units_context,
 };
 
 /// Collect the identifiers that must share units because they sit in the
@@ -163,7 +163,6 @@ fn init_value_equivalence_group(
 #[salsa::tracked]
 pub fn check_model_units(db: &dyn Db, model: SourceModel, project: SourceProject) {
     use crate::common::{ErrorCode, ErrorKind};
-    use crate::dimensions::DimensionsContext;
     use crate::model::{ModelStage0, ModelStage1, ScopeStage0, VariableStage0};
 
     // Skip stdlib models -- they are generic and unit checking doesn't
@@ -185,7 +184,7 @@ pub fn check_model_units(db: &dyn Db, model: SourceModel, project: SourceProject
     let model_name = model.name(db).clone();
     let units_ctx = project_units_context(db, project);
     let dm_dims = project_datamodel_dims(db, project);
-    let dim_context = DimensionsContext::from(dm_dims.as_slice());
+    let dim_context = project_dimensions_context(db, project);
 
     // Helper: build a ModelStage0 from a SourceModel's parsed variables.
     let build_model_s0 = |src_model: &SourceModel, is_stdlib: bool| -> ModelStage0 {
@@ -240,7 +239,7 @@ pub fn check_model_units(db: &dyn Db, model: SourceModel, project: SourceProject
         .map(|ms0| {
             let scope = ScopeStage0 {
                 models: &models_s0,
-                dimensions: &dim_context,
+                dimensions: dim_context,
                 model_name: ms0.ident.as_str(),
             };
             ModelStage1::new(&scope, ms0)

--- a/src/simlin-engine/src/dimensions.rs
+++ b/src/simlin-engine/src/dimensions.rs
@@ -219,6 +219,49 @@ impl PartialEq for DimensionsContext {
     }
 }
 
+// SAFETY: A `DimensionsContext` is value-defined by its `dimensions` and
+// `indexed_parents` maps -- exactly what its manual `PartialEq` above compares.
+// The `relationship_cache` is a pure memoization (subdimension offset lookups)
+// that does NOT affect identity, so two contexts built from the same dimensions
+// are equal regardless of which one has populated its cache. This makes a
+// by-`PartialEq` `maybe_update` sound: salsa treats the cached value as
+// immutable across revisions and rebuilds the (cold) cache on overwrite, so
+// overwriting on a genuine value change and skipping on equality never loses or
+// corrupts memoized data. This is needed so `DimensionsContext` can be a salsa
+// `returns(ref)` query value (`db::project_dimensions_context`), computed once
+// per project instead of rebuilt per variable.
+//
+// We hand-write this (rather than deriving) because the type intentionally does
+// NOT derive `salsa::Update`: it has a `Mutex<HashMap<...>>` cache field that is
+// neither `Eq` nor `Update`-derivable. The impl mirrors salsa's own
+// `update_fallback` (overwrite-and-report-changed iff `*old != new`) but keys on
+// this type's manual `PartialEq`.
+//
+// The crate is `#![deny(unsafe_code)]`; this is a targeted opt-in, mirroring the
+// precedent in `common.rs` (`CanonicalStorage`) and `vm.rs`. The `unsafe` is
+// confined to dereferencing the `*mut Self` salsa hands us, under the documented
+// `Update` contract.
+#[allow(unsafe_code)]
+unsafe impl salsa::Update for DimensionsContext {
+    unsafe fn maybe_update(old_pointer: *mut Self, new_value: Self) -> bool {
+        // SAFETY: by the `Update` contract `old_pointer` points to a valid,
+        // fully-owned `DimensionsContext` from a (possibly older) revision. It
+        // owns its maps and cache (no borrowed `'db` references), so taking a
+        // `&mut` is sound.
+        let old = unsafe { &mut *old_pointer };
+        if *old != new_value {
+            *old = new_value;
+            true
+        } else {
+            // The values are equal by the manual `PartialEq` (same dimensions
+            // and indexed_parents); the cache difference is immaterial, so we do
+            // not overwrite and report no change -- salsa's early-cutoff then
+            // avoids invalidating downstream queries.
+            false
+        }
+    }
+}
+
 impl DimensionsContext {
     pub(crate) fn from(dimensions: &[datamodel::Dimension]) -> DimensionsContext {
         // Validate: indexed dimensions should not have mappings set.
@@ -1814,6 +1857,102 @@ mod tests {
         assert_eq!(
             dim.get_offset(&CanonicalElementName::from_raw("3")),
             Some(2)
+        );
+    }
+
+    // ========== salsa::Update smoke test ==========
+
+    /// `DimensionsContext` is a salsa `returns(ref)` value via a manual
+    /// `unsafe impl salsa::Update`. Its identity is its `dimensions` +
+    /// `indexed_parents` maps (its manual `PartialEq`); the relationship
+    /// cache is pure memoization and must not affect update semantics.
+    #[test]
+    fn salsa_update_reports_change_only_on_value_difference() {
+        use salsa::Update;
+
+        let dim_a = datamodel::Dimension::named(
+            "DimA".to_string(),
+            vec!["a1".to_string(), "a2".to_string()],
+        );
+        let dim_a3 = datamodel::Dimension::named(
+            "DimA".to_string(),
+            vec!["a1".to_string(), "a2".to_string(), "a3".to_string()],
+        );
+
+        // Changed value -> overwrite and report changed.
+        let mut slot = DimensionsContext::from(std::slice::from_ref(&dim_a));
+        let changed = {
+            // SAFETY (test): `&mut slot` is a valid, owned `DimensionsContext`;
+            // we pass its pointer and a fresh owned value, matching the
+            // `Update::maybe_update` contract.
+            #[allow(unsafe_code)]
+            unsafe {
+                DimensionsContext::maybe_update(
+                    &mut slot as *mut _,
+                    DimensionsContext::from(std::slice::from_ref(&dim_a3)),
+                )
+            }
+        };
+        assert!(changed, "a changed dimension must report an update");
+        assert_eq!(
+            slot.get(&crate::common::CanonicalDimensionName::from_raw("DimA"))
+                .unwrap()
+                .len(),
+            3,
+            "the overwritten value must be observable"
+        );
+
+        // Equal value -> no overwrite, report unchanged.
+        let unchanged = {
+            #[allow(unsafe_code)]
+            unsafe {
+                DimensionsContext::maybe_update(
+                    &mut slot as *mut _,
+                    DimensionsContext::from(std::slice::from_ref(&dim_a3)),
+                )
+            }
+        };
+        assert!(!unchanged, "an equal value must report no update");
+    }
+
+    /// The relationship cache is pure memoization: two contexts built from
+    /// the same dimensions are equal even when one has populated its cache,
+    /// so `maybe_update` must report no change (no spurious salsa invalidation).
+    #[test]
+    fn salsa_update_ignores_relationship_cache_state() {
+        use salsa::Update;
+
+        let parent = datamodel::Dimension::named(
+            "DimA".to_string(),
+            vec!["a1".to_string(), "a2".to_string(), "a3".to_string()],
+        );
+        let mut child = datamodel::Dimension::named(
+            "SubA".to_string(),
+            vec!["a2".to_string(), "a3".to_string()],
+        );
+        child.parent = Some("DimA".to_string());
+
+        let dims = vec![parent, child];
+        let mut slot = DimensionsContext::from(dims.as_slice());
+
+        // Populate the relationship cache on `slot` via a lookup.
+        let sub_name = crate::common::CanonicalDimensionName::from_raw("SubA");
+        let parent_name = crate::common::CanonicalDimensionName::from_raw("DimA");
+        let _ = slot.get_subdimension_relation(&sub_name, &parent_name);
+
+        // A value-equal context with a *cold* cache must still compare equal.
+        let unchanged = {
+            #[allow(unsafe_code)]
+            unsafe {
+                DimensionsContext::maybe_update(
+                    &mut slot as *mut _,
+                    DimensionsContext::from(dims.as_slice()),
+                )
+            }
+        };
+        assert!(
+            !unchanged,
+            "cache state must not affect update semantics: equal dims => no update"
         );
     }
 }

--- a/src/simlin-engine/src/project.rs
+++ b/src/simlin-engine/src/project.rs
@@ -74,7 +74,7 @@ impl Project {
         use crate::db::{
             CompilationDiagnostic, DiagnosticError, model_module_ident_context,
             parse_source_variable_with_module_context, project_datamodel_dims,
-            project_units_context,
+            project_dimensions_context, project_units_context,
         };
         use crate::model::{ModelStage0, VariableStage0, enumerate_modules};
 
@@ -98,7 +98,9 @@ impl Project {
                 })
                 .collect();
         let dm_dims = project_datamodel_dims(db, source_project);
-        let dims_ctx = DimensionsContext::from(dm_dims.as_slice());
+        // Read the project-global dimension context from the salsa-cached query
+        // rather than rebuilding it here (it is canonicalized once per project).
+        let dims_ctx = project_dimensions_context(db, source_project);
 
         // Build ModelStage0 from salsa-parsed variables for all models.
         let project_models = source_project.models(db);
@@ -172,7 +174,7 @@ impl Project {
             .map(|ms0| {
                 let scope = ScopeStage0 {
                     models: &models_s0,
-                    dimensions: &dims_ctx,
+                    dimensions: dims_ctx,
                     model_name: ms0.ident.as_str(),
                 };
                 ModelStage1::new(&scope, ms0)
@@ -235,7 +237,10 @@ impl Project {
             models,
             model_order: ordered_models,
             errors: project_errors,
-            dimensions_ctx: dims_ctx,
+            // Owned field: clone the cached project-global context (the
+            // interned-backed dimensions clone cheaply; only the
+            // relationship-cache memo is rebuilt cold).
+            dimensions_ctx: (*dims_ctx).clone(),
         }
     }
 }


### PR DESCRIPTION
Profiled and optimized the salsa-based compilation path using the C-LEARN v77 model (1.4 MB, ~53k lines, 934 datamodel vars, 5215 slots) as the stress test. Compilation -- not parsing or simulation -- dominated cold-compile time, almost entirely from redundant work and allocation churn (~53% of CPU was in malloc/free/memcpy at the start).

## Overall difference

| Metric | Before | After | Change |
|---|---|---|---|
| Compile time (salsa) | 2539 ms | 579 ms | **4.4x faster (-77%)** |
| Allocations | 51.6 M | 9.1 M | **-82%** |
| Bytes churned | 6087 MiB | 869 MiB | **-86%** |

Compiled output is byte-identical at every step: `n_slots` stays 5215, and the heavy `simulates_clearn` / `simulates_clearn_wasm` oracles match `Ref.vdf` (within the 1% matched-floor gate) under both the VM and the wasm backend throughout.

## What changed (per commit)

| Commit | Optimization | Compile | Allocs |
|---|---|---|---|
| `765d4e01` | cache module-ident context in the implicit-var compile path | 2539 -> 1009 ms | 51.6 -> 22.8 M |
| `8bd91532` | intern canonicalized identifiers (dedup, refcounted handles) | 1009 -> 924 ms | 22.8 -> 15.7 M |
| `3524a440` | cache the project dimension context per project (salsa query) | 924 -> 706 ms | 15.7 -> 11.2 M |
| `ccaa4546` | intern the model dependency-graph maps (+ FxHash) | 706 -> 694 ms | 11.2 -> 10.9 M |
| `e40be662` | use FxHash for the identifier interner | 694 -> 653 ms | (flat) |
| `c0d654df` | route the last implicit-var module-ident lookups through the cache | 653 -> 579 ms | 10.9 -> 9.1 M |

Plus `b61b5184`, a small doc fix: the prior "remove stale implementation plans" commit left a dangling `docs/test-plans/` link that was failing the documentation-link pre-commit check on every commit.

### Notes on the approach
- The biggest wins came from eliminating redundant re-derivation: the implicit-variable compile path was reconstructing every datamodel variable and re-parsing every equation on each of hundreds of synthesized helper variables (commits 1 and 6), and the project dimension context was being rebuilt per variable (commit 3).
- Interning canonical identifiers (commit 2) makes clones cheap refcount bumps and is a long-wanted change; a hand-rolled, std-only, non-leaking sharded interner is used rather than a crate, to keep the wasm build free of a `getrandom` transitive dependency.
- The dep-graph map interning (commit 4) is a smaller win on this model (its hot cost is irreducible parse/classify work, and C-LEARN's graph isn't dense), but it is a correct structural improvement that helps more on denser graphs. Re-profiling after it landed is what surfaced the larger remaining levers (commits 5 and 6).
- Two `#[salsa::Update]` impls could not be derived (a Mutex-bearing `DimensionsContext`, and the interned identifier handle), so each has a single targeted `unsafe impl` behind `#[allow(unsafe_code)]` in an otherwise `#![deny(unsafe_code)]` crate.

## Verification
Each commit passed the full pre-commit suite (Rust fmt/clippy/test, TS lint/build/tsc/test, Python). The behavior oracle for the whole series is `cargo test -p simlin-engine --release --features file_io --test simulate -- --ignored simulates_clearn simulates_clearn_wasm`.

## Remaining
The remaining ~579 ms is increasingly genuine work (parse, AST lowering, array expansion, bytecode emit -- all salsa-cached per variable). The clearest next lever is the allocator: a large fraction of compile is still glibc malloc, and the engine (correctly) does not set a global allocator, so mimalloc on the compile host (the CLI already uses it) would help broadly without touching engine code.