### PR TITLE
engine: orthogonal flows, compactness, and loop legibility in auto-layout

### DIFF
--- a/src/simlin-engine/examples/layout_eval.rs
+++ b/src/simlin-engine/examples/layout_eval.rs
@@ -816,6 +816,7 @@ fn write_metrics_table(html: &mut String, render: &RenderReport) {
         ("aspect_penalty", m.aspect_penalty),
         ("chain_straightness", m.chain_straightness),
         ("loop_compactness", m.loop_compactness),
+        ("flow_bends", m.flow_bends),
     ];
     html.push_str("<table class=\"metrics\">");
     for (name, value) in rows {
@@ -996,6 +997,7 @@ fn render_index_html(report: &EvalReport) -> String {
         ("aspect_penalty", w.aspect_penalty),
         ("chain_straightness", w.chain_straightness),
         ("loop_compactness", w.loop_compactness),
+        ("flow_bends", w.flow_bends),
     ];
     html.push_str("<table class=\"weights\"><caption>weights</caption>");
     for (name, value) in weight_rows {

--- a/src/simlin-engine/examples/layout_eval.rs
+++ b/src/simlin-engine/examples/layout_eval.rs
@@ -817,6 +817,7 @@ fn write_metrics_table(html: &mut String, render: &RenderReport) {
         ("chain_straightness", m.chain_straightness),
         ("loop_compactness", m.loop_compactness),
         ("flow_bends", m.flow_bends),
+        ("loop_straightness", m.loop_straightness),
     ];
     html.push_str("<table class=\"metrics\">");
     for (name, value) in rows {
@@ -998,6 +999,7 @@ fn render_index_html(report: &EvalReport) -> String {
         ("chain_straightness", w.chain_straightness),
         ("loop_compactness", w.loop_compactness),
         ("flow_bends", w.flow_bends),
+        ("loop_straightness", w.loop_straightness),
     ];
     html.push_str("<table class=\"weights\"><caption>weights</caption>");
     for (name, value) in weight_rows {

--- a/src/simlin-engine/examples/layout_eval_baseline.json
+++ b/src/simlin-engine/examples/layout_eval_baseline.json
@@ -10,13 +10,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.7917411964189063,
-            "edge_length_cv": 0.26271728598231836,
-            "aspect_penalty": 0.11976320582877964,
+            "sprawl": 0.7932025869461911,
+            "edge_length_cv": 0.2610911829947331,
+            "aspect_penalty": 0.13544536271809005,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.11819146068235306
+          "weighted_cost": 0.19765785842970066
         },
         {
           "seed": 1,
@@ -25,13 +27,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.7917411964189063,
-            "edge_length_cv": 0.26271728598231836,
-            "aspect_penalty": 0.11976320582877964,
+            "sprawl": 0.7932025869461911,
+            "edge_length_cv": 0.2610911829947331,
+            "aspect_penalty": 0.13544536271809005,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.11819146068235306
+          "weighted_cost": 0.19765785842970066
         },
         {
           "seed": 2,
@@ -40,13 +44,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.7917411964189063,
-            "edge_length_cv": 0.26271728598231836,
-            "aspect_penalty": 0.11976320582877964,
+            "sprawl": 0.7932025869461911,
+            "edge_length_cv": 0.2610911829947331,
+            "aspect_penalty": 0.13544536271809005,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.11819146068235306
+          "weighted_cost": 0.19765785842970066
         },
         {
           "seed": 3,
@@ -55,13 +61,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.7917411964189063,
-            "edge_length_cv": 0.26271728598231836,
-            "aspect_penalty": 0.11976320582877964,
+            "sprawl": 0.7932025869461911,
+            "edge_length_cv": 0.2610911829947331,
+            "aspect_penalty": 0.13544536271809005,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.11819146068235306
+          "weighted_cost": 0.19765785842970066
         },
         {
           "seed": 4,
@@ -70,13 +78,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.7917411964189063,
-            "edge_length_cv": 0.26271728598231836,
-            "aspect_penalty": 0.11976320582877964,
+            "sprawl": 0.7932025869461911,
+            "edge_length_cv": 0.2610911829947331,
+            "aspect_penalty": 0.13544536271809005,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.11819146068235306
+          "weighted_cost": 0.19765785842970066
         },
         {
           "seed": 5,
@@ -85,13 +95,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.7917411964189063,
-            "edge_length_cv": 0.26271728598231836,
-            "aspect_penalty": 0.11976320582877964,
+            "sprawl": 0.7932025869461911,
+            "edge_length_cv": 0.2610911829947331,
+            "aspect_penalty": 0.13544536271809005,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.11819146068235306
+          "weighted_cost": 0.19765785842970066
         },
         {
           "seed": 6,
@@ -100,13 +112,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.7917411964189063,
-            "edge_length_cv": 0.26271728598231836,
-            "aspect_penalty": 0.11976320582877964,
+            "sprawl": 0.7932025869461911,
+            "edge_length_cv": 0.2610911829947331,
+            "aspect_penalty": 0.13544536271809005,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.11819146068235306
+          "weighted_cost": 0.19765785842970066
         },
         {
           "seed": 7,
@@ -115,13 +129,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.7917411964189063,
-            "edge_length_cv": 0.26271728598231836,
-            "aspect_penalty": 0.11976320582877964,
+            "sprawl": 0.7932025869461911,
+            "edge_length_cv": 0.2610911829947331,
+            "aspect_penalty": 0.13544536271809005,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.11819146068235306
+          "weighted_cost": 0.19765785842970066
         },
         {
           "seed": 42,
@@ -130,13 +146,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.7917411964189063,
-            "edge_length_cv": 0.26271728598231836,
-            "aspect_penalty": 0.11976320582877964,
+            "sprawl": 0.7932025869461911,
+            "edge_length_cv": 0.2610911829947331,
+            "aspect_penalty": 0.13544536271809005,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.11819146068235306
+          "weighted_cost": 0.19765785842970066
         },
         {
           "seed": 123,
@@ -145,13 +163,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.7917411964189063,
-            "edge_length_cv": 0.26271728598231836,
-            "aspect_penalty": 0.11976320582877964,
+            "sprawl": 0.7932025869461911,
+            "edge_length_cv": 0.2610911829947331,
+            "aspect_penalty": 0.13544536271809005,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.11819146068235306
+          "weighted_cost": 0.19765785842970066
         },
         {
           "seed": 456,
@@ -160,13 +180,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.7917411964189063,
-            "edge_length_cv": 0.26271728598231836,
-            "aspect_penalty": 0.11976320582877964,
+            "sprawl": 0.7932025869461911,
+            "edge_length_cv": 0.2610911829947331,
+            "aspect_penalty": 0.13544536271809005,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.11819146068235306
+          "weighted_cost": 0.19765785842970066
         },
         {
           "seed": 789,
@@ -175,21 +197,23 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.7917411964189063,
-            "edge_length_cv": 0.26271728598231836,
-            "aspect_penalty": 0.11976320582877964,
+            "sprawl": 0.7932025869461911,
+            "edge_length_cv": 0.2610911829947331,
+            "aspect_penalty": 0.13544536271809005,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.11819146068235306
+          "weighted_cost": 0.19765785842970066
         }
       ],
-      "median_cost": 0.11819146068235306,
+      "median_cost": 0.19765785842970066,
       "spread": [
-        0.11819146068235306,
-        0.11819146068235306
+        0.19765785842970066,
+        0.19765785842970066
       ],
-      "best_of_k_cost": 0.11819146068235306,
+      "best_of_k_cost": 0.19765785842970066,
       "best_seed": 0,
       "median_seed": 0,
       "worst_seed": 0
@@ -204,28 +228,32 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.9793576684363742,
-            "edge_length_cv": 0.4442977178909008,
-            "aspect_penalty": 0.03205128205128216,
+            "sprawl": 0.8836152259425175,
+            "edge_length_cv": 0.37369814882506985,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.09793576684363742
+          "weighted_cost": 0.1767230451885035
         },
         {
           "seed": 1,
           "metrics": {
             "node_overlap": 0.0,
-            "node_connector_overlap": 0.03295297255908847,
+            "node_connector_overlap": 0.033944624958484985,
             "label_overlap": 0.0,
             "crossings": 0.2222222222222222,
-            "sprawl": 0.6297931109414153,
-            "edge_length_cv": 0.5454105601279405,
-            "aspect_penalty": 2.9184496992031947,
+            "sprawl": 0.6209866914411803,
+            "edge_length_cv": 0.5730547821116815,
+            "aspect_penalty": 2.5436507936507935,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.31815450587545224
+          "weighted_cost": 0.3803641854689433
         },
         {
           "seed": 2,
@@ -234,28 +262,32 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.7631538905963535,
-            "edge_length_cv": 0.2930968896869597,
-            "aspect_penalty": 2.290142754401291,
+            "sprawl": 0.760183886538782,
+            "edge_length_cv": 0.2921899080548419,
+            "aspect_penalty": 1.3826699834162524,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.07631538905963536
+          "weighted_cost": 0.15203677730775642
         },
         {
           "seed": 3,
           "metrics": {
             "node_overlap": 0.0,
-            "node_connector_overlap": 0.057296160280803206,
+            "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.8986969888901886,
-            "edge_length_cv": 0.28391014115875635,
-            "aspect_penalty": 1.3909126891141987,
+            "sprawl": 0.8620670400074891,
+            "edge_length_cv": 0.29840579737450973,
+            "aspect_penalty": 1.1242090651822654,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.14716585916982206
+          "weighted_cost": 0.17241340800149785
         },
         {
           "seed": 4,
@@ -264,28 +296,32 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.2222222222222222,
-            "sprawl": 0.8382496386251012,
-            "edge_length_cv": 0.20625322925514133,
-            "aspect_penalty": 2.2653309208440984,
+            "sprawl": 0.8419573080245638,
+            "edge_length_cv": 0.2070469549586528,
+            "aspect_penalty": 1.2046165884194053,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.30604718608473236
+          "weighted_cost": 0.390613683827135
         },
         {
           "seed": 5,
           "metrics": {
             "node_overlap": 0.0,
-            "node_connector_overlap": 0.009412141626149916,
+            "node_connector_overlap": 0.009298152814814695,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.9071685971682938,
-            "edge_length_cv": 0.3956468955674967,
+            "sprawl": 0.9463824608199494,
+            "edge_length_cv": 0.356464037268458,
             "aspect_penalty": 0.6148775894538607,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.1001290013429793
+          "weighted_cost": 0.1985746449788046
         },
         {
           "seed": 6,
@@ -294,13 +330,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.8485849489244103,
-            "edge_length_cv": 0.28440867905624906,
-            "aspect_penalty": 0.3650793650793651,
+            "sprawl": 0.8821366289829145,
+            "edge_length_cv": 0.3078393138268285,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.08485849489244103
+          "weighted_cost": 0.1764273257965829
         },
         {
           "seed": 7,
@@ -309,43 +347,49 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.9559544260969809,
-            "edge_length_cv": 0.15626686553122665,
-            "aspect_penalty": 0.1381074727642806,
+            "sprawl": 0.9629366509286451,
+            "edge_length_cv": 0.16736351313364584,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.0955954426096981
+          "weighted_cost": 0.19258733018572904
         },
         {
           "seed": 42,
           "metrics": {
             "node_overlap": 0.0,
-            "node_connector_overlap": 0.020510702309047668,
+            "node_connector_overlap": 0.0034061861475130606,
             "label_overlap": 0.0,
             "crossings": 0.1111111111111111,
-            "sprawl": 0.654678203753486,
-            "edge_length_cv": 0.4745209511928338,
-            "aspect_penalty": 2.4613620042338704,
+            "sprawl": 0.6712318321999149,
+            "edge_length_cv": 0.46807026723224493,
+            "aspect_penalty": 1.81120527306968,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.19708963379550737
+          "weighted_cost": 0.24876366369860714
         },
         {
           "seed": 123,
           "metrics": {
             "node_overlap": 0.0,
-            "node_connector_overlap": 0.0269234399656284,
+            "node_connector_overlap": 0.01952424960676582,
             "label_overlap": 0.0,
-            "crossings": 0.1111111111111111,
-            "sprawl": 1.2784064934041004,
-            "edge_length_cv": 0.3446754360828329,
-            "aspect_penalty": 0.08203318544183658,
+            "crossings": 0.0,
+            "sprawl": 1.0385011725559112,
+            "edge_length_cv": 0.42562431304846177,
+            "aspect_penalty": 0.252476506004256,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2658752004171495
+          "weighted_cost": 0.22722448411794807
         },
         {
           "seed": 456,
@@ -354,39 +398,43 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 0.9770110095126119,
-            "edge_length_cv": 0.3687223741354589,
+            "sprawl": 0.9963435841418137,
+            "edge_length_cv": 0.4106297937365929,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.0977011009512612
+          "weighted_cost": 0.19926871682836275
         },
         {
           "seed": 789,
           "metrics": {
             "node_overlap": 0.0,
-            "node_connector_overlap": 0.022047957508946416,
+            "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.2347387607184244,
-            "edge_length_cv": 0.5473909792947921,
-            "aspect_penalty": 1.019793969265288,
+            "sprawl": 1.397541275395428,
+            "edge_length_cv": 0.6092927845061417,
+            "aspect_penalty": 0.16173620863749694,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.14552183358078885
+          "weighted_cost": 0.2795082550790856
         }
       ],
-      "median_cost": 0.12282541746188408,
+      "median_cost": 0.19892168090358367,
       "spread": [
-        0.09717468636587043,
-        0.2142860254509179
+        0.17664911534052335,
+        0.25644981154372676
       ],
-      "best_of_k_cost": 0.0977011009512612,
+      "best_of_k_cost": 0.19926871682836275,
       "best_seed": 2,
       "median_seed": 5,
-      "worst_seed": 1
+      "worst_seed": 4
     },
     {
       "model": "logistic_growth",
@@ -398,13 +446,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.0695290083991442,
+            "edge_length_cv": 0.17217974049680632,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.31744430207475827,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.2704593035495808
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.4016794528646902
         },
         {
           "seed": 1,
@@ -413,13 +463,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.0395652790471699,
+            "edge_length_cv": 0.09779512391099372,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.24567843839715708,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.25920663156109086
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.3658550943244059
         },
         {
           "seed": 2,
@@ -428,13 +480,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.1092486763864682,
+            "edge_length_cv": 0.2048318622612551,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.34827343583463755,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.28998100631839646
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.42390721024298833
         },
         {
           "seed": 3,
@@ -443,13 +497,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.2132131759638447,
+            "edge_length_cv": 0.2376883029323176,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.29443278938398476,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.28968087957424843
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.4231338389037877
         },
         {
           "seed": 4,
@@ -458,13 +514,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.0808038959563016,
+            "edge_length_cv": 0.2746507084970142,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.3012663960181087,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.26422946609706655
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.3968402842082105
         },
         {
           "seed": 5,
@@ -472,14 +530,16 @@
             "node_overlap": 0.03375,
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
-            "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "crossings": 0.14285714285714285,
+            "sprawl": 1.1935142282151967,
+            "edge_length_cv": 0.3279090325353458,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.6135303257902378,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.292909775195911
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.6900130963358684
         },
         {
           "seed": 6,
@@ -488,13 +548,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.207703269013744,
+            "edge_length_cv": 0.13999832182315233,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.3935464903662237,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.29753287145471186
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.4624625370947095
         },
         {
           "seed": 7,
@@ -503,13 +565,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.2206273000422716,
+            "edge_length_cv": 0.1631996331385811,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.2873942369624405,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.28677457779580046
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.42151061257301053
         },
         {
           "seed": 42,
@@ -518,28 +582,32 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.0977413618095229,
+            "edge_length_cv": 0.1935296097191283,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.35644245450619727,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.2596785934540375
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.42184311350978726
         },
         {
           "seed": 123,
           "metrics": {
-            "node_overlap": 0.03375,
+            "node_overlap": 0.033750000000000016,
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.165857662264709,
+            "edge_length_cv": 0.15792800546333421,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.35449169623420484,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.2780848549440337
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.4365266964410271
         },
         {
           "seed": 456,
@@ -548,13 +616,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.001103334507119,
+            "edge_length_cv": 0.19498350334051162,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.5224671471393787,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.21077167161141264
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.46403469291831656
         },
         {
           "seed": 789,
@@ -563,24 +633,26 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.009579521376098,
+            "edge_length_cv": 0.26640944699663793,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.32260826169216406,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.24558496226773144
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.3892677051788584
         }
       ],
-      "median_cost": 0.2491551836532827,
+      "median_cost": 0.4224884762067875,
       "spread": [
-        0.2491551836532827,
-        0.2491551836532827
+        0.4004696607005702,
+        0.4430106566044477
       ],
-      "best_of_k_cost": 0.2491551836532827,
-      "best_seed": 0,
-      "median_seed": 0,
-      "worst_seed": 0
+      "best_of_k_cost": 0.3892677051788584,
+      "best_seed": 1,
+      "median_seed": 3,
+      "worst_seed": 5
     },
     {
       "model": "fishbanks",
@@ -588,192 +660,216 @@
         {
           "seed": 0,
           "metrics": {
-            "node_overlap": 0.03476394849785409,
-            "node_connector_overlap": 0.0005859275291945574,
-            "label_overlap": 0.032036725067385155,
-            "crossings": 0.0,
-            "sprawl": 1.739649566476268,
-            "edge_length_cv": 0.3332041062311589,
+            "node_overlap": 0.03476394849785408,
+            "node_connector_overlap": 0.08568423033828318,
+            "label_overlap": 0.04110504804875194,
+            "crossings": 0.3333333333333333,
+            "sprawl": 1.6143573398683797,
+            "edge_length_cv": 0.43495266699420937,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3107995770740052
+            "loop_compactness": 0.8452303428015734,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.4630819207904695
           },
-          "weighted_cost": 0.31905145201056184
+          "weighted_cost": 1.2021583573915746
         },
         {
           "seed": 1,
           "metrics": {
-            "node_overlap": 0.03476394849785409,
-            "node_connector_overlap": 0.0005859275291945574,
-            "label_overlap": 0.032036725067385155,
-            "crossings": 0.0,
-            "sprawl": 1.739649566476268,
-            "edge_length_cv": 0.3332041062311589,
+            "node_overlap": 0.03476394849785408,
+            "node_connector_overlap": 0.006962267313529018,
+            "label_overlap": 0.04110504804875194,
+            "crossings": 0.13333333333333333,
+            "sprawl": 1.3590826636926427,
+            "edge_length_cv": 0.3431770636033404,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3107995770740052
+            "loop_compactness": 0.8598427576691204,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.39076126579718773
           },
-          "weighted_cost": 0.31905145201056184
+          "weighted_cost": 0.8709943595793639
         },
         {
           "seed": 2,
           "metrics": {
-            "node_overlap": 0.03476394849785409,
-            "node_connector_overlap": 0.0005859275291945574,
-            "label_overlap": 0.032036725067385155,
-            "crossings": 0.0,
-            "sprawl": 1.739649566476268,
-            "edge_length_cv": 0.3332041062311589,
+            "node_overlap": 0.034763948497854066,
+            "node_connector_overlap": 0.006884632504338363,
+            "label_overlap": 0.04110504804875194,
+            "crossings": 0.06666666666666667,
+            "sprawl": 1.4104035925158442,
+            "edge_length_cv": 0.39531305968667735,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3107995770740052
+            "loop_compactness": 0.6736648685514584,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.43350788146500446
           },
-          "weighted_cost": 0.31905145201056184
+          "weighted_cost": 0.7443177497878637
         },
         {
           "seed": 3,
           "metrics": {
-            "node_overlap": 0.03476394849785409,
-            "node_connector_overlap": 0.0005859275291945574,
-            "label_overlap": 0.032036725067385155,
-            "crossings": 0.0,
-            "sprawl": 1.739649566476268,
-            "edge_length_cv": 0.3332041062311589,
+            "node_overlap": 0.03476394849785408,
+            "node_connector_overlap": 0.005547168048489169,
+            "label_overlap": 0.04110504804875194,
+            "crossings": 0.13333333333333333,
+            "sprawl": 1.6164780320802155,
+            "edge_length_cv": 0.6184917294273167,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3107995770740052
+            "loop_compactness": 0.38449846215069705,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.3205882211495155
           },
-          "weighted_cost": 0.31905145201056184
+          "weighted_cost": 0.723903311319702
         },
         {
           "seed": 4,
           "metrics": {
-            "node_overlap": 0.03476394849785409,
-            "node_connector_overlap": 0.0005859275291945574,
-            "label_overlap": 0.032036725067385155,
-            "crossings": 0.0,
-            "sprawl": 1.739649566476268,
-            "edge_length_cv": 0.3332041062311589,
+            "node_overlap": 0.03476394849785408,
+            "node_connector_overlap": 0.006962267313529018,
+            "label_overlap": 0.04110504804875194,
+            "crossings": 0.13333333333333333,
+            "sprawl": 1.3590826636926427,
+            "edge_length_cv": 0.3431770636033404,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3107995770740052
+            "loop_compactness": 0.8598427576691204,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.39076126579718773
           },
-          "weighted_cost": 0.31905145201056184
+          "weighted_cost": 0.8709943595793639
         },
         {
           "seed": 5,
           "metrics": {
-            "node_overlap": 0.03476394849785409,
-            "node_connector_overlap": 0.0005859275291945574,
-            "label_overlap": 0.032036725067385155,
-            "crossings": 0.0,
-            "sprawl": 1.739649566476268,
-            "edge_length_cv": 0.3332041062311589,
+            "node_overlap": 0.03476394849785408,
+            "node_connector_overlap": 0.0,
+            "label_overlap": 0.04110504804875194,
+            "crossings": 0.13333333333333333,
+            "sprawl": 1.3246103376847838,
+            "edge_length_cv": 0.42943805128756574,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3107995770740052
+            "loop_compactness": 0.3594978082239031,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6666666666666666
           },
-          "weighted_cost": 0.31905145201056184
+          "weighted_cost": 0.6845901873731239
         },
         {
           "seed": 6,
           "metrics": {
-            "node_overlap": 0.03476394849785409,
-            "node_connector_overlap": 0.0005859275291945574,
-            "label_overlap": 0.032036725067385155,
-            "crossings": 0.0,
-            "sprawl": 1.739649566476268,
-            "edge_length_cv": 0.3332041062311589,
+            "node_overlap": 0.03476394849785408,
+            "node_connector_overlap": 0.02102888590378746,
+            "label_overlap": 0.04110504804875208,
+            "crossings": 0.2,
+            "sprawl": 1.6575940164596439,
+            "edge_length_cv": 0.5031401402309018,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3107995770740052
+            "loop_compactness": 0.6493083733978511,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.3081093890430895
           },
-          "weighted_cost": 0.31905145201056184
+          "weighted_cost": 0.9189509740057717
         },
         {
           "seed": 7,
           "metrics": {
-            "node_overlap": 0.03476394849785409,
-            "node_connector_overlap": 0.0005859275291945574,
-            "label_overlap": 0.032036725067385155,
-            "crossings": 0.0,
-            "sprawl": 1.739649566476268,
-            "edge_length_cv": 0.3332041062311589,
+            "node_overlap": 0.03476394849785408,
+            "node_connector_overlap": 0.01586118306043599,
+            "label_overlap": 0.04110504804875194,
+            "crossings": 0.06666666666666667,
+            "sprawl": 1.5989740024432533,
+            "edge_length_cv": 0.45338724107118894,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3107995770740052
+            "loop_compactness": 0.5775948806524611,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.36560054449676893
           },
-          "weighted_cost": 0.31905145201056184
+          "weighted_cost": 0.7457896534730207
         },
         {
           "seed": 42,
           "metrics": {
-            "node_overlap": 0.03476394849785409,
-            "node_connector_overlap": 0.0005859275291945574,
-            "label_overlap": 0.032036725067385155,
-            "crossings": 0.0,
-            "sprawl": 1.739649566476268,
-            "edge_length_cv": 0.3332041062311589,
+            "node_overlap": 0.03476394849785408,
+            "node_connector_overlap": 0.01896177280711285,
+            "label_overlap": 0.04110504804875194,
+            "crossings": 0.13333333333333333,
+            "sprawl": 1.4147746629675255,
+            "edge_length_cv": 0.3704016124212521,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3107995770740052
+            "loop_compactness": 0.7149476673872288,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.4478158538908568
           },
-          "weighted_cost": 0.31905145201056184
+          "weighted_cost": 0.8418796876245346
         },
         {
           "seed": 123,
           "metrics": {
-            "node_overlap": 0.03476394849785409,
-            "node_connector_overlap": 0.0005859275291945574,
-            "label_overlap": 0.032036725067385155,
-            "crossings": 0.0,
-            "sprawl": 1.739649566476268,
-            "edge_length_cv": 0.3332041062311589,
+            "node_overlap": 0.03476394849785408,
+            "node_connector_overlap": 0.015398834072719523,
+            "label_overlap": 0.04110504804875194,
+            "crossings": 0.06666666666666667,
+            "sprawl": 1.5967429369599595,
+            "edge_length_cv": 0.5159877166443811,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3107995770740052
+            "loop_compactness": 0.8652906278835424,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.3184356721684644
           },
-          "weighted_cost": 0.31905145201056184
+          "weighted_cost": 0.8552429030482476
         },
         {
           "seed": 456,
           "metrics": {
-            "node_overlap": 0.03476394849785409,
-            "node_connector_overlap": 0.0005859275291945574,
-            "label_overlap": 0.032036725067385155,
-            "crossings": 0.0,
-            "sprawl": 1.739649566476268,
-            "edge_length_cv": 0.3332041062311589,
+            "node_overlap": 0.03476394849785408,
+            "node_connector_overlap": 0.006962267313529018,
+            "label_overlap": 0.04110504804875194,
+            "crossings": 0.13333333333333333,
+            "sprawl": 1.3590826636926427,
+            "edge_length_cv": 0.3431770636033404,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3107995770740052
+            "loop_compactness": 0.8598427576691204,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.39076126579718773
           },
-          "weighted_cost": 0.31905145201056184
+          "weighted_cost": 0.8709943595793639
         },
         {
           "seed": 789,
           "metrics": {
-            "node_overlap": 0.03476394849785409,
-            "node_connector_overlap": 0.0005859275291945574,
-            "label_overlap": 0.032036725067385155,
-            "crossings": 0.0,
-            "sprawl": 1.739649566476268,
-            "edge_length_cv": 0.3332041062311589,
+            "node_overlap": 0.03476394849785408,
+            "node_connector_overlap": 0.011711803570043349,
+            "label_overlap": 0.04110504804875194,
+            "crossings": 0.2,
+            "sprawl": 1.6603987448123414,
+            "edge_length_cv": 0.4317694697031315,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3107995770740052
+            "loop_compactness": 0.7334237377417374,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.2477220589807632
           },
-          "weighted_cost": 0.31905145201056184
+          "weighted_cost": 0.9378022500738888
         }
       ],
-      "median_cost": 0.31905145201056184,
+      "median_cost": 0.8631186313138057,
       "spread": [
-        0.31905145201056184,
-        0.31905145201056184
+        0.7454216775517315,
+        0.8829835131859658
       ],
-      "best_of_k_cost": 0.31905145201056184,
-      "best_seed": 0,
-      "median_seed": 0,
+      "best_of_k_cost": 0.8418796876245346,
+      "best_seed": 5,
+      "median_seed": 1,
       "worst_seed": 0
     },
     {
@@ -786,13 +882,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.0695290083991442,
+            "edge_length_cv": 0.17217974049680632,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.31744430207475827,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.2704593035495808
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.4016794528646902
         },
         {
           "seed": 1,
@@ -801,13 +899,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.0395652790471699,
+            "edge_length_cv": 0.09779512391099372,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.24567843839715708,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.25920663156109086
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.3658550943244059
         },
         {
           "seed": 2,
@@ -816,13 +916,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.1092486763864682,
+            "edge_length_cv": 0.2048318622612551,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.34827343583463755,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.28998100631839646
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.42390721024298833
         },
         {
           "seed": 3,
@@ -831,13 +933,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.2132131759638447,
+            "edge_length_cv": 0.2376883029323176,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.29443278938398476,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.28968087957424843
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.4231338389037877
         },
         {
           "seed": 4,
@@ -846,13 +950,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.0808038959563016,
+            "edge_length_cv": 0.2746507084970142,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.3012663960181087,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.26422946609706655
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.3968402842082105
         },
         {
           "seed": 5,
@@ -860,14 +966,16 @@
             "node_overlap": 0.03375,
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
-            "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "crossings": 0.14285714285714285,
+            "sprawl": 1.1935142282151967,
+            "edge_length_cv": 0.3279090325353458,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.6135303257902378,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.292909775195911
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.6900130963358684
         },
         {
           "seed": 6,
@@ -876,13 +984,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.207703269013744,
+            "edge_length_cv": 0.13999832182315233,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.3935464903662237,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.29753287145471186
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.4624625370947095
         },
         {
           "seed": 7,
@@ -891,13 +1001,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.2206273000422716,
+            "edge_length_cv": 0.1631996331385811,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.2873942369624405,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.28677457779580046
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.42151061257301053
         },
         {
           "seed": 42,
@@ -906,28 +1018,32 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.0977413618095229,
+            "edge_length_cv": 0.1935296097191283,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.35644245450619727,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.2596785934540375
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.42184311350978726
         },
         {
           "seed": 123,
           "metrics": {
-            "node_overlap": 0.03375,
+            "node_overlap": 0.033750000000000016,
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.165857662264709,
+            "edge_length_cv": 0.15792800546333421,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.35449169623420484,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.2780848549440337
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.4365266964410271
         },
         {
           "seed": 456,
@@ -936,13 +1052,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.001103334507119,
+            "edge_length_cv": 0.19498350334051162,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.5224671471393787,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.21077167161141264
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.46403469291831656
         },
         {
           "seed": 789,
@@ -951,24 +1069,26 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3540314284648383,
-            "edge_length_cv": 0.19849482736033042,
+            "sprawl": 1.009579521376098,
+            "edge_length_cv": 0.26640944699663793,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.3200081632271955
+            "loop_compactness": 0.32260826169216406,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.24558496226773144
           },
-          "weighted_cost": 0.2491551836532827
+          "weighted_cost": 0.3892677051788584
         }
       ],
-      "median_cost": 0.2491551836532827,
+      "median_cost": 0.4224884762067875,
       "spread": [
-        0.2491551836532827,
-        0.2491551836532827
+        0.4004696607005702,
+        0.4430106566044477
       ],
-      "best_of_k_cost": 0.2491551836532827,
-      "best_seed": 0,
-      "median_seed": 0,
-      "worst_seed": 0
+      "best_of_k_cost": 0.3892677051788584,
+      "best_seed": 1,
+      "median_seed": 3,
+      "worst_seed": 5
     },
     {
       "model": "population",
@@ -980,13 +1100,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.4699864668640177,
-            "edge_length_cv": 0.24246362236311722,
-            "aspect_penalty": 1.200884077834088,
+            "sprawl": 1.2408599625896033,
+            "edge_length_cv": 0.08831889638826458,
+            "aspect_penalty": 0.3978988546752582,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2002793570958739
+          "weighted_cost": 0.3014527029273928
         },
         {
           "seed": 1,
@@ -995,13 +1117,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.4699864668640177,
-            "edge_length_cv": 0.24246362236311722,
-            "aspect_penalty": 1.200884077834088,
+            "sprawl": 1.2408599625896033,
+            "edge_length_cv": 0.08831889638826458,
+            "aspect_penalty": 0.3978988546752582,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2002793570958739
+          "weighted_cost": 0.3014527029273928
         },
         {
           "seed": 2,
@@ -1010,13 +1134,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.4699864668640177,
-            "edge_length_cv": 0.24246362236311722,
-            "aspect_penalty": 1.200884077834088,
+            "sprawl": 1.2408599625896033,
+            "edge_length_cv": 0.08831889638826458,
+            "aspect_penalty": 0.3978988546752582,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2002793570958739
+          "weighted_cost": 0.3014527029273928
         },
         {
           "seed": 3,
@@ -1025,13 +1151,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.4699864668640177,
-            "edge_length_cv": 0.24246362236311722,
-            "aspect_penalty": 1.200884077834088,
+            "sprawl": 1.2408599625896033,
+            "edge_length_cv": 0.08831889638826458,
+            "aspect_penalty": 0.3978988546752582,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2002793570958739
+          "weighted_cost": 0.3014527029273928
         },
         {
           "seed": 4,
@@ -1040,13 +1168,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.4699864668640177,
-            "edge_length_cv": 0.24246362236311722,
-            "aspect_penalty": 1.200884077834088,
+            "sprawl": 1.2408599625896033,
+            "edge_length_cv": 0.08831889638826458,
+            "aspect_penalty": 0.3978988546752582,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2002793570958739
+          "weighted_cost": 0.3014527029273928
         },
         {
           "seed": 5,
@@ -1055,13 +1185,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.4699864668640177,
-            "edge_length_cv": 0.24246362236311722,
-            "aspect_penalty": 1.200884077834088,
+            "sprawl": 1.2408599625896033,
+            "edge_length_cv": 0.08831889638826458,
+            "aspect_penalty": 0.3978988546752582,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2002793570958739
+          "weighted_cost": 0.3014527029273928
         },
         {
           "seed": 6,
@@ -1070,13 +1202,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.4699864668640177,
-            "edge_length_cv": 0.24246362236311722,
-            "aspect_penalty": 1.200884077834088,
+            "sprawl": 1.2408599625896033,
+            "edge_length_cv": 0.08831889638826458,
+            "aspect_penalty": 0.3978988546752582,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2002793570958739
+          "weighted_cost": 0.3014527029273928
         },
         {
           "seed": 7,
@@ -1085,13 +1219,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.4699864668640177,
-            "edge_length_cv": 0.24246362236311722,
-            "aspect_penalty": 1.200884077834088,
+            "sprawl": 1.2408599625896033,
+            "edge_length_cv": 0.08831889638826458,
+            "aspect_penalty": 0.3978988546752582,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2002793570958739
+          "weighted_cost": 0.3014527029273928
         },
         {
           "seed": 42,
@@ -1100,13 +1236,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.4699864668640177,
-            "edge_length_cv": 0.24246362236311722,
-            "aspect_penalty": 1.200884077834088,
+            "sprawl": 1.2408599625896033,
+            "edge_length_cv": 0.08831889638826458,
+            "aspect_penalty": 0.3978988546752582,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2002793570958739
+          "weighted_cost": 0.3014527029273928
         },
         {
           "seed": 123,
@@ -1115,13 +1253,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.4699864668640177,
-            "edge_length_cv": 0.24246362236311722,
-            "aspect_penalty": 1.200884077834088,
+            "sprawl": 1.2408599625896033,
+            "edge_length_cv": 0.08831889638826458,
+            "aspect_penalty": 0.3978988546752582,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2002793570958739
+          "weighted_cost": 0.3014527029273928
         },
         {
           "seed": 456,
@@ -1130,13 +1270,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.4699864668640177,
-            "edge_length_cv": 0.24246362236311722,
-            "aspect_penalty": 1.200884077834088,
+            "sprawl": 1.2408599625896033,
+            "edge_length_cv": 0.08831889638826458,
+            "aspect_penalty": 0.3978988546752582,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2002793570958739
+          "weighted_cost": 0.3014527029273928
         },
         {
           "seed": 789,
@@ -1145,21 +1287,23 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.4699864668640177,
-            "edge_length_cv": 0.24246362236311722,
-            "aspect_penalty": 1.200884077834088,
+            "sprawl": 1.2408599625896033,
+            "edge_length_cv": 0.08831889638826458,
+            "aspect_penalty": 0.3978988546752582,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2002793570958739
+          "weighted_cost": 0.3014527029273928
         }
       ],
-      "median_cost": 0.2002793570958739,
+      "median_cost": 0.3014527029273928,
       "spread": [
-        0.2002793570958739,
-        0.2002793570958739
+        0.3014527029273928,
+        0.3014527029273928
       ],
-      "best_of_k_cost": 0.2002793570958739,
+      "best_of_k_cost": 0.3014527029273928,
       "best_seed": 0,
       "median_seed": 0,
       "worst_seed": 0
@@ -1170,193 +1314,217 @@
         {
           "seed": 0,
           "metrics": {
-            "node_overlap": 0.024763069397737765,
-            "node_connector_overlap": 0.002007894012473498,
+            "node_overlap": 0.024763069397737713,
+            "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.13043478260869565,
-            "sprawl": 1.5971835581946983,
-            "edge_length_cv": 0.3260103604292148,
+            "sprawl": 1.1948775873522024,
+            "edge_length_cv": 0.33861002145028124,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5013205389923634
+            "loop_compactness": 0.5853627724940595,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.33705916027673083
           },
-          "weighted_cost": 0.44225423658646756
+          "weighted_cost": 0.6620243945021708
         },
         {
           "seed": 1,
           "metrics": {
-            "node_overlap": 0.024763069397737696,
-            "node_connector_overlap": 0.0,
+            "node_overlap": 0.024763069397737713,
+            "node_connector_overlap": 0.0014414446307170312,
             "label_overlap": 0.0,
             "crossings": 0.08695652173913043,
-            "sprawl": 1.7517809312066512,
-            "edge_length_cv": 0.3518392922883832,
+            "sprawl": 1.3832868223999235,
+            "edge_length_cv": 0.37189676423713974,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.49908639046248926
+            "loop_compactness": 0.5200378462318094,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.31123117240504933
           },
-          "weighted_cost": 0.41166928187315555
+          "weighted_cost": 0.6289566559807986
         },
         {
           "seed": 2,
           "metrics": {
-            "node_overlap": 0.024763069397737765,
-            "node_connector_overlap": 0.002007894012473498,
+            "node_overlap": 0.011844697676119335,
+            "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.13043478260869565,
-            "sprawl": 1.5971835581946983,
-            "edge_length_cv": 0.3260103604292148,
+            "sprawl": 3.244912288623023,
+            "edge_length_cv": 0.2695427912851834,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5013205389923634
+            "loop_compactness": 0.6717892770164458,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.36178073107784336
           },
-          "weighted_cost": 0.44225423658646756
+          "weighted_cost": 1.096155721923782
         },
         {
           "seed": 3,
           "metrics": {
-            "node_overlap": 0.024763069397737765,
-            "node_connector_overlap": 0.002007894012473498,
+            "node_overlap": 0.024763069397737713,
+            "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.13043478260869565,
-            "sprawl": 1.5971835581946983,
-            "edge_length_cv": 0.3260103604292148,
+            "sprawl": 1.2638022287176784,
+            "edge_length_cv": 0.34166080818268335,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5013205389923634
+            "loop_compactness": 0.5849770287913719,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.37234476093767166
           },
-          "weighted_cost": 0.44225423658646756
+          "weighted_cost": 0.679183585360285
         },
         {
           "seed": 4,
           "metrics": {
-            "node_overlap": 0.024763069397737765,
-            "node_connector_overlap": 0.016902098920911757,
+            "node_overlap": 0.02476306939773773,
+            "node_connector_overlap": 0.01757739223256019,
             "label_overlap": 0.0,
-            "crossings": 0.13043478260869565,
-            "sprawl": 1.816059995802566,
-            "edge_length_cv": 0.4812143979587461,
+            "crossings": 0.17391304347826086,
+            "sprawl": 1.410765434804514,
+            "edge_length_cv": 0.46016881737394383,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5512985899831205
+            "loop_compactness": 0.6440847033872134,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.3182416417478747
           },
-          "weighted_cost": 0.49153059800338195
+          "weighted_cost": 0.7878646375991344
         },
         {
           "seed": 5,
           "metrics": {
-            "node_overlap": 0.024763069397737765,
-            "node_connector_overlap": 0.002007894012473498,
+            "node_overlap": 0.024763069397737713,
+            "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.13043478260869565,
-            "sprawl": 1.5971835581946983,
-            "edge_length_cv": 0.3260103604292148,
+            "sprawl": 1.1948775873522024,
+            "edge_length_cv": 0.33861002145028124,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5013205389923634
+            "loop_compactness": 0.5853627724940595,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.33705916027673083
           },
-          "weighted_cost": 0.44225423658646756
+          "weighted_cost": 0.6620243945021708
         },
         {
           "seed": 6,
           "metrics": {
-            "node_overlap": 0.024763069397737696,
-            "node_connector_overlap": 0.010886074926650046,
+            "node_overlap": 0.02476306939773773,
+            "node_connector_overlap": 0.009487406438905726,
             "label_overlap": 0.0,
-            "crossings": 0.08695652173913043,
-            "sprawl": 1.662289851182621,
-            "edge_length_cv": 0.39615327249160925,
-            "aspect_penalty": 0.0,
+            "crossings": 0.17391304347826086,
+            "sprawl": 1.3929498812353063,
+            "edge_length_cv": 0.49623777740045866,
+            "aspect_penalty": 0.004879319457522735,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5381168800822896
+            "loop_compactness": 0.6422994704752761,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.44404714253744454
           },
-          "weighted_cost": 0.42336387120235275
+          "weighted_cost": 0.7880779980058206
         },
         {
           "seed": 7,
           "metrics": {
-            "node_overlap": 0.024763069397737765,
-            "node_connector_overlap": 0.006362469163866689,
+            "node_overlap": 0.024763069397737713,
+            "node_connector_overlap": 0.007675591013226364,
             "label_overlap": 0.0,
-            "crossings": 0.08695652173913043,
-            "sprawl": 1.7582442695933749,
-            "edge_length_cv": 0.4691965377011812,
+            "crossings": 0.21739130434782608,
+            "sprawl": 1.3869543741108474,
+            "edge_length_cv": 0.40221938316813444,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6338648269635392
+            "loop_compactness": 0.6346648307435367,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.35645147611838324
           },
-          "weighted_cost": 0.4523726940009572
+          "weighted_cost": 0.8167319194902127
         },
         {
           "seed": 42,
           "metrics": {
-            "node_overlap": 0.024763069397737696,
-            "node_connector_overlap": 0.04326778598562912,
+            "node_overlap": 0.024763069397737713,
+            "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
-            "crossings": 0.21739130434782608,
-            "sprawl": 1.7284303454348817,
-            "edge_length_cv": 0.4903855791370296,
+            "crossings": 0.13043478260869565,
+            "sprawl": 1.1948775873522024,
+            "edge_length_cv": 0.33861002145028124,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6397419690463544
+            "loop_compactness": 0.5853627724940595,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.33705916027673083
           },
-          "weighted_cost": 0.6182006865362697
+          "weighted_cost": 0.6620243945021708
         },
         {
           "seed": 123,
           "metrics": {
-            "node_overlap": 0.024763069397737765,
-            "node_connector_overlap": 0.0019542348220739788,
+            "node_overlap": 0.024763069397737713,
+            "node_connector_overlap": 0.005377274496934227,
             "label_overlap": 0.0,
-            "crossings": 0.08695652173913043,
-            "sprawl": 1.641600968115911,
-            "edge_length_cv": 0.3927281212546181,
+            "crossings": 0.13043478260869565,
+            "sprawl": 1.2485781479016096,
+            "edge_length_cv": 0.46492254670069055,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.4987185104100216
+            "loop_compactness": 0.5334625826645447,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.35421195756431567
           },
-          "weighted_cost": 0.4025135503730387
+          "weighted_cost": 0.6590969849059389
         },
         {
           "seed": 456,
           "metrics": {
-            "node_overlap": 0.024763069397737765,
-            "node_connector_overlap": 0.002007894012473498,
+            "node_overlap": 0.024763069397737713,
+            "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.13043478260869565,
-            "sprawl": 1.5971835581946983,
-            "edge_length_cv": 0.3260103604292148,
+            "sprawl": 1.1948775873522024,
+            "edge_length_cv": 0.33861002145028124,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5013205389923634
+            "loop_compactness": 0.5853627724940595,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.33705916027673083
           },
-          "weighted_cost": 0.44225423658646756
+          "weighted_cost": 0.6620243945021708
         },
         {
           "seed": 789,
           "metrics": {
-            "node_overlap": 0.024763069397737765,
-            "node_connector_overlap": 0.002007894012473498,
+            "node_overlap": 0.024763069397737713,
+            "node_connector_overlap": 0.020534662882022013,
             "label_overlap": 0.0,
-            "crossings": 0.13043478260869565,
-            "sprawl": 1.5971835581946983,
-            "edge_length_cv": 0.3260103604292148,
+            "crossings": 0.17391304347826086,
+            "sprawl": 1.5255943560534784,
+            "edge_length_cv": 0.5612590549553415,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5013205389923634
+            "loop_compactness": 0.674276852188812,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.4116513268461032
           },
-          "weighted_cost": 0.44225423658646756
+          "weighted_cost": 0.8352055205288513
         }
       ],
-      "median_cost": 0.44225423658646756,
+      "median_cost": 0.6706039899312279,
       "spread": [
-        0.43753164524043886,
-        0.44478385094009
+        0.6620243945021708,
+        0.7952414783769186
       ],
-      "best_of_k_cost": 0.4025135503730387,
-      "best_seed": 123,
-      "median_seed": 0,
-      "worst_seed": 42
+      "best_of_k_cost": 0.6590969849059389,
+      "best_seed": 1,
+      "median_seed": 3,
+      "worst_seed": 2
     },
     {
       "model": "hares_and_foxes",
@@ -1368,13 +1536,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.0238761793440667,
-            "edge_length_cv": 0.218851833948224,
+            "sprawl": 1.228990217870891,
+            "edge_length_cv": 0.28606799997289617,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.10238761793440668
+          "weighted_cost": 0.2457980435741782
         },
         {
           "seed": 1,
@@ -1382,14 +1552,16 @@
             "node_overlap": 0.0,
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
-            "crossings": 0.25,
-            "sprawl": 1.319420017033598,
-            "edge_length_cv": 0.22556493661400984,
+            "crossings": 0.0,
+            "sprawl": 1.2218901467164682,
+            "edge_length_cv": 0.1961122230011898,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.3819420017033598
+          "weighted_cost": 0.24437802934329367
         },
         {
           "seed": 2,
@@ -1398,13 +1570,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.400887939957353,
-            "edge_length_cv": 0.22252043275843983,
-            "aspect_penalty": 0.0,
+            "sprawl": 1.1669861552324692,
+            "edge_length_cv": 0.24054977453011245,
+            "aspect_penalty": 0.1323078953140473,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.14008879399573532
+          "weighted_cost": 0.23339723104649385
         },
         {
           "seed": 3,
@@ -1413,13 +1587,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.0344115134034018,
-            "edge_length_cv": 0.1139275504683678,
+            "sprawl": 1.4385141963465509,
+            "edge_length_cv": 0.4452967243084567,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.10344115134034018
+          "weighted_cost": 0.2877028392693102
         },
         {
           "seed": 4,
@@ -1428,13 +1604,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3814535633999414,
-            "edge_length_cv": 0.4271292996040237,
-            "aspect_penalty": 0.0,
+            "sprawl": 1.9765182312183323,
+            "edge_length_cv": 0.41962997971172394,
+            "aspect_penalty": 0.06333039731030454,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.13814535633999414
+          "weighted_cost": 0.3953036462436665
         },
         {
           "seed": 5,
@@ -1442,29 +1620,33 @@
             "node_overlap": 0.0,
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
-            "crossings": 0.25,
-            "sprawl": 1.319420017033598,
-            "edge_length_cv": 0.22556493661400984,
+            "crossings": 0.0,
+            "sprawl": 1.19525981983137,
+            "edge_length_cv": 0.4896083755529902,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.3819420017033598
+          "weighted_cost": 0.239051963966274
         },
         {
           "seed": 6,
           "metrics": {
             "node_overlap": 0.0,
-            "node_connector_overlap": 0.03406066852816516,
+            "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.8097612570117823,
-            "edge_length_cv": 0.11475720862310707,
-            "aspect_penalty": 0.0,
+            "sprawl": 1.174037344705379,
+            "edge_length_cv": 0.3113074663188617,
+            "aspect_penalty": 0.3669957725717232,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.2150367942293434
+          "weighted_cost": 0.2348074689410758
         },
         {
           "seed": 7,
@@ -1472,14 +1654,16 @@
             "node_overlap": 0.0,
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
-            "crossings": 0.25,
-            "sprawl": 1.319420017033598,
-            "edge_length_cv": 0.22556493661400984,
+            "crossings": 0.0,
+            "sprawl": 0.9658275858003817,
+            "edge_length_cv": 0.3876784910946535,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.3819420017033598
+          "weighted_cost": 0.19316551716007635
         },
         {
           "seed": 42,
@@ -1488,69 +1672,77 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.8973489476791177,
-            "edge_length_cv": 0.33184828895099494,
-            "aspect_penalty": 0.0,
+            "sprawl": 1.1905681438631572,
+            "edge_length_cv": 0.1729579260593722,
+            "aspect_penalty": 0.31504279445043437,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.18973489476791178
+          "weighted_cost": 0.23811362877263145
         },
         {
           "seed": 123,
           "metrics": {
             "node_overlap": 0.0,
-            "node_connector_overlap": 0.0,
+            "node_connector_overlap": 0.05755964068162532,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.295897885602751,
-            "edge_length_cv": 0.2982144694140595,
+            "sprawl": 1.1539380074938739,
+            "edge_length_cv": 0.3783713713241633,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.12958978856027512
+          "weighted_cost": 0.2883472421804001
         },
         {
           "seed": 456,
           "metrics": {
             "node_overlap": 0.0,
-            "node_connector_overlap": 0.0,
+            "node_connector_overlap": 0.04348749323609555,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.1720693432543847,
-            "edge_length_cv": 0.31476389169707064,
+            "sprawl": 1.8026240922742207,
+            "edge_length_cv": 0.4208061767745891,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.11720693432543848
+          "weighted_cost": 0.40401231169093976
         },
         {
           "seed": 789,
           "metrics": {
             "node_overlap": 0.0,
-            "node_connector_overlap": 0.00833838751592645,
+            "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 2.151411886332582,
-            "edge_length_cv": 0.3101115661693288,
+            "sprawl": 1.0856519054096903,
+            "edge_length_cv": 0.3352621885189167,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.22347957614918465
+          "weighted_cost": 0.21713038108193805
         }
       ],
-      "median_cost": 0.16491184438182355,
+      "median_cost": 0.24171499665478385,
       "spread": [
-        0.12649407500156595,
-        0.26309518253772846
+        0.2344549094674303,
+        0.28786393999708265
       ],
-      "best_of_k_cost": 0.11720693432543848,
-      "best_seed": 0,
-      "median_seed": 2,
-      "worst_seed": 1
+      "best_of_k_cost": 0.21713038108193805,
+      "best_seed": 7,
+      "median_seed": 1,
+      "worst_seed": 456
     },
     {
       "model": "multipoint",
@@ -1564,9 +1756,11 @@
             "crossings": 0.0,
             "sprawl": 0.0,
             "edge_length_cv": 0.0,
-            "aspect_penalty": 1.5022222222222221,
+            "aspect_penalty": 0.9022222222222225,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -1579,9 +1773,11 @@
             "crossings": 0.0,
             "sprawl": 0.0,
             "edge_length_cv": 0.0,
-            "aspect_penalty": 1.5022222222222221,
+            "aspect_penalty": 0.9022222222222225,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -1594,9 +1790,11 @@
             "crossings": 0.0,
             "sprawl": 0.0,
             "edge_length_cv": 0.0,
-            "aspect_penalty": 1.5022222222222221,
+            "aspect_penalty": 0.9022222222222225,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -1609,9 +1807,11 @@
             "crossings": 0.0,
             "sprawl": 0.0,
             "edge_length_cv": 0.0,
-            "aspect_penalty": 1.5022222222222221,
+            "aspect_penalty": 0.9022222222222225,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -1624,9 +1824,11 @@
             "crossings": 0.0,
             "sprawl": 0.0,
             "edge_length_cv": 0.0,
-            "aspect_penalty": 1.5022222222222221,
+            "aspect_penalty": 0.9022222222222225,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -1639,9 +1841,11 @@
             "crossings": 0.0,
             "sprawl": 0.0,
             "edge_length_cv": 0.0,
-            "aspect_penalty": 1.5022222222222221,
+            "aspect_penalty": 0.9022222222222225,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -1654,9 +1858,11 @@
             "crossings": 0.0,
             "sprawl": 0.0,
             "edge_length_cv": 0.0,
-            "aspect_penalty": 1.5022222222222221,
+            "aspect_penalty": 0.9022222222222225,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -1669,9 +1875,11 @@
             "crossings": 0.0,
             "sprawl": 0.0,
             "edge_length_cv": 0.0,
-            "aspect_penalty": 1.5022222222222221,
+            "aspect_penalty": 0.9022222222222225,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -1684,9 +1892,11 @@
             "crossings": 0.0,
             "sprawl": 0.0,
             "edge_length_cv": 0.0,
-            "aspect_penalty": 1.5022222222222221,
+            "aspect_penalty": 0.9022222222222225,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -1699,9 +1909,11 @@
             "crossings": 0.0,
             "sprawl": 0.0,
             "edge_length_cv": 0.0,
-            "aspect_penalty": 1.5022222222222221,
+            "aspect_penalty": 0.9022222222222225,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -1714,9 +1926,11 @@
             "crossings": 0.0,
             "sprawl": 0.0,
             "edge_length_cv": 0.0,
-            "aspect_penalty": 1.5022222222222221,
+            "aspect_penalty": 0.9022222222222225,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -1729,9 +1943,11 @@
             "crossings": 0.0,
             "sprawl": 0.0,
             "edge_length_cv": 0.0,
-            "aspect_penalty": 1.5022222222222221,
+            "aspect_penalty": 0.9022222222222225,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         }
@@ -1756,13 +1972,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5271178805293377,
-            "edge_length_cv": 0.10705879581928317,
+            "sprawl": 1.23975104782799,
+            "edge_length_cv": 0.09857461825509387,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.19503153726923472
+          "weighted_cost": 0.290269958781899
         },
         {
           "seed": 1,
@@ -1771,13 +1989,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5271178805293377,
-            "edge_length_cv": 0.10705879581928317,
+            "sprawl": 1.23975104782799,
+            "edge_length_cv": 0.09857461825509387,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.19503153726923472
+          "weighted_cost": 0.290269958781899
         },
         {
           "seed": 2,
@@ -1786,13 +2006,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5271178805293377,
-            "edge_length_cv": 0.10705879581928317,
+            "sprawl": 1.23975104782799,
+            "edge_length_cv": 0.09857461825509387,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.19503153726923472
+          "weighted_cost": 0.290269958781899
         },
         {
           "seed": 3,
@@ -1801,13 +2023,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5271178805293377,
-            "edge_length_cv": 0.10705879581928317,
+            "sprawl": 1.23975104782799,
+            "edge_length_cv": 0.09857461825509387,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.19503153726923472
+          "weighted_cost": 0.290269958781899
         },
         {
           "seed": 4,
@@ -1816,13 +2040,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5271178805293377,
-            "edge_length_cv": 0.10705879581928317,
+            "sprawl": 1.23975104782799,
+            "edge_length_cv": 0.09857461825509387,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.19503153726923472
+          "weighted_cost": 0.290269958781899
         },
         {
           "seed": 5,
@@ -1831,13 +2057,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5271178805293377,
-            "edge_length_cv": 0.10705879581928317,
+            "sprawl": 1.23975104782799,
+            "edge_length_cv": 0.09857461825509387,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.19503153726923472
+          "weighted_cost": 0.290269958781899
         },
         {
           "seed": 6,
@@ -1846,13 +2074,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5271178805293377,
-            "edge_length_cv": 0.10705879581928317,
+            "sprawl": 1.23975104782799,
+            "edge_length_cv": 0.09857461825509387,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.19503153726923472
+          "weighted_cost": 0.290269958781899
         },
         {
           "seed": 7,
@@ -1861,13 +2091,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5271178805293377,
-            "edge_length_cv": 0.10705879581928317,
+            "sprawl": 1.23975104782799,
+            "edge_length_cv": 0.09857461825509387,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.19503153726923472
+          "weighted_cost": 0.290269958781899
         },
         {
           "seed": 42,
@@ -1876,13 +2108,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5271178805293377,
-            "edge_length_cv": 0.10705879581928317,
+            "sprawl": 1.23975104782799,
+            "edge_length_cv": 0.09857461825509387,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.19503153726923472
+          "weighted_cost": 0.290269958781899
         },
         {
           "seed": 123,
@@ -1891,13 +2125,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5271178805293377,
-            "edge_length_cv": 0.10705879581928317,
+            "sprawl": 1.23975104782799,
+            "edge_length_cv": 0.09857461825509387,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.19503153726923472
+          "weighted_cost": 0.290269958781899
         },
         {
           "seed": 456,
@@ -1906,13 +2142,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5271178805293377,
-            "edge_length_cv": 0.10705879581928317,
+            "sprawl": 1.23975104782799,
+            "edge_length_cv": 0.09857461825509387,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.19503153726923472
+          "weighted_cost": 0.290269958781899
         },
         {
           "seed": 789,
@@ -1921,21 +2159,23 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5271178805293377,
-            "edge_length_cv": 0.10705879581928317,
+            "sprawl": 1.23975104782799,
+            "edge_length_cv": 0.09857461825509387,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.19503153726923472
+          "weighted_cost": 0.290269958781899
         }
       ],
-      "median_cost": 0.19503153726923472,
+      "median_cost": 0.290269958781899,
       "spread": [
-        0.19503153726923472,
-        0.19503153726923472
+        0.290269958781899,
+        0.290269958781899
       ],
-      "best_of_k_cost": 0.19503153726923472,
+      "best_of_k_cost": 0.290269958781899,
       "best_seed": 0,
       "median_seed": 0,
       "worst_seed": 0
@@ -1946,192 +2186,216 @@
         {
           "seed": 0,
           "metrics": {
-            "node_overlap": 0.14292550977944254,
-            "node_connector_overlap": 0.029402233004882795,
+            "node_overlap": 0.14292550977944257,
+            "node_connector_overlap": 0.07874643194986122,
             "label_overlap": 0.0,
-            "crossings": 0.0,
-            "sprawl": 1.491498683199778,
-            "edge_length_cv": 0.21055389321675655,
-            "aspect_penalty": 0.0,
+            "crossings": 0.5,
+            "sprawl": 1.3507796714696096,
+            "edge_length_cv": 0.45542381940066795,
+            "aspect_penalty": 0.8396982093245615,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5268086566432967
+            "loop_compactness": 0.917997052867288,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.2748289317589672
           },
-          "weighted_cost": 0.4531797752651273
+          "weighted_cost": 1.3865095903460378
         },
         {
           "seed": 1,
           "metrics": {
             "node_overlap": 0.14292550977944254,
-            "node_connector_overlap": 0.029402233004882795,
+            "node_connector_overlap": 0.05368923480833391,
             "label_overlap": 0.0,
-            "crossings": 0.0,
-            "sprawl": 1.491498683199778,
-            "edge_length_cv": 0.21055389321675655,
+            "crossings": 0.375,
+            "sprawl": 1.2497817625149574,
+            "edge_length_cv": 0.15661518692207232,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5268086566432967
+            "loop_compactness": 0.5141352860514037,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.16166439453184614
           },
-          "weighted_cost": 0.4531797752651273
+          "weighted_cost": 1.043391650964514
         },
         {
           "seed": 2,
           "metrics": {
             "node_overlap": 0.14292550977944254,
-            "node_connector_overlap": 0.029402233004882795,
+            "node_connector_overlap": 0.05739384839998312,
             "label_overlap": 0.0,
-            "crossings": 0.0,
-            "sprawl": 1.491498683199778,
-            "edge_length_cv": 0.21055389321675655,
+            "crossings": 0.125,
+            "sprawl": 1.105830775826482,
+            "edge_length_cv": 0.21414163583637771,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5268086566432967
+            "loop_compactness": 0.4783146914388712,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.23006389967349836
           },
-          "weighted_cost": 0.4531797752651273
+          "weighted_cost": 0.7608177798876204
         },
         {
           "seed": 3,
           "metrics": {
             "node_overlap": 0.14292550977944254,
-            "node_connector_overlap": 0.029402233004882795,
+            "node_connector_overlap": 0.03366922572189482,
             "label_overlap": 0.0,
-            "crossings": 0.0,
-            "sprawl": 1.491498683199778,
-            "edge_length_cv": 0.21055389321675655,
+            "crossings": 0.125,
+            "sprawl": 1.2854106234824583,
+            "edge_length_cv": 0.33748941379701564,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5268086566432967
+            "loop_compactness": 0.7829428048865084,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.45759328372739344
           },
-          "weighted_cost": 0.4531797752651273
+          "weighted_cost": 0.9176133105251717
         },
         {
           "seed": 4,
           "metrics": {
-            "node_overlap": 0.14292550977944254,
-            "node_connector_overlap": 0.029402233004882795,
+            "node_overlap": 0.1429255097794431,
+            "node_connector_overlap": 0.03376620751651381,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.491498683199778,
-            "edge_length_cv": 0.21055389321675655,
+            "sprawl": 1.2989223527440266,
+            "edge_length_cv": 0.4699894313443017,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5268086566432967
+            "loop_compactness": 0.5470879543433413,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.048567333695646774
           },
-          "weighted_cost": 0.4531797752651273
+          "weighted_cost": 0.6601681029516635
         },
         {
           "seed": 5,
           "metrics": {
             "node_overlap": 0.14292550977944254,
-            "node_connector_overlap": 0.029402233004882795,
+            "node_connector_overlap": 0.05232996826889643,
             "label_overlap": 0.0,
-            "crossings": 0.0,
-            "sprawl": 1.491498683199778,
-            "edge_length_cv": 0.21055389321675655,
+            "crossings": 0.375,
+            "sprawl": 1.598872259770682,
+            "edge_length_cv": 0.2979907298096308,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5268086566432967
+            "loop_compactness": 0.5040015759096583,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.1374144658794832
           },
-          "weighted_cost": 0.4531797752651273
+          "weighted_cost": 1.1053720069542872
         },
         {
           "seed": 6,
           "metrics": {
-            "node_overlap": 0.14292550977944254,
-            "node_connector_overlap": 0.029402233004882795,
+            "node_overlap": 0.09884281581485074,
+            "node_connector_overlap": 0.017585427164416256,
             "label_overlap": 0.0,
-            "crossings": 0.0,
-            "sprawl": 1.491498683199778,
-            "edge_length_cv": 0.21055389321675655,
+            "crossings": 0.25,
+            "sprawl": 1.2240757649666012,
+            "edge_length_cv": 0.21785931759294788,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5268086566432967
+            "loop_compactness": 0.649219675628467,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.3333333333333333
           },
-          "weighted_cost": 0.4531797752651273
+          "weighted_cost": 0.9042645995573074
         },
         {
           "seed": 7,
           "metrics": {
             "node_overlap": 0.14292550977944254,
-            "node_connector_overlap": 0.029402233004882795,
+            "node_connector_overlap": 0.03976287212374372,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.491498683199778,
-            "edge_length_cv": 0.21055389321675655,
+            "sprawl": 1.1030807484299563,
+            "edge_length_cv": 0.2540338479893443,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5268086566432967
+            "loop_compactness": 0.565158858437151,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.15641986418561762
           },
-          "weighted_cost": 0.4531797752651273
+          "weighted_cost": 0.6450100613825998
         },
         {
           "seed": 42,
           "metrics": {
             "node_overlap": 0.14292550977944254,
-            "node_connector_overlap": 0.029402233004882795,
+            "node_connector_overlap": 0.03823283129751742,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.491498683199778,
-            "edge_length_cv": 0.21055389321675655,
-            "aspect_penalty": 0.0,
+            "sprawl": 1.1472951165480416,
+            "edge_length_cv": 0.28925706340995067,
+            "aspect_penalty": 0.24895073500693243,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5268086566432967
+            "loop_compactness": 0.5518054002419153,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.10498812980413981
           },
-          "weighted_cost": 0.4531797752651273
+          "weighted_cost": 0.6418383374637484
         },
         {
           "seed": 123,
           "metrics": {
             "node_overlap": 0.14292550977944254,
-            "node_connector_overlap": 0.029402233004882795,
+            "node_connector_overlap": 0.05368923480833391,
             "label_overlap": 0.0,
-            "crossings": 0.0,
-            "sprawl": 1.491498683199778,
-            "edge_length_cv": 0.21055389321675655,
+            "crossings": 0.375,
+            "sprawl": 1.2497817625149574,
+            "edge_length_cv": 0.15661518692207232,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5268086566432967
+            "loop_compactness": 0.5141352860514037,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.16166439453184614
           },
-          "weighted_cost": 0.4531797752651273
+          "weighted_cost": 1.043391650964514
         },
         {
           "seed": 456,
           "metrics": {
-            "node_overlap": 0.14292550977944254,
-            "node_connector_overlap": 0.029402233004882795,
+            "node_overlap": 0.14292550977944202,
+            "node_connector_overlap": 0.07717328372897628,
             "label_overlap": 0.0,
-            "crossings": 0.0,
-            "sprawl": 1.491498683199778,
-            "edge_length_cv": 0.21055389321675655,
-            "aspect_penalty": 0.0,
+            "crossings": 0.25,
+            "sprawl": 1.1987847095608246,
+            "edge_length_cv": 0.3761450197916289,
+            "aspect_penalty": 0.023546725533480695,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5268086566432967
+            "loop_compactness": 0.4873195293257049,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.127070122338004
           },
-          "weighted_cost": 0.4531797752651273
+          "weighted_cost": 0.9174905593846656
         },
         {
           "seed": 789,
           "metrics": {
-            "node_overlap": 0.14292550977944254,
-            "node_connector_overlap": 0.029402233004882795,
+            "node_overlap": 0.1429255097794431,
+            "node_connector_overlap": 0.04985300122850721,
             "label_overlap": 0.0,
-            "crossings": 0.0,
-            "sprawl": 1.491498683199778,
-            "edge_length_cv": 0.21055389321675655,
+            "crossings": 0.375,
+            "sprawl": 1.7157507559852456,
+            "edge_length_cv": 0.7146821530127622,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5268086566432967
+            "loop_compactness": 0.9070368311076114,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.27482893175896594
           },
-          "weighted_cost": 0.4531797752651273
+          "weighted_cost": 1.3012262878239407
         }
       ],
-      "median_cost": 0.4531797752651273,
+      "median_cost": 0.9175519349549186,
       "spread": [
-        0.4531797752651273,
-        0.4531797752651273
+        0.7356553606536311,
+        1.0588867399619573
       ],
-      "best_of_k_cost": 0.4531797752651273,
-      "best_seed": 0,
-      "median_seed": 0,
+      "best_of_k_cost": 0.6418383374637484,
+      "best_seed": 42,
+      "median_seed": 456,
       "worst_seed": 0
     },
     {
@@ -2144,13 +2408,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5084017890421362,
-            "edge_length_cv": 0.24288435259347946,
-            "aspect_penalty": 1.1412180001360572,
+            "sprawl": 1.2719329648690079,
+            "edge_length_cv": 0.08831889638826457,
+            "aspect_penalty": 0.33361314038954415,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.20412088931368577
+          "weighted_cost": 0.3076673033832737
         },
         {
           "seed": 1,
@@ -2159,13 +2425,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5084017890421362,
-            "edge_length_cv": 0.24288435259347946,
-            "aspect_penalty": 1.1412180001360572,
+            "sprawl": 1.2719329648690079,
+            "edge_length_cv": 0.08831889638826457,
+            "aspect_penalty": 0.33361314038954415,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.20412088931368577
+          "weighted_cost": 0.3076673033832737
         },
         {
           "seed": 2,
@@ -2174,13 +2442,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5084017890421362,
-            "edge_length_cv": 0.24288435259347946,
-            "aspect_penalty": 1.1412180001360572,
+            "sprawl": 1.2719329648690079,
+            "edge_length_cv": 0.08831889638826457,
+            "aspect_penalty": 0.33361314038954415,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.20412088931368577
+          "weighted_cost": 0.3076673033832737
         },
         {
           "seed": 3,
@@ -2189,13 +2459,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5084017890421362,
-            "edge_length_cv": 0.24288435259347946,
-            "aspect_penalty": 1.1412180001360572,
+            "sprawl": 1.2719329648690079,
+            "edge_length_cv": 0.08831889638826457,
+            "aspect_penalty": 0.33361314038954415,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.20412088931368577
+          "weighted_cost": 0.3076673033832737
         },
         {
           "seed": 4,
@@ -2204,13 +2476,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5084017890421362,
-            "edge_length_cv": 0.24288435259347946,
-            "aspect_penalty": 1.1412180001360572,
+            "sprawl": 1.2719329648690079,
+            "edge_length_cv": 0.08831889638826457,
+            "aspect_penalty": 0.33361314038954415,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.20412088931368577
+          "weighted_cost": 0.3076673033832737
         },
         {
           "seed": 5,
@@ -2219,13 +2493,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5084017890421362,
-            "edge_length_cv": 0.24288435259347946,
-            "aspect_penalty": 1.1412180001360572,
+            "sprawl": 1.2719329648690079,
+            "edge_length_cv": 0.08831889638826457,
+            "aspect_penalty": 0.33361314038954415,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.20412088931368577
+          "weighted_cost": 0.3076673033832737
         },
         {
           "seed": 6,
@@ -2234,13 +2510,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5084017890421362,
-            "edge_length_cv": 0.24288435259347946,
-            "aspect_penalty": 1.1412180001360572,
+            "sprawl": 1.2719329648690079,
+            "edge_length_cv": 0.08831889638826457,
+            "aspect_penalty": 0.33361314038954415,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.20412088931368577
+          "weighted_cost": 0.3076673033832737
         },
         {
           "seed": 7,
@@ -2249,13 +2527,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5084017890421362,
-            "edge_length_cv": 0.24288435259347946,
-            "aspect_penalty": 1.1412180001360572,
+            "sprawl": 1.2719329648690079,
+            "edge_length_cv": 0.08831889638826457,
+            "aspect_penalty": 0.33361314038954415,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.20412088931368577
+          "weighted_cost": 0.3076673033832737
         },
         {
           "seed": 42,
@@ -2264,13 +2544,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5084017890421362,
-            "edge_length_cv": 0.24288435259347946,
-            "aspect_penalty": 1.1412180001360572,
+            "sprawl": 1.2719329648690079,
+            "edge_length_cv": 0.08831889638826457,
+            "aspect_penalty": 0.33361314038954415,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.20412088931368577
+          "weighted_cost": 0.3076673033832737
         },
         {
           "seed": 123,
@@ -2279,13 +2561,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5084017890421362,
-            "edge_length_cv": 0.24288435259347946,
-            "aspect_penalty": 1.1412180001360572,
+            "sprawl": 1.2719329648690079,
+            "edge_length_cv": 0.08831889638826457,
+            "aspect_penalty": 0.33361314038954415,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.20412088931368577
+          "weighted_cost": 0.3076673033832737
         },
         {
           "seed": 456,
@@ -2294,13 +2578,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5084017890421362,
-            "edge_length_cv": 0.24288435259347946,
-            "aspect_penalty": 1.1412180001360572,
+            "sprawl": 1.2719329648690079,
+            "edge_length_cv": 0.08831889638826457,
+            "aspect_penalty": 0.33361314038954415,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.20412088931368577
+          "weighted_cost": 0.3076673033832737
         },
         {
           "seed": 789,
@@ -2309,21 +2595,23 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.5084017890421362,
-            "edge_length_cv": 0.24288435259347946,
-            "aspect_penalty": 1.1412180001360572,
+            "sprawl": 1.2719329648690079,
+            "edge_length_cv": 0.08831889638826457,
+            "aspect_penalty": 0.33361314038954415,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.20412088931368577
+          "weighted_cost": 0.3076673033832737
         }
       ],
-      "median_cost": 0.20412088931368577,
+      "median_cost": 0.3076673033832737,
       "spread": [
-        0.20412088931368577,
-        0.20412088931368577
+        0.3076673033832737,
+        0.3076673033832737
       ],
-      "best_of_k_cost": 0.20412088931368577,
+      "best_of_k_cost": 0.3076673033832737,
       "best_seed": 0,
       "median_seed": 0,
       "worst_seed": 0
@@ -2342,7 +2630,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2357,7 +2647,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2372,7 +2664,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2387,7 +2681,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2402,7 +2698,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2417,7 +2715,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2432,7 +2732,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2447,7 +2749,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2462,7 +2766,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2477,7 +2783,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2492,7 +2800,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2507,7 +2817,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         }
@@ -2536,7 +2848,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2551,7 +2865,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2566,7 +2882,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2581,7 +2899,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2596,7 +2916,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2611,7 +2933,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2626,7 +2950,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2641,7 +2967,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2656,7 +2984,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2671,7 +3001,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2686,7 +3018,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         },
@@ -2701,7 +3035,9 @@
             "edge_length_cv": 0.0,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
           "weighted_cost": 0.0
         }
@@ -2723,192 +3059,216 @@
           "seed": 0,
           "metrics": {
             "node_overlap": 0.03366774358102364,
-            "node_connector_overlap": 0.004725946522717274,
-            "label_overlap": 0.06412416534170721,
-            "crossings": 0.4095238095238095,
-            "sprawl": 2.346159115620886,
-            "edge_length_cv": 0.6004312698171721,
+            "node_connector_overlap": 0.01735845466376796,
+            "label_overlap": 0.060548107082135955,
+            "crossings": 0.2,
+            "sprawl": 1.663341406617301,
+            "edge_length_cv": 0.5298837404528474,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6114475582296282
+            "loop_compactness": 0.715042092339224,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.9642857142857143
           },
-          "weighted_cost": 0.8995194660887533
+          "weighted_cost": 1.026687995014649
         },
         {
           "seed": 1,
           "metrics": {
-            "node_overlap": 0.03366774358102364,
-            "node_connector_overlap": 0.0031439975713443992,
-            "label_overlap": 0.06275823302855715,
-            "crossings": 0.42857142857142855,
-            "sprawl": 2.351566222277826,
-            "edge_length_cv": 0.5975840089475338,
+            "node_overlap": 0.03346290349839446,
+            "node_connector_overlap": 0.013472977620639466,
+            "label_overlap": 0.06283506533948285,
+            "crossings": 0.22857142857142856,
+            "sprawl": 1.6155862337658629,
+            "edge_length_cv": 0.5449424414263883,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6078733438564711
+            "loop_compactness": 0.7232043134115199,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.9642857142857143
           },
-          "weighted_cost": 0.9152663609442542
+          "weighted_cost": 1.0471699185762975
         },
         {
           "seed": 2,
           "metrics": {
-            "node_overlap": 0.03366774358102364,
-            "node_connector_overlap": 0.005774621876396386,
-            "label_overlap": 0.0597082271918878,
-            "crossings": 0.4,
-            "sprawl": 2.3423101804893305,
-            "edge_length_cv": 0.6141800085892077,
+            "node_overlap": 0.03346290349839446,
+            "node_connector_overlap": 0.015900682028631895,
+            "label_overlap": 0.06683812846987626,
+            "crossings": 0.19047619047619047,
+            "sprawl": 1.6160756372671428,
+            "edge_length_cv": 0.5656860344263355,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6302385897911023
+            "loop_compactness": 0.7271292194699819,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.9642857142857143
           },
-          "weighted_cost": 0.8909412581460165
+          "weighted_cost": 1.017173291143086
         },
         {
           "seed": 3,
           "metrics": {
-            "node_overlap": 0.03366774358102364,
-            "node_connector_overlap": 0.005463770533988782,
-            "label_overlap": 0.06275823302855715,
-            "crossings": 0.37142857142857144,
-            "sprawl": 2.3438963457073663,
-            "edge_length_cv": 0.6099797704751414,
+            "node_overlap": 0.03346290349839446,
+            "node_connector_overlap": 0.01615058449441615,
+            "label_overlap": 0.06447294443191919,
+            "crossings": 0.2,
+            "sprawl": 1.6089293631969956,
+            "edge_length_cv": 0.5585503711799498,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6094704359201256
+            "loop_compactness": 0.718913716417784,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.9642857142857143
           },
-          "weighted_cost": 0.860075562122909
+          "weighted_cost": 1.0198663630598142
         },
         {
           "seed": 4,
           "metrics": {
-            "node_overlap": 0.03366774358102364,
-            "node_connector_overlap": 0.0033339806365742463,
-            "label_overlap": 0.06275823302855715,
-            "crossings": 0.42857142857142855,
-            "sprawl": 2.3612998862040913,
-            "edge_length_cv": 0.5998865322183855,
+            "node_overlap": 0.03346290349839446,
+            "node_connector_overlap": 0.015417390186207742,
+            "label_overlap": 0.06283506533948285,
+            "crossings": 0.20952380952380953,
+            "sprawl": 1.6270633792334788,
+            "edge_length_cv": 0.5531268810625588,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6164935072958607
+            "loop_compactness": 0.700679022277094,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.9642857142857143
           },
-          "weighted_cost": 0.9185847512619578
+          "weighted_cost": 1.0233520247339996
         },
         {
           "seed": 5,
           "metrics": {
-            "node_overlap": 0.03366774358102364,
-            "node_connector_overlap": 0.0031605060226327177,
-            "label_overlap": 0.06069677757603526,
-            "crossings": 0.41904761904761906,
-            "sprawl": 2.332654119966897,
-            "edge_length_cv": 0.6176570390969117,
+            "node_overlap": 0.03346290349839446,
+            "node_connector_overlap": 0.013472977620639466,
+            "label_overlap": 0.06283506533948285,
+            "crossings": 0.22857142857142856,
+            "sprawl": 1.6155862337658629,
+            "edge_length_cv": 0.5449424414263883,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.573495115036952
+            "loop_compactness": 0.7232043134115199,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.9642857142857143
           },
-          "weighted_cost": 0.8932118369832385
+          "weighted_cost": 1.0471699185762975
         },
         {
           "seed": 6,
           "metrics": {
-            "node_overlap": 0.033875106928999144,
-            "node_connector_overlap": 0.005405006682411661,
-            "label_overlap": 0.06275823302855715,
-            "crossings": 0.38095238095238093,
-            "sprawl": 2.3822623492394768,
-            "edge_length_cv": 0.5908017712556004,
+            "node_overlap": 0.03346290349839446,
+            "node_connector_overlap": 0.01466003480923588,
+            "label_overlap": 0.05729748444171206,
+            "crossings": 0.19047619047619047,
+            "sprawl": 1.627721576710515,
+            "edge_length_cv": 0.5403344574084297,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6169433026858121
+            "loop_compactness": 0.723816866157302,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.9642857142857143
           },
-          "weighted_cost": 0.8754527881877495
+          "weighted_cost": 1.0073962464591282
         },
         {
           "seed": 7,
           "metrics": {
-            "node_overlap": 0.03366774358102364,
-            "node_connector_overlap": 0.0028483383510188734,
-            "label_overlap": 0.061613831281046555,
-            "crossings": 0.4,
-            "sprawl": 2.36420340317681,
-            "edge_length_cv": 0.5940336549386188,
+            "node_overlap": 0.03346290349839446,
+            "node_connector_overlap": 0.013594953737298719,
+            "label_overlap": 0.06283506533948285,
+            "crossings": 0.22857142857142856,
+            "sprawl": 1.6133976739656597,
+            "edge_length_cv": 0.5420324031953525,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6110493684945025
+            "loop_compactness": 0.7232043134115199,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.9642857142857143
           },
-          "weighted_cost": 0.8873125956543957
+          "weighted_cost": 1.046854182732916
         },
         {
           "seed": 42,
           "metrics": {
-            "node_overlap": 0.03366774358102364,
-            "node_connector_overlap": 0.0030753047586715107,
-            "label_overlap": 0.06315283935626927,
-            "crossings": 0.37142857142857144,
-            "sprawl": 2.3843039829820176,
-            "edge_length_cv": 0.5977809024718981,
+            "node_overlap": 0.03346290349839446,
+            "node_connector_overlap": 0.01454922826263932,
+            "label_overlap": 0.06283506533948285,
+            "crossings": 0.22857142857142856,
+            "sprawl": 1.6310839691456696,
+            "edge_length_cv": 0.53627086427199,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5827508175122499
+            "loop_compactness": 0.7252669344572478,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.9642857142857143
           },
-          "weighted_cost": 0.8554425618008001
+          "weighted_cost": 1.0521707647125498
         },
         {
           "seed": 123,
           "metrics": {
             "node_overlap": 0.03366774358102364,
-            "node_connector_overlap": 0.00718140587843908,
-            "label_overlap": 0.06059662644232856,
-            "crossings": 0.37142857142857144,
-            "sprawl": 2.389099442963133,
-            "edge_length_cv": 0.5944159599825384,
+            "node_connector_overlap": 0.01627810987593352,
+            "label_overlap": 0.05977738457724403,
+            "crossings": 0.2,
+            "sprawl": 1.6154929575825405,
+            "edge_length_cv": 0.5535939290017915,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6127373928140031
+            "loop_compactness": 0.7222903559191249,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.9642857142857143
           },
-          "weighted_cost": 0.8649686398301768
+          "weighted_cost": 1.018166543346931
         },
         {
           "seed": 456,
           "metrics": {
             "node_overlap": 0.03366774358102364,
-            "node_connector_overlap": 0.005514249685052332,
-            "label_overlap": 0.06358444588366795,
-            "crossings": 0.4,
-            "sprawl": 2.363324059469581,
-            "edge_length_cv": 0.6042329336589535,
+            "node_connector_overlap": 0.016906785395203783,
+            "label_overlap": 0.063616208710647,
+            "crossings": 0.18095238095238095,
+            "sprawl": 1.6190603607797767,
+            "edge_length_cv": 0.5563941299831441,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6086833460725043
+            "loop_compactness": 0.7202424271245069,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.9642857142857143
           },
-          "weighted_cost": 0.891269681614828
+          "weighted_cost": 1.0034807330735849
         },
         {
           "seed": 789,
           "metrics": {
-            "node_overlap": 0.033875106928999144,
-            "node_connector_overlap": 0.006006699516782619,
-            "label_overlap": 0.06281250447190341,
-            "crossings": 0.3904761904761905,
-            "sprawl": 2.4022382431694274,
-            "edge_length_cv": 0.5886814931275709,
+            "node_overlap": 0.033260540903746014,
+            "node_connector_overlap": 0.0164985781224376,
+            "label_overlap": 0.06283506533948285,
+            "crossings": 0.23809523809523808,
+            "sprawl": 1.624963826611921,
+            "edge_length_cv": 0.5466254311343512,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6206526650750345
+            "loop_compactness": 0.7118726224687183,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.9642857142857143
           },
-          "weighted_cost": 0.888557491979577
+          "weighted_cost": 1.0568598081993477
         }
       ],
-      "median_cost": 0.8897493750627967,
+      "median_cost": 1.0250200098743243,
       "spread": [
-        0.8728317510983563,
-        0.8947887442596172
+        1.0179182302959697,
+        1.0471699185762975
       ],
-      "best_of_k_cost": 0.8554425618008001,
-      "best_seed": 42,
-      "median_seed": 789,
-      "worst_seed": 4
+      "best_of_k_cost": 1.0034807330735849,
+      "best_seed": 456,
+      "median_seed": 0,
+      "worst_seed": 789
     },
     {
       "model": "ai_modules_arrays",
@@ -2920,13 +3280,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3193721388991295,
-            "edge_length_cv": 0.09970602603853732,
-            "aspect_penalty": 0.16769629005072284,
+            "sprawl": 0.37326949442324286,
+            "edge_length_cv": 0.370733451417772,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.13193721388991295
+          "weighted_cost": 0.07465389888464857
         },
         {
           "seed": 1,
@@ -2935,13 +3297,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3193721388991295,
-            "edge_length_cv": 0.09970602603853732,
-            "aspect_penalty": 0.16769629005072284,
+            "sprawl": 0.37326949442324286,
+            "edge_length_cv": 0.370733451417772,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.13193721388991295
+          "weighted_cost": 0.07465389888464857
         },
         {
           "seed": 2,
@@ -2950,13 +3314,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3193721388991295,
-            "edge_length_cv": 0.09970602603853732,
-            "aspect_penalty": 0.16769629005072284,
+            "sprawl": 0.37326949442324286,
+            "edge_length_cv": 0.370733451417772,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.13193721388991295
+          "weighted_cost": 0.07465389888464857
         },
         {
           "seed": 3,
@@ -2965,13 +3331,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3193721388991295,
-            "edge_length_cv": 0.09970602603853732,
-            "aspect_penalty": 0.16769629005072284,
+            "sprawl": 0.37326949442324286,
+            "edge_length_cv": 0.370733451417772,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.13193721388991295
+          "weighted_cost": 0.07465389888464857
         },
         {
           "seed": 4,
@@ -2980,13 +3348,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3193721388991295,
-            "edge_length_cv": 0.09970602603853732,
-            "aspect_penalty": 0.16769629005072284,
+            "sprawl": 0.37326949442324286,
+            "edge_length_cv": 0.370733451417772,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.13193721388991295
+          "weighted_cost": 0.07465389888464857
         },
         {
           "seed": 5,
@@ -2995,13 +3365,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3193721388991295,
-            "edge_length_cv": 0.09970602603853732,
-            "aspect_penalty": 0.16769629005072284,
+            "sprawl": 0.37326949442324286,
+            "edge_length_cv": 0.370733451417772,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.13193721388991295
+          "weighted_cost": 0.07465389888464857
         },
         {
           "seed": 6,
@@ -3010,13 +3382,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3193721388991295,
-            "edge_length_cv": 0.09970602603853732,
-            "aspect_penalty": 0.16769629005072284,
+            "sprawl": 0.37326949442324286,
+            "edge_length_cv": 0.370733451417772,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.13193721388991295
+          "weighted_cost": 0.07465389888464857
         },
         {
           "seed": 7,
@@ -3025,13 +3399,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3193721388991295,
-            "edge_length_cv": 0.09970602603853732,
-            "aspect_penalty": 0.16769629005072284,
+            "sprawl": 0.37326949442324286,
+            "edge_length_cv": 0.370733451417772,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.13193721388991295
+          "weighted_cost": 0.07465389888464857
         },
         {
           "seed": 42,
@@ -3040,13 +3416,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3193721388991295,
-            "edge_length_cv": 0.09970602603853732,
-            "aspect_penalty": 0.16769629005072284,
+            "sprawl": 0.37326949442324286,
+            "edge_length_cv": 0.370733451417772,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.13193721388991295
+          "weighted_cost": 0.07465389888464857
         },
         {
           "seed": 123,
@@ -3055,13 +3433,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3193721388991295,
-            "edge_length_cv": 0.09970602603853732,
-            "aspect_penalty": 0.16769629005072284,
+            "sprawl": 0.37326949442324286,
+            "edge_length_cv": 0.370733451417772,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.13193721388991295
+          "weighted_cost": 0.07465389888464857
         },
         {
           "seed": 456,
@@ -3070,13 +3450,15 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3193721388991295,
-            "edge_length_cv": 0.09970602603853732,
-            "aspect_penalty": 0.16769629005072284,
+            "sprawl": 0.37326949442324286,
+            "edge_length_cv": 0.370733451417772,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.13193721388991295
+          "weighted_cost": 0.07465389888464857
         },
         {
           "seed": 789,
@@ -3085,21 +3467,23 @@
             "node_connector_overlap": 0.0,
             "label_overlap": 0.0,
             "crossings": 0.0,
-            "sprawl": 1.3193721388991295,
-            "edge_length_cv": 0.09970602603853732,
-            "aspect_penalty": 0.16769629005072284,
+            "sprawl": 0.37326949442324286,
+            "edge_length_cv": 0.370733451417772,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.0
+            "loop_compactness": 0.0,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.0
           },
-          "weighted_cost": 0.13193721388991295
+          "weighted_cost": 0.07465389888464857
         }
       ],
-      "median_cost": 0.13193721388991295,
+      "median_cost": 0.07465389888464857,
       "spread": [
-        0.13193721388991295,
-        0.13193721388991295
+        0.07465389888464857,
+        0.07465389888464857
       ],
-      "best_of_k_cost": 0.13193721388991295,
+      "best_of_k_cost": 0.07465389888464857,
       "best_seed": 0,
       "median_seed": 0,
       "worst_seed": 0
@@ -3110,193 +3494,217 @@
         {
           "seed": 0,
           "metrics": {
-            "node_overlap": 0.01139247113214623,
-            "node_connector_overlap": 0.0035639552334164595,
+            "node_overlap": 0.015735131757445838,
+            "node_connector_overlap": 0.01687604720051637,
             "label_overlap": 0.0,
-            "crossings": 1.2110552763819096,
-            "sprawl": 6.588948495271649,
-            "edge_length_cv": 0.6621423900801049,
+            "crossings": 1.2738693467336684,
+            "sprawl": 2.4109057250978414,
+            "edge_length_cv": 0.6912592137719059,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7077790618993843
+            "loop_compactness": 0.8557404213973576,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8478260869565217
           },
-          "weighted_cost": 2.061851317749483
+          "weighted_cost": 2.215740447965794
         },
         {
           "seed": 1,
           "metrics": {
-            "node_overlap": 0.018196454312297584,
-            "node_connector_overlap": 0.01939163521045703,
-            "label_overlap": 0.8887139167472308,
-            "crossings": 1.2135678391959799,
-            "sprawl": 1.9629032767664236,
-            "edge_length_cv": 0.6992981113971375,
+            "node_overlap": 0.01707989948865733,
+            "node_connector_overlap": 0.02650524392495415,
+            "label_overlap": 0.407996627283499,
+            "crossings": 1.2160804020100502,
+            "sprawl": 1.8737197256961,
+            "edge_length_cv": 0.6762832295466932,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7819877744829478
+            "loop_compactness": 0.8315990150948197,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8478260869565217
           },
-          "weighted_cost": 2.531657116763345
+          "weighted_cost": 2.4598283325799604
         },
         {
           "seed": 2,
           "metrics": {
-            "node_overlap": 0.018196454312297602,
-            "node_connector_overlap": 0.01669819747246417,
-            "label_overlap": 0.777750588146048,
-            "crossings": 1.2412060301507537,
-            "sprawl": 1.9476406806756943,
-            "edge_length_cv": 0.7034999341149305,
+            "node_overlap": 0.012919003008107444,
+            "node_connector_overlap": 0.007081133335195029,
+            "label_overlap": 0.0,
+            "crossings": 1.379396984924623,
+            "sprawl": 4.006889579365737,
+            "edge_length_cv": 0.6322929780685507,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.8292813488570848
+            "loop_compactness": 0.6399223889676684,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8478260869565217
           },
-          "weighted_cost": 2.4559356753634045
+          "weighted_cost": 2.5415266014237927
         },
         {
           "seed": 3,
           "metrics": {
-            "node_overlap": 0.016887607067776277,
-            "node_connector_overlap": 0.009996035768607027,
-            "label_overlap": 0.09280563745493708,
-            "crossings": 1.0904522613065326,
-            "sprawl": 2.546255810037785,
-            "edge_length_cv": 0.6867718309150002,
+            "node_overlap": 0.015818098378156713,
+            "node_connector_overlap": 0.01694000359458034,
+            "label_overlap": 0.0,
+            "crossings": 1.3618090452261307,
+            "sprawl": 2.3962451728808656,
+            "edge_length_cv": 0.6990074254863038,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.8963483775006924
+            "loop_compactness": 0.8649300916516701,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8478260869565217
           },
-          "weighted_cost": 1.6888542169768046
+          "weighted_cost": 2.304570827131361
         },
         {
           "seed": 4,
           "metrics": {
-            "node_overlap": 0.014317261078496324,
-            "node_connector_overlap": 0.005835236254939618,
+            "node_overlap": 0.01587389723774591,
+            "node_connector_overlap": 0.016112267552554186,
             "label_overlap": 0.0,
-            "crossings": 1.3743718592964824,
-            "sprawl": 4.258696271606056,
-            "edge_length_cv": 0.6762437458541632,
+            "crossings": 1.4723618090452262,
+            "sprawl": 2.495825459016063,
+            "edge_length_cv": 0.6591462795229761,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.9038233726629222
+            "loop_compactness": 0.838047164531921,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8478260869565217
           },
-          "weighted_cost": 2.046349826956255
+          "weighted_cost": 2.4235145401471594
         },
         {
           "seed": 5,
           "metrics": {
-            "node_overlap": 0.018086749409203434,
-            "node_connector_overlap": 0.018619137995883245,
-            "label_overlap": 0.7422900306075229,
-            "crossings": 1.329145728643216,
-            "sprawl": 1.9407748663663207,
-            "edge_length_cv": 0.6893106873703193,
+            "node_overlap": 0.017112374782134118,
+            "node_connector_overlap": 0.016970091259992937,
+            "label_overlap": 0.3058879664103606,
+            "crossings": 1.2010050251256281,
+            "sprawl": 1.8455558030746888,
+            "edge_length_cv": 0.7007325492948168,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.9164637050564652
+            "loop_compactness": 0.8483740428550308,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8478260869565217
           },
-          "weighted_cost": 2.531335059556574
+          "weighted_cost": 2.334218844030718
         },
         {
           "seed": 6,
           "metrics": {
-            "node_overlap": 0.015707669285688886,
-            "node_connector_overlap": 0.007197681832434684,
+            "node_overlap": 0.015818098378156703,
+            "node_connector_overlap": 0.01499822034986526,
             "label_overlap": 0.0,
-            "crossings": 1.1281407035175879,
-            "sprawl": 3.2664612557843866,
-            "edge_length_cv": 0.6848918564951515,
+            "crossings": 1.3165829145728642,
+            "sprawl": 2.399513149544941,
+            "edge_length_cv": 0.6904307463123497,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.8750511306392148
+            "loop_compactness": 0.839578355794327,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8478260869565217
           },
-          "weighted_cost": 1.696454962873954
+          "weighted_cost": 2.2479158142232576
         },
         {
           "seed": 7,
           "metrics": {
-            "node_overlap": 0.016983208987821758,
-            "node_connector_overlap": 0.01141074279327077,
-            "label_overlap": 0.08813026188789005,
-            "crossings": 1.1959798994974875,
-            "sprawl": 2.533478857395325,
-            "edge_length_cv": 0.6981370159618602,
+            "node_overlap": 0.015818098378156703,
+            "node_connector_overlap": 0.01173347309505542,
+            "label_overlap": 0.0,
+            "crossings": 1.5125628140703518,
+            "sprawl": 2.4468128896798063,
+            "edge_length_cv": 0.6924514002039581,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.8963434040348238
+            "loop_compactness": 0.8199274977010701,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8478260869565217
           },
-          "weighted_cost": 1.7899378499147087
+          "weighted_cost": 2.4422305712556054
         },
         {
           "seed": 42,
           "metrics": {
-            "node_overlap": 0.018123170436112095,
-            "node_connector_overlap": 0.020490373858688835,
-            "label_overlap": 0.8214886998604811,
-            "crossings": 1.2864321608040201,
-            "sprawl": 1.9281056570440527,
-            "edge_length_cv": 0.6985228101062666,
+            "node_overlap": 0.012919003008107444,
+            "node_connector_overlap": 0.007544837134564105,
+            "label_overlap": 0.0,
+            "crossings": 1.3241206030150754,
+            "sprawl": 3.959859595876896,
+            "edge_length_cv": 0.6558804297021629,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.8182116816796483
+            "loop_compactness": 0.8555238862147909,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8478260869565217
           },
-          "weighted_cost": 2.543897891083619
+          "weighted_cost": 2.563548525514695
         },
         {
           "seed": 123,
           "metrics": {
-            "node_overlap": 0.0169512216389669,
-            "node_connector_overlap": 0.015225712429881768,
-            "label_overlap": 0.4273128702336791,
-            "crossings": 1.3090452261306533,
-            "sprawl": 2.563161122875517,
-            "edge_length_cv": 0.6885573182249769,
+            "node_overlap": 0.01576269042530074,
+            "node_connector_overlap": 0.014448863578830453,
+            "label_overlap": 4.510330596205672e-16,
+            "crossings": 1.57035175879397,
+            "sprawl": 2.4431617299306247,
+            "edge_length_cv": 0.7071325917899842,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.8289077059117557
+            "loop_compactness": 0.8311110329168642,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8478260869565217
           },
-          "weighted_cost": 2.2320780691986717
+          "weighted_cost": 2.5064226806466245
         },
         {
           "seed": 456,
           "metrics": {
-            "node_overlap": 0.016983208987821713,
-            "node_connector_overlap": 0.011949426625439605,
-            "label_overlap": 0.08841528396101503,
-            "crossings": 1.3165829145728642,
-            "sprawl": 2.544857043854582,
-            "edge_length_cv": 0.6792580016732231,
+            "node_overlap": 0.015790345795576758,
+            "node_connector_overlap": 0.011323093092217297,
+            "label_overlap": 0.2608695652173913,
+            "crossings": 1.4321608040201006,
+            "sprawl": 2.4684532050078287,
+            "edge_length_cv": 0.6707229278420446,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.8771992780038026
+            "loop_compactness": 0.8601128693414721,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8478260869565217
           },
-          "weighted_cost": 1.9077163580335494
+          "weighted_cost": 2.6426622055590925
         },
         {
           "seed": 789,
           "metrics": {
-            "node_overlap": 0.017144973806290018,
-            "node_connector_overlap": 0.013633793877145686,
-            "label_overlap": 0.08005391610451887,
-            "crossings": 1.2663316582914572,
-            "sprawl": 2.5683538177038265,
-            "edge_length_cv": 0.684277153910954,
+            "node_overlap": 0.015790345795576755,
+            "node_connector_overlap": 0.011526400216425531,
+            "label_overlap": 0.0,
+            "crossings": 1.4949748743718594,
+            "sprawl": 2.442018504558439,
+            "edge_length_cv": 0.6897355492379993,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7635343514521393
+            "loop_compactness": 0.8680142533534396,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8478260869565217
           },
-          "weighted_cost": 1.8248833117128294
+          "weighted_cost": 2.4426836313325775
         }
       ],
-      "median_cost": 2.054100572352869,
+      "median_cost": 2.4424571012940914,
       "spread": [
-        1.816146946263299,
-        2.4747855214116967
+        2.326806839805879,
+        2.515198660840917
       ],
-      "best_of_k_cost": 1.8248833117128294,
-      "best_seed": 3,
-      "median_seed": 0,
-      "worst_seed": 42
+      "best_of_k_cost": 2.4426836313325775,
+      "best_seed": 0,
+      "median_seed": 7,
+      "worst_seed": 456
     },
     {
       "model": "beer_game",
@@ -3304,193 +3712,217 @@
         {
           "seed": 0,
           "metrics": {
-            "node_overlap": 0.017662588880415282,
-            "node_connector_overlap": 0.0013758017848263734,
-            "label_overlap": 0.0567296005289951,
-            "crossings": 0.9,
-            "sprawl": 6.24857383770245,
-            "edge_length_cv": 0.5253542275570826,
+            "node_overlap": 0.029446246966763904,
+            "node_connector_overlap": 0.017133000809880207,
+            "label_overlap": 0.0,
+            "crossings": 0.65,
+            "sprawl": 2.5150137808120516,
+            "edge_length_cv": 0.44009345332440797,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6941222980826653
+            "loop_compactness": 0.685757139303958,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8461538461538461
           },
-          "weighted_cost": 1.774155949485148
+          "weighted_cost": 1.558500244276022
         },
         {
           "seed": 1,
           "metrics": {
-            "node_overlap": 0.017662588880415282,
-            "node_connector_overlap": 0.0013758017848263734,
-            "label_overlap": 0.0567296005289951,
-            "crossings": 0.9,
-            "sprawl": 6.24857383770245,
-            "edge_length_cv": 0.5253542275570826,
+            "node_overlap": 0.0328717090245016,
+            "node_connector_overlap": 0.02531304420242634,
+            "label_overlap": 0.0,
+            "crossings": 0.7,
+            "sprawl": 2.010687433973158,
+            "edge_length_cv": 0.46350612105814093,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6941222980826653
+            "loop_compactness": 0.7055014757109696,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8461538461538461
           },
-          "weighted_cost": 1.774155949485148
+          "weighted_cost": 1.527138214921332
         },
         {
           "seed": 2,
           "metrics": {
-            "node_overlap": 0.036102289821159976,
-            "node_connector_overlap": 0.021803819750933782,
-            "label_overlap": 0.0301468463876485,
-            "crossings": 0.76,
-            "sprawl": 2.1676684884083053,
-            "edge_length_cv": 0.6447575573407051,
+            "node_overlap": 0.029446246966763904,
+            "node_connector_overlap": 0.017133000809880207,
+            "label_overlap": 0.0,
+            "crossings": 0.65,
+            "sprawl": 2.5150137808120516,
+            "edge_length_cv": 0.44009345332440797,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.71598301618661
+            "loop_compactness": 0.685757139303958,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8461538461538461
           },
-          "weighted_cost": 1.2438155588472253
+          "weighted_cost": 1.558500244276022
         },
         {
           "seed": 3,
           "metrics": {
-            "node_overlap": 0.0173276434398212,
-            "node_connector_overlap": 0.00522653246228744,
-            "label_overlap": 0.03221209473837633,
-            "crossings": 0.76,
-            "sprawl": 6.118900778139194,
-            "edge_length_cv": 0.5745208408231924,
+            "node_overlap": 0.033052792654934965,
+            "node_connector_overlap": 0.024737522862067245,
+            "label_overlap": 0.0,
+            "crossings": 0.63,
+            "sprawl": 2.082306682948479,
+            "edge_length_cv": 0.4872128821275265,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6905249279340181
+            "loop_compactness": 0.6988574379764088,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8461538461538461
           },
-          "weighted_cost": 1.599287580437909
+          "weighted_cost": 1.4684100119126462
         },
         {
           "seed": 4,
           "metrics": {
-            "node_overlap": 0.017662588880415282,
-            "node_connector_overlap": 0.0013758017848263734,
-            "label_overlap": 0.0567296005289951,
-            "crossings": 0.9,
-            "sprawl": 6.24857383770245,
-            "edge_length_cv": 0.5253542275570826,
+            "node_overlap": 0.032692598758892084,
+            "node_connector_overlap": 0.024086730915249828,
+            "label_overlap": 0.0,
+            "crossings": 0.64,
+            "sprawl": 1.994634735862889,
+            "edge_length_cv": 0.47796737186002575,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6941222980826653
+            "loop_compactness": 0.6881830187329596,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8461538461538461
           },
-          "weighted_cost": 1.774155949485148
+          "weighted_cost": 1.455594868955288
         },
         {
           "seed": 5,
           "metrics": {
-            "node_overlap": 0.017662588880415282,
-            "node_connector_overlap": 0.0013758017848263734,
-            "label_overlap": 0.0567296005289951,
-            "crossings": 0.9,
-            "sprawl": 6.24857383770245,
-            "edge_length_cv": 0.5253542275570826,
+            "node_overlap": 0.02944624696676391,
+            "node_connector_overlap": 0.014162277200417177,
+            "label_overlap": 0.0,
+            "crossings": 0.7,
+            "sprawl": 2.5379489326508335,
+            "edge_length_cv": 0.4868670559551512,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6941222980826653
+            "loop_compactness": 0.7406286565308288,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8461538461538461
           },
-          "weighted_cost": 1.774155949485148
+          "weighted_cost": 1.632065157925064
         },
         {
           "seed": 6,
           "metrics": {
-            "node_overlap": 0.01766258888041528,
-            "node_connector_overlap": 0.0015895949414331378,
-            "label_overlap": 0.0567296005289951,
-            "crossings": 0.92,
-            "sprawl": 6.218385823262977,
-            "edge_length_cv": 0.5337816729377975,
+            "node_overlap": 0.02944624696676391,
+            "node_connector_overlap": 0.015091972533178967,
+            "label_overlap": 0.0,
+            "crossings": 0.66,
+            "sprawl": 2.499588682224831,
+            "edge_length_cv": 0.46767479443480164,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.726037507396799
+            "loop_compactness": 0.7318127728530209,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8461538461538461
           },
-          "weighted_cost": 1.7993297435263411
+          "weighted_cost": 1.581796449701502
         },
         {
           "seed": 7,
           "metrics": {
-            "node_overlap": 0.022284223718749985,
-            "node_connector_overlap": 0.0038191040633412375,
+            "node_overlap": 0.03323588244345284,
+            "node_connector_overlap": 0.0290500856866868,
             "label_overlap": 0.0,
-            "crossings": 0.82,
-            "sprawl": 4.700337752064914,
-            "edge_length_cv": 0.5622594755646577,
+            "crossings": 0.59,
+            "sprawl": 2.0204139515431367,
+            "edge_length_cv": 0.48988640469882405,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7085948362121849
+            "loop_compactness": 0.6779565732111612,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8461538461538461
           },
-          "weighted_cost": 1.4932858120416286
+          "weighted_cost": 1.412166772338616
         },
         {
           "seed": 42,
           "metrics": {
-            "node_overlap": 0.033052792654934965,
-            "node_connector_overlap": 0.014425475478638015,
+            "node_overlap": 0.029446246966763904,
+            "node_connector_overlap": 0.017133000809880207,
             "label_overlap": 0.0,
-            "crossings": 0.83,
-            "sprawl": 2.7641320364741304,
-            "edge_length_cv": 0.5755457850238214,
+            "crossings": 0.65,
+            "sprawl": 2.5150137808120516,
+            "edge_length_cv": 0.44009345332440797,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7220661879028553
+            "loop_compactness": 0.685757139303958,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8461538461538461
           },
-          "weighted_cost": 1.3344080187566998
+          "weighted_cost": 1.558500244276022
         },
         {
           "seed": 123,
           "metrics": {
-            "node_overlap": 0.017615431165621878,
-            "node_connector_overlap": 0.0014502126466618972,
-            "label_overlap": 0.0567296005289951,
-            "crossings": 0.85,
-            "sprawl": 6.236563866780379,
-            "edge_length_cv": 0.5272957693656422,
+            "node_overlap": 0.03323588244345284,
+            "node_connector_overlap": 0.025411267521769615,
+            "label_overlap": 0.0,
+            "crossings": 0.67,
+            "sprawl": 2.0596465582892427,
+            "edge_length_cv": 0.4570418348351993,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6920812697860758
+            "loop_compactness": 0.7338360215760534,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8461538461538461
           },
-          "weighted_cost": 1.722471948465836
+          "weighted_cost": 1.5187262548688771
         },
         {
           "seed": 456,
           "metrics": {
-            "node_overlap": 0.03234017068423419,
-            "node_connector_overlap": 0.03198463944647778,
+            "node_overlap": 0.0328717090245016,
+            "node_connector_overlap": 0.06150163637319987,
             "label_overlap": 0.0,
             "crossings": 0.59,
-            "sprawl": 2.691399854564319,
-            "edge_length_cv": 0.6512621263768991,
+            "sprawl": 2.009170025682547,
+            "edge_length_cv": 0.5209063958879556,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7261496282832239
+            "loop_compactness": 0.7200247915273112,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8461538461538461
           },
-          "weighted_cost": 1.1050022026579498
+          "weighted_cost": 1.45883265176052
         },
         {
           "seed": 789,
           "metrics": {
-            "node_overlap": 0.03632083403396673,
-            "node_connector_overlap": 0.029405257125580432,
-            "label_overlap": 0.026520238797641673,
-            "crossings": 0.73,
-            "sprawl": 2.1846667269422086,
-            "edge_length_cv": 0.6175833600874707,
+            "node_overlap": 0.029446246966763904,
+            "node_connector_overlap": 0.019095047467563353,
+            "label_overlap": 0.0,
+            "crossings": 0.63,
+            "sprawl": 2.5520377966516854,
+            "edge_length_cv": 0.4357793844159173,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6908636915410801
+            "loop_compactness": 0.6857571393039583,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.8461538461538461
           },
-          "weighted_cost": 1.2134289255366797
+          "weighted_cost": 1.5478670941016321
         }
       ],
-      "median_cost": 1.6608797644518725,
+      "median_cost": 1.537502654511482,
       "spread": [
-        1.311759903779331,
-        1.774155949485148
+        1.4660156718746147,
+        1.558500244276022
       ],
-      "best_of_k_cost": 1.1050022026579498,
-      "best_seed": 456,
-      "median_seed": 3,
-      "worst_seed": 6
+      "best_of_k_cost": 1.45883265176052,
+      "best_seed": 7,
+      "median_seed": 1,
+      "worst_seed": 5
     },
     {
       "model": "wonderland",
@@ -3498,193 +3930,217 @@
         {
           "seed": 0,
           "metrics": {
-            "node_overlap": 0.02617864501272573,
-            "node_connector_overlap": 0.009525091788782872,
-            "label_overlap": 0.05375854736382184,
+            "node_overlap": 0.02617864501272576,
+            "node_connector_overlap": 0.012005305088275325,
+            "label_overlap": 0.05793480117648287,
             "crossings": 0.1346153846153846,
-            "sprawl": 1.9368756521020267,
-            "edge_length_cv": 0.5695973966780598,
+            "sprawl": 1.513349360347758,
+            "edge_length_cv": 0.5657597957286353,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5952364529515817
+            "loop_compactness": 0.6521605242362543,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6153846153846154
           },
-          "weighted_cost": 0.5665743472288132
+          "weighted_cost": 0.8558066791953833
         },
         {
           "seed": 1,
           "metrics": {
             "node_overlap": 0.02617864501272573,
-            "node_connector_overlap": 0.01294147943178973,
-            "label_overlap": 0.05375854736382184,
-            "crossings": 0.11538461538461539,
-            "sprawl": 1.972912769291543,
-            "edge_length_cv": 0.5555032941265796,
+            "node_connector_overlap": 0.005542364861480269,
+            "label_overlap": 0.05479369808549754,
+            "crossings": 0.1346153846153846,
+            "sprawl": 1.4571803053552428,
+            "edge_length_cv": 0.5918294099145847,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.61350870639707
+            "loop_compactness": 0.48166469605376566,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6153846153846154
           },
-          "weighted_cost": 0.5589317407213745
+          "weighted_cost": 0.7667704936061046
         },
         {
           "seed": 2,
           "metrics": {
-            "node_overlap": 0.026178645012725727,
-            "node_connector_overlap": 0.00484056033342482,
-            "label_overlap": 0.055853220700274514,
-            "crossings": 0.1346153846153846,
-            "sprawl": 1.9992486203549957,
-            "edge_length_cv": 0.5642800865991534,
+            "node_overlap": 0.02617864501272573,
+            "node_connector_overlap": 0.014472351378418189,
+            "label_overlap": 0.43491124978192264,
+            "crossings": 0.15384615384615385,
+            "sprawl": 1.4504382942734781,
+            "edge_length_cv": 0.5680100171972058,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5363256965768411
+            "loop_compactness": 0.5379659453871359,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6153846153846154
           },
-          "weighted_cost": 0.5554940968415195
+          "weighted_cost": 1.196220898567232
         },
         {
           "seed": 3,
           "metrics": {
             "node_overlap": 0.02617864501272573,
-            "node_connector_overlap": 0.009169101767542959,
-            "label_overlap": 0.054231709583896566,
-            "crossings": 0.11538461538461539,
-            "sprawl": 2.011808070607132,
-            "edge_length_cv": 0.5600647132670614,
+            "node_connector_overlap": 0.00923938598761689,
+            "label_overlap": 0.05744041490857642,
+            "crossings": 0.15384615384615385,
+            "sprawl": 1.5219965364277397,
+            "edge_length_cv": 0.5661788104752684,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6197971156390025
+            "loop_compactness": 0.47216302249773134,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6153846153846154
           },
-          "weighted_cost": 0.5610941577192445
+          "weighted_cost": 0.8015075775781749
         },
         {
           "seed": 4,
           "metrics": {
-            "node_overlap": 0.02617864501272573,
-            "node_connector_overlap": 0.009525091788782872,
-            "label_overlap": 0.05375854736382184,
-            "crossings": 0.1346153846153846,
-            "sprawl": 1.9368756521020267,
-            "edge_length_cv": 0.5695973966780598,
+            "node_overlap": 0.02584041153247996,
+            "node_connector_overlap": 0.014761322169851415,
+            "label_overlap": 0.06251303305094898,
+            "crossings": 0.11538461538461539,
+            "sprawl": 1.4557173274998958,
+            "edge_length_cv": 0.6473545550538722,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5952364529515817
+            "loop_compactness": 0.5335232531681342,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6153846153846154
           },
-          "weighted_cost": 0.5665743472288132
+          "weighted_cost": 0.7845906104435901
         },
         {
           "seed": 5,
           "metrics": {
             "node_overlap": 0.02617864501272573,
-            "node_connector_overlap": 0.009525091788782872,
-            "label_overlap": 0.05375854736382184,
-            "crossings": 0.1346153846153846,
-            "sprawl": 1.9368756521020267,
-            "edge_length_cv": 0.5695973966780598,
+            "node_connector_overlap": 0.016171780908997326,
+            "label_overlap": 0.05684712256717363,
+            "crossings": 0.21153846153846154,
+            "sprawl": 1.446409522320342,
+            "edge_length_cv": 0.6119508656460726,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5952364529515817
+            "loop_compactness": 0.49107389469874596,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6153846153846154
           },
-          "weighted_cost": 0.5665743472288132
+          "weighted_cost": 0.8579859339093865
         },
         {
           "seed": 6,
           "metrics": {
-            "node_overlap": 0.02617864501272573,
-            "node_connector_overlap": 0.01160601091017705,
-            "label_overlap": 0.052190647980833185,
-            "crossings": 0.09615384615384616,
-            "sprawl": 1.9600680837391,
-            "edge_length_cv": 0.6216422402267461,
+            "node_overlap": 0.01719667036336946,
+            "node_connector_overlap": 0.008420348194647155,
+            "label_overlap": 0.029966413478587774,
+            "crossings": 0.19230769230769232,
+            "sprawl": 5.68910187773312,
+            "edge_length_cv": 0.4770500841408981,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6141748202964967
+            "loop_compactness": 0.5343484186756164,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6153846153846154
           },
-          "weighted_cost": 0.5356796635056164
+          "weighted_cost": 1.660989328899629
         },
         {
           "seed": 7,
           "metrics": {
             "node_overlap": 0.02617864501272573,
-            "node_connector_overlap": 0.009525091788782872,
-            "label_overlap": 0.05375854736382184,
-            "crossings": 0.1346153846153846,
-            "sprawl": 1.9368756521020267,
-            "edge_length_cv": 0.5695973966780598,
+            "node_connector_overlap": 0.013015432708125456,
+            "label_overlap": 0.061726216331882314,
+            "crossings": 0.15384615384615385,
+            "sprawl": 1.4542258813732665,
+            "edge_length_cv": 0.5631581836353289,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5952364529515817
+            "loop_compactness": 0.5240520484752231,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6153846153846154
           },
-          "weighted_cost": 0.5665743472288132
+          "weighted_cost": 0.8167709051020915
         },
         {
           "seed": 42,
           "metrics": {
-            "node_overlap": 0.026178645012725727,
-            "node_connector_overlap": 0.01535690367308697,
-            "label_overlap": 0.053546136283824194,
-            "crossings": 0.07692307692307693,
-            "sprawl": 1.924907973889892,
-            "edge_length_cv": 0.6171283181832727,
+            "node_overlap": 0.02617864501272573,
+            "node_connector_overlap": 0.006561082178295447,
+            "label_overlap": 0.055264268121373555,
+            "crossings": 0.11538461538461539,
+            "sprawl": 1.4824994069404818,
+            "edge_length_cv": 0.5716290091088273,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.4127210807425616
+            "loop_compactness": 0.5216707279949413,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6153846153846154
           },
-          "weighted_cost": 0.4676758294673435
+          "weighted_cost": 0.7700952448215446
         },
         {
           "seed": 123,
           "metrics": {
             "node_overlap": 0.02617864501272573,
-            "node_connector_overlap": 0.008938604939279057,
-            "label_overlap": 0.0568580752953885,
+            "node_connector_overlap": 0.010153826828517025,
+            "label_overlap": 0.4486259662720202,
             "crossings": 0.1346153846153846,
-            "sprawl": 1.9020337435597103,
-            "edge_length_cv": 0.634382054535096,
+            "sprawl": 1.501344051351043,
+            "edge_length_cv": 0.6350349742195764,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5773996206842658
+            "loop_compactness": 0.6231344218760133,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6153846153846154
           },
-          "weighted_cost": 0.5611439893898154
+          "weighted_cost": 1.230634863287723
         },
         {
           "seed": 456,
           "metrics": {
             "node_overlap": 0.02617864501272573,
-            "node_connector_overlap": 0.009525091788782872,
-            "label_overlap": 0.05375854736382184,
+            "node_connector_overlap": 0.014151629345203216,
+            "label_overlap": 0.061726216331882314,
             "crossings": 0.1346153846153846,
-            "sprawl": 1.9368756521020267,
-            "edge_length_cv": 0.5695973966780598,
+            "sprawl": 1.4445477925760057,
+            "edge_length_cv": 0.5659945704654727,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5952364529515817
+            "loop_compactness": 0.5878985778713302,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6153846153846154
           },
-          "weighted_cost": 0.5665743472288132
+          "weighted_cost": 0.8222793265073907
         },
         {
           "seed": 789,
           "metrics": {
             "node_overlap": 0.02617864501272573,
-            "node_connector_overlap": 0.011352413283414924,
-            "label_overlap": 0.05375854736382184,
-            "crossings": 0.1346153846153846,
-            "sprawl": 1.944965921400355,
-            "edge_length_cv": 0.5633814418623334,
+            "node_connector_overlap": 0.0029599367444394075,
+            "label_overlap": 0.062330170086129566,
+            "crossings": 0.19230769230769232,
+            "sprawl": 1.3581715581303329,
+            "edge_length_cv": 0.7373413525099772,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5960945988962876
+            "loop_compactness": 0.7124993063621157,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6153846153846154
           },
-          "weighted_cost": 0.5694252321394545
+          "weighted_cost": 0.9019489398603614
         }
       ],
-      "median_cost": 0.5638591683093143,
+      "median_cost": 0.839043002851387,
       "spread": [
-        0.5580723297514107,
-        0.5665743472288132
+        0.7972783357945287,
+        0.975516929537079
       ],
-      "best_of_k_cost": 0.4676758294673435,
-      "best_seed": 42,
+      "best_of_k_cost": 0.7700952448215446,
+      "best_seed": 1,
       "median_seed": 0,
-      "worst_seed": 789
+      "worst_seed": 6
     },
     {
       "model": "scirev",
@@ -3692,193 +4148,217 @@
         {
           "seed": 0,
           "metrics": {
-            "node_overlap": 0.0030163357188578792,
-            "node_connector_overlap": 0.028005195469312676,
-            "label_overlap": 0.022727272727272728,
-            "crossings": 1.9163179916317992,
-            "sprawl": 5.406930235285493,
-            "edge_length_cv": 0.48140650559621107,
+            "node_overlap": 0.003054492961650663,
+            "node_connector_overlap": 0.03736832116527603,
+            "label_overlap": 0.03378478526787733,
+            "crossings": 2.5313807531380754,
+            "sprawl": 4.525226395378209,
+            "edge_length_cv": 0.4685234939589514,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.8188876018902156
+            "loop_compactness": 0.8051977327874777,
+            "flow_bends": 0.23076923076923078,
+            "loop_straightness": 1.0
           },
-          "weighted_cost": 2.715481719548346
+          "weighted_cost": 3.9673281093388972
         },
         {
           "seed": 1,
           "metrics": {
-            "node_overlap": 0.01286392328593878,
-            "node_connector_overlap": 0.03904051836935182,
-            "label_overlap": 0.007347015146626237,
-            "crossings": 1.9539748953974896,
-            "sprawl": 2.1543249273982346,
-            "edge_length_cv": 0.5334649264638169,
+            "node_overlap": 0.003017934553240774,
+            "node_connector_overlap": 0.03676973187567564,
+            "label_overlap": 0.028225806451612902,
+            "crossings": 2.1255230125523012,
+            "sprawl": 4.185192037518877,
+            "edge_length_cv": 0.47433962886409825,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.8074085099515245
+            "loop_compactness": 0.8150458038831379,
+            "flow_bends": 0.3076923076923077,
+            "loop_straightness": 1.0
           },
-          "weighted_cost": 2.4305109724271112
+          "weighted_cost": 3.502747060643707
         },
         {
           "seed": 2,
           "metrics": {
-            "node_overlap": 0.006128788237794964,
-            "node_connector_overlap": 0.02142634257684445,
-            "label_overlap": 0.012057521215070494,
-            "crossings": 2.3305439330543933,
-            "sprawl": 3.5859620960517042,
-            "edge_length_cv": 0.48168744529584184,
+            "node_overlap": 0.008844783277554252,
+            "node_connector_overlap": 0.04589306070638068,
+            "label_overlap": 0.0,
+            "crossings": 2.288702928870293,
+            "sprawl": 2.3028538477848266,
+            "edge_length_cv": 0.4915751705844835,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.8787222640688567
+            "loop_compactness": 0.8655895834130762,
+            "flow_bends": 0.15384615384615385,
+            "loop_straightness": 1.0
           },
-          "weighted_cost": 2.948433360706488
+          "weighted_cost": 3.273324298853347
         },
         {
           "seed": 3,
           "metrics": {
-            "node_overlap": 0.0030163357188578875,
-            "node_connector_overlap": 0.028746184573386343,
-            "label_overlap": 0.017857142857142856,
-            "crossings": 2.6820083682008367,
-            "sprawl": 5.7231599556828545,
-            "edge_length_cv": 0.5121096353872975,
+            "node_overlap": 0.0031765293795181287,
+            "node_connector_overlap": 0.033910146327249154,
+            "label_overlap": 0.07108433734940683,
+            "crossings": 2.3682008368200838,
+            "sprawl": 4.474547407415176,
+            "edge_length_cv": 0.5499335572840354,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7433944500661069
+            "loop_compactness": 0.8823655387695712,
+            "flow_bends": 0.3076923076923077,
+            "loop_straightness": 1.0
           },
-          "weighted_cost": 3.4897926394350365
+          "weighted_cost": 3.8703813930209674
         },
         {
           "seed": 4,
           "metrics": {
-            "node_overlap": 0.0030179345532407777,
-            "node_connector_overlap": 0.03202490330848322,
-            "label_overlap": 0.05,
-            "crossings": 2.0209205020920504,
-            "sprawl": 5.415241763631539,
-            "edge_length_cv": 0.4887552735722597,
+            "node_overlap": 0.0031782122339010627,
+            "node_connector_overlap": 0.031132335514188043,
+            "label_overlap": 0.04216867469879518,
+            "crossings": 2.1715481171548117,
+            "sprawl": 4.272307821858353,
+            "edge_length_cv": 0.460931649762885,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.8480153839226886
+            "loop_compactness": 0.8537049763028427,
+            "flow_bends": 0.3076923076923077,
+            "loop_straightness": 1.0
           },
-          "weighted_cost": 2.859491362297601
+          "weighted_cost": 3.5901247406483496
         },
         {
           "seed": 5,
           "metrics": {
-            "node_overlap": 0.01814195984332548,
-            "node_connector_overlap": 0.04262889558943696,
-            "label_overlap": 0.11233884007651083,
-            "crossings": 2.0292887029288704,
-            "sprawl": 1.6952137559215488,
-            "edge_length_cv": 0.5201585509494606,
+            "node_overlap": 0.0033400887489442085,
+            "node_connector_overlap": 0.0410836590576568,
+            "label_overlap": 0.088941480206552,
+            "crossings": 2.2594142259414225,
+            "sprawl": 4.330850195537304,
+            "edge_length_cv": 0.4953082505302481,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.8447773768385787
+            "loop_compactness": 0.8668556038568427,
+            "flow_bends": 0.3076923076923077,
+            "loop_straightness": 1.0
           },
-          "weighted_cost": 2.5831141182399433
+          "weighted_cost": 3.75184558075862
         },
         {
           "seed": 6,
           "metrics": {
-            "node_overlap": 0.012834477349088595,
-            "node_connector_overlap": 0.03879152503836566,
-            "label_overlap": 0.006253105058500097,
-            "crossings": 1.8661087866108788,
-            "sprawl": 2.053251966344979,
-            "edge_length_cv": 0.5252305062598752,
+            "node_overlap": 0.0030163357188578927,
+            "node_connector_overlap": 0.03882600310163627,
+            "label_overlap": 0.02108433734939759,
+            "crossings": 2.5313807531380754,
+            "sprawl": 4.278187466149768,
+            "edge_length_cv": 0.489320221808483,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7456897100578803
+            "loop_compactness": 0.8575774501844523,
+            "flow_bends": 0.3076923076923077,
+            "loop_straightness": 1.0
           },
-          "weighted_cost": 2.315735518205801
+          "weighted_cost": 3.9391297487655477
         },
         {
           "seed": 7,
           "metrics": {
-            "node_overlap": 0.01286392328593878,
-            "node_connector_overlap": 0.029821045263786747,
-            "label_overlap": 0.006208888949518813,
-            "crossings": 1.891213389121339,
-            "sprawl": 2.1170397632431524,
-            "edge_length_cv": 0.5101664794979154,
+            "node_overlap": 0.0030179345532407678,
+            "node_connector_overlap": 0.03879519501531315,
+            "label_overlap": 0.028225806451612902,
+            "crossings": 1.9665271966527196,
+            "sprawl": 4.182038063866251,
+            "edge_length_cv": 0.5055823162396889,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7138275141171839
+            "loop_compactness": 0.7797449999321169,
+            "flow_bends": 0.3076923076923077,
+            "loop_straightness": 1.0
           },
-          "weighted_cost": 2.3302681014741946
+          "weighted_cost": 3.3310255915728297
         },
         {
           "seed": 42,
           "metrics": {
-            "node_overlap": 0.008844783277554223,
-            "node_connector_overlap": 0.025646326352350684,
-            "label_overlap": 0.0,
-            "crossings": 1.7698744769874477,
-            "sprawl": 2.7335910373852053,
-            "edge_length_cv": 0.5405674874746326,
+            "node_overlap": 0.0030179345532407786,
+            "node_connector_overlap": 0.04504639924977587,
+            "label_overlap": 0.028225806451612902,
+            "crossings": 2.071129707112971,
+            "sprawl": 4.157823908112761,
+            "edge_length_cv": 0.4855521108372051,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7564945353057686
+            "loop_compactness": 0.7946962868114376,
+            "flow_bends": 0.3076923076923077,
+            "loop_straightness": 1.0
           },
-          "weighted_cost": 2.266848324182315
+          "weighted_cost": 3.4430169898685734
         },
         {
           "seed": 123,
           "metrics": {
-            "node_overlap": 0.0030179345532407786,
-            "node_connector_overlap": 0.035771679615317464,
-            "label_overlap": 0.05,
-            "crossings": 2.2510460251046025,
-            "sprawl": 5.559977071368,
-            "edge_length_cv": 0.4932704735822467,
+            "node_overlap": 0.00882951251094925,
+            "node_connector_overlap": 0.04678445545218922,
+            "label_overlap": 0.0,
+            "crossings": 2.0251046025104604,
+            "sprawl": 2.1468711179563367,
+            "edge_length_cv": 0.4851011766911578,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.8638008895762934
+            "loop_compactness": 0.7343177052226957,
+            "flow_bends": 0.15384615384615385,
+            "loop_straightness": 1.0
           },
-          "weighted_cost": 3.111783568804034
+          "weighted_cost": 2.926896799230868
         },
         {
           "seed": 456,
           "metrics": {
-            "node_overlap": 0.01809025334271636,
-            "node_connector_overlap": 0.04279697167252383,
-            "label_overlap": 0.11059942681175312,
-            "crossings": 2.0502092050209204,
-            "sprawl": 1.6939232076640536,
-            "edge_length_cv": 0.535025603929376,
+            "node_overlap": 0.0030163357188578528,
+            "node_connector_overlap": 0.037510367539945876,
+            "label_overlap": 0.02108433734940307,
+            "crossings": 2.062761506276151,
+            "sprawl": 4.269747690916647,
+            "edge_length_cv": 0.47446374755125054,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7713614838275408
+            "loop_compactness": 0.8442884162162339,
+            "flow_bends": 0.3076923076923077,
+            "loop_straightness": 1.0
           },
-          "weighted_cost": 2.5839285485712042
+          "weighted_cost": 3.4621912977080265
         },
         {
           "seed": 789,
           "metrics": {
-            "node_overlap": 0.008829512510949303,
-            "node_connector_overlap": 0.04021105235215466,
-            "label_overlap": 0.0,
-            "crossings": 2.1297071129707112,
-            "sprawl": 2.8541986016906082,
-            "edge_length_cv": 0.5086782920690742,
+            "node_overlap": 0.006128788237794972,
+            "node_connector_overlap": 0.03405854750367748,
+            "label_overlap": 0.009157262889271461,
+            "crossings": 1.8451882845188285,
+            "sprawl": 2.7667208133505996,
+            "edge_length_cv": 0.50576315802094,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7901676233963436
+            "loop_compactness": 0.7159114140931172,
+            "flow_bends": 0.15384615384615385,
+            "loop_straightness": 1.0
           },
-          "weighted_cost": 2.661709443851962
+          "weighted_cost": 2.8573185345338623
         }
       ],
-      "median_cost": 2.622818996211583,
+      "median_cost": 3.482469179175867,
       "spread": [
-        2.405450254688882,
-        2.881726861899823
+        3.3166002683929587,
+        3.781479533824207
       ],
-      "best_of_k_cost": 2.266848324182315,
-      "best_seed": 42,
-      "median_seed": 456,
-      "worst_seed": 3
+      "best_of_k_cost": 2.8573185345338623,
+      "best_seed": 789,
+      "median_seed": 1,
+      "worst_seed": 0
     },
     {
       "model": "thyroid",
@@ -3886,192 +4366,216 @@
         {
           "seed": 0,
           "metrics": {
-            "node_overlap": 0.5907319042725002,
-            "node_connector_overlap": 0.09574856156536189,
-            "label_overlap": 6.857142857142858,
-            "crossings": 1.122093023255814,
-            "sprawl": 3.227248487459677,
-            "edge_length_cv": 0.8051325301807163,
+            "node_overlap": 0.9475094291329813,
+            "node_connector_overlap": 0.16311509059310642,
+            "label_overlap": 8.0,
+            "crossings": 1.5465116279069768,
+            "sprawl": 4.593256766713006,
+            "edge_length_cv": 0.6655162731800662,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7978859842478355
+            "loop_compactness": 0.8220632669372514,
+            "flow_bends": 0.5161290322580645,
+            "loop_straightness": 0.8421052631578947
           },
-          "weighted_cost": 9.187912691044462
+          "weighted_cost": 12.066242688905067
         },
         {
           "seed": 1,
           "metrics": {
-            "node_overlap": 0.5922972177241284,
-            "node_connector_overlap": 0.09510489938159968,
-            "label_overlap": 6.857142857142858,
-            "crossings": 1.063953488372093,
-            "sprawl": 3.2684188708317454,
-            "edge_length_cv": 0.7820398968435773,
-            "aspect_penalty": 0.030994069299540516,
+            "node_overlap": 0.9473664070893877,
+            "node_connector_overlap": 0.15699694971855294,
+            "label_overlap": 8.0,
+            "crossings": 1.5174418604651163,
+            "sprawl": 4.613256810418719,
+            "edge_length_cv": 0.6650933998969977,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7938897536051591
+            "loop_compactness": 0.8357804530190079,
+            "flow_bends": 0.5161290322580645,
+            "loop_straightness": 0.8421052631578947
           },
-          "weighted_cost": 9.133812788105143
+          "weighted_cost": 12.040398641718904
         },
         {
           "seed": 2,
           "metrics": {
-            "node_overlap": 0.7174709354361295,
-            "node_connector_overlap": 0.09762081088008452,
-            "label_overlap": 6.24925251566232,
-            "crossings": 1.180232558139535,
-            "sprawl": 3.7691463523303597,
-            "edge_length_cv": 0.8061602526245092,
-            "aspect_penalty": 0.003749204296805697,
+            "node_overlap": 0.9474669000421844,
+            "node_connector_overlap": 0.15961585329189093,
+            "label_overlap": 8.0,
+            "crossings": 1.5348837209302326,
+            "sprawl": 4.589905760685724,
+            "edge_length_cv": 0.6508028889301408,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7940773093436689
+            "loop_compactness": 0.8232218390085322,
+            "flow_bends": 0.5161290322580645,
+            "loop_straightness": 0.8421052631578947
           },
-          "weighted_cost": 8.820010782687023
+          "weighted_cost": 12.050866243159366
         },
         {
           "seed": 3,
           "metrics": {
-            "node_overlap": 0.7180758183404274,
-            "node_connector_overlap": 0.09907585655891261,
-            "label_overlap": 6.283031865068345,
-            "crossings": 1.127906976744186,
-            "sprawl": 3.7766827375843395,
-            "edge_length_cv": 0.792491615423253,
-            "aspect_penalty": 0.023461877265002817,
+            "node_overlap": 0.7150615602572254,
+            "node_connector_overlap": 0.15276654382128033,
+            "label_overlap": 6.249021709201575,
+            "crossings": 1.436046511627907,
+            "sprawl": 2.969212154628184,
+            "edge_length_cv": 0.6906897779485318,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7948275350069339
+            "loop_compactness": 0.825165900336323,
+            "flow_bends": 0.3870967741935484,
+            "loop_straightness": 0.8421052631578947
           },
-          "weighted_cost": 8.804465674222039
+          "weighted_cost": 9.619080158412975
         },
         {
           "seed": 4,
           "metrics": {
-            "node_overlap": 0.9474934190722155,
-            "node_connector_overlap": 0.1050018382622357,
-            "label_overlap": 8.132352941176471,
-            "crossings": 1.1569767441860466,
-            "sprawl": 5.693649309625779,
-            "edge_length_cv": 0.7838866724011592,
+            "node_overlap": 0.8120833602440553,
+            "node_connector_overlap": 0.15000562392360767,
+            "label_overlap": 6.032608695652174,
+            "crossings": 1.4186046511627908,
+            "sprawl": 3.4645371817711528,
+            "edge_length_cv": 0.674328783426335,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7898613066027019
+            "loop_compactness": 0.8280517525504121,
+            "flow_bends": 0.3870967741935484,
+            "loop_straightness": 0.8421052631578947
           },
-          "weighted_cost": 11.108655200310222
+          "weighted_cost": 9.579705510801846
         },
         {
           "seed": 5,
           "metrics": {
-            "node_overlap": 0.8129208013398859,
-            "node_connector_overlap": 0.09716659110031145,
-            "label_overlap": 6.0,
-            "crossings": 1.2034883720930232,
-            "sprawl": 4.3059960728826585,
-            "edge_length_cv": 0.7844040759907935,
+            "node_overlap": 0.7174709354361297,
+            "node_connector_overlap": 0.15221434524351232,
+            "label_overlap": 6.283548608839896,
+            "crossings": 1.4593023255813953,
+            "sprawl": 3.010044657139332,
+            "edge_length_cv": 0.6824517450565238,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7974775110012257
+            "loop_compactness": 0.8167443447357939,
+            "flow_bends": 0.3870967741935484,
+            "loop_straightness": 0.8421052631578947
           },
-          "weighted_cost": 8.743544749571791
+          "weighted_cost": 9.683517926867939
         },
         {
           "seed": 6,
           "metrics": {
-            "node_overlap": 0.7168670707401327,
-            "node_connector_overlap": 0.09909293266251276,
-            "label_overlap": 6.249353226724383,
-            "crossings": 1.1511627906976745,
-            "sprawl": 3.760388547874569,
-            "edge_length_cv": 0.7957786778697821,
-            "aspect_penalty": 0.012206100972169898,
+            "node_overlap": 0.7156623857065336,
+            "node_connector_overlap": 0.15420855315247817,
+            "label_overlap": 6.28809697258654,
+            "crossings": 1.3662790697674418,
+            "sprawl": 3.0106158321082033,
+            "edge_length_cv": 0.6754181753025363,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7972735404534678
+            "loop_compactness": 0.8231536101246992,
+            "flow_bends": 0.3870967741935484,
+            "loop_straightness": 0.8421052631578947
           },
-          "weighted_cost": 8.791833260725527
+          "weighted_cost": 9.597906634129338
         },
         {
           "seed": 7,
           "metrics": {
-            "node_overlap": 0.5899523460410556,
-            "node_connector_overlap": 0.09661920525500517,
-            "label_overlap": 6.857142857142858,
-            "crossings": 1.0988372093023255,
-            "sprawl": 3.2190584912816775,
-            "edge_length_cv": 0.8140432220330279,
+            "node_overlap": 0.9474669000421844,
+            "node_connector_overlap": 0.15944760535598151,
+            "label_overlap": 8.0,
+            "crossings": 1.5406976744186047,
+            "sprawl": 4.590749653255894,
+            "edge_length_cv": 0.652666678982102,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7933573657037148
+            "loop_compactness": 0.8232218390085322,
+            "flow_bends": 0.5161290322580645,
+            "loop_straightness": 0.8421052631578947
           },
-          "weighted_cost": 9.16279680829534
+          "weighted_cost": 12.056680727225862
         },
         {
           "seed": 42,
           "metrics": {
-            "node_overlap": 0.8125018650055728,
-            "node_connector_overlap": 0.0988982517774336,
-            "label_overlap": 6.0,
-            "crossings": 1.1744186046511629,
-            "sprawl": 4.277512568657417,
-            "edge_length_cv": 0.7986692161172608,
+            "node_overlap": 0.9474194395239735,
+            "node_connector_overlap": 0.15951487553991753,
+            "label_overlap": 8.0,
+            "crossings": 1.4767441860465116,
+            "sprawl": 4.550391194448503,
+            "edge_length_cv": 0.6755652540408777,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7985396034782851
+            "loop_compactness": 0.8245557247431585,
+            "flow_bends": 0.5161290322580645,
+            "loop_straightness": 0.8421052631578947
           },
-          "weighted_cost": 8.713204879169481
+          "weighted_cost": 11.985208911051867
         },
         {
           "seed": 123,
           "metrics": {
-            "node_overlap": 0.8129208013398859,
-            "node_connector_overlap": 0.09752496997079335,
-            "label_overlap": 6.0,
-            "crossings": 1.2093023255813953,
-            "sprawl": 4.302794404494863,
-            "edge_length_cv": 0.7822792020048979,
+            "node_overlap": 0.9475199381022458,
+            "node_connector_overlap": 0.16273336028752633,
+            "label_overlap": 8.0,
+            "crossings": 1.5465116279069768,
+            "sprawl": 4.650273848168665,
+            "edge_length_cv": 0.6458063838582816,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7974800058300341
+            "loop_compactness": 0.8232001305126443,
+            "flow_bends": 0.5161290322580645,
+            "loop_straightness": 0.8421052631578947
           },
-          "weighted_cost": 8.749397538799068
+          "weighted_cost": 12.077729629290038
         },
         {
           "seed": 456,
           "metrics": {
-            "node_overlap": 0.7168670707401327,
-            "node_connector_overlap": 0.09653252061160343,
-            "label_overlap": 6.248102660381588,
-            "crossings": 1.1511627906976745,
-            "sprawl": 3.772378551570708,
-            "edge_length_cv": 0.7976258598596359,
+            "node_overlap": 0.8758707162888123,
+            "node_connector_overlap": 0.15065851254467985,
+            "label_overlap": 7.490550486574051,
+            "crossings": 1.3895348837209303,
+            "sprawl": 3.881120076093125,
+            "edge_length_cv": 0.6871482315467444,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.7973203262475569
+            "loop_compactness": 0.8198932555549225,
+            "flow_bends": 0.3870967741935484,
+            "loop_straightness": 0.8421052631578947
           },
-          "weighted_cost": 8.78923297914996
+          "weighted_cost": 11.153070959013892
         },
         {
           "seed": 789,
           "metrics": {
-            "node_overlap": 0.9476944745780637,
-            "node_connector_overlap": 0.10438218995392821,
-            "label_overlap": 8.132352941176471,
-            "crossings": 1.197674418604651,
-            "sprawl": 5.679587518007298,
-            "edge_length_cv": 0.7708619122544834,
-            "aspect_penalty": 0.003113166807795942,
+            "node_overlap": 0.9475206750753469,
+            "node_connector_overlap": 0.16315133076397784,
+            "label_overlap": 8.044040066012924,
+            "crossings": 1.563953488372093,
+            "sprawl": 4.572091092052931,
+            "edge_length_cv": 0.6622663943485297,
+            "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.796551917729428
+            "loop_compactness": 0.8220247257512111,
+            "flow_bends": 0.5161290322580645,
+            "loop_straightness": 0.8421052631578947
           },
-          "weighted_cost": 11.1492007555462
+          "weighted_cost": 12.123523550089912
         }
       ],
-      "median_cost": 8.81223822845453,
+      "median_cost": 12.012803776385386,
       "spread": [
-        8.779274119062237,
-        9.16907577898262
+        9.667408484754198,
+        12.059071217645663
       ],
-      "best_of_k_cost": 8.713204879169481,
-      "best_seed": 42,
-      "median_seed": 2,
+      "best_of_k_cost": 11.153070959013892,
+      "best_seed": 4,
+      "median_seed": 1,
       "worst_seed": 789
     },
     {
@@ -4080,193 +4584,217 @@
         {
           "seed": 0,
           "metrics": {
-            "node_overlap": 0.008302760410691478,
-            "node_connector_overlap": 0.02495158541823151,
+            "node_overlap": 0.006305257786806489,
+            "node_connector_overlap": 0.024290261455352583,
             "label_overlap": 0.0,
-            "crossings": 1.1303191489361701,
-            "sprawl": 2.685055828484436,
-            "edge_length_cv": 0.5230127468512106,
+            "crossings": 1.074468085106383,
+            "sprawl": 2.6162576353814475,
+            "edge_length_cv": 0.450891737122621,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6548613214828575
+            "loop_compactness": 0.5162635378033302,
+            "flow_bends": 0.11764705882352941,
+            "loop_straightness": 0.8
           },
-          "weighted_cost": 1.5957944079842512
+          "weighted_cost": 1.9324676053696932
         },
         {
           "seed": 1,
           "metrics": {
-            "node_overlap": 0.010268380907686354,
-            "node_connector_overlap": 0.028801928359733792,
+            "node_overlap": 0.008313379487320138,
+            "node_connector_overlap": 0.026635318481394193,
             "label_overlap": 0.0,
-            "crossings": 1.1037234042553192,
-            "sprawl": 2.058214859138437,
-            "edge_length_cv": 0.5466983745698276,
+            "crossings": 1.0212765957446808,
+            "sprawl": 2.0267142784782166,
+            "edge_length_cv": 0.4806988985456621,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6638018815244391
+            "loop_compactness": 0.504836724777955,
+            "flow_bends": 0.058823529411764705,
+            "loop_straightness": 0.8
           },
-          "weighted_cost": 1.5145656698176926
+          "weighted_cost": 1.7523263687319852
         },
         {
           "seed": 2,
           "metrics": {
-            "node_overlap": 0.008281603435570892,
-            "node_connector_overlap": 0.02490638650656993,
+            "node_overlap": 0.006305257786806491,
+            "node_connector_overlap": 0.02635893165067456,
             "label_overlap": 0.0,
-            "crossings": 1.0904255319148937,
-            "sprawl": 2.679952566248296,
-            "edge_length_cv": 0.5275164218123948,
+            "crossings": 1.0186170212765957,
+            "sprawl": 2.604097078015303,
+            "edge_length_cv": 0.45600725649134544,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6559728963126994
+            "loop_compactness": 0.5094623614827638,
+            "flow_bends": 0.11764705882352941,
+            "loop_straightness": 0.8
           },
-          "weighted_cost": 1.5556020025600388
+          "weighted_cost": 1.8735326297337724
         },
         {
           "seed": 3,
           "metrics": {
-            "node_overlap": 0.004492681063310259,
-            "node_connector_overlap": 0.024235244807532225,
+            "node_overlap": 0.00829216842796186,
+            "node_connector_overlap": 0.028033870891733165,
             "label_overlap": 0.0,
-            "crossings": 1.1303191489361701,
-            "sprawl": 4.324577993214567,
-            "edge_length_cv": 0.5190390047388069,
+            "crossings": 0.9228723404255319,
+            "sprawl": 2.080055775759923,
+            "edge_length_cv": 0.5149695620472804,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6297293153386739
+            "loop_compactness": 0.4725335952064032,
+            "flow_bends": 0.11764705882352941,
+            "loop_straightness": 0.8
           },
-          "weighted_cost": 1.7489372029631376
+          "weighted_cost": 1.6618700318033022
         },
         {
           "seed": 4,
           "metrics": {
-            "node_overlap": 0.008281603435570892,
-            "node_connector_overlap": 0.02490638650656993,
-            "label_overlap": 0.0,
-            "crossings": 1.0904255319148937,
-            "sprawl": 2.679952566248296,
-            "edge_length_cv": 0.5275164218123948,
+            "node_overlap": 0.008302760410691475,
+            "node_connector_overlap": 0.02768697190822113,
+            "label_overlap": 0.11206896551724138,
+            "crossings": 0.9069148936170213,
+            "sprawl": 1.990570589596074,
+            "edge_length_cv": 0.48239456714935713,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6559728963126994
+            "loop_compactness": 0.49650043175824465,
+            "flow_bends": 0.11764705882352941,
+            "loop_straightness": 0.8
           },
-          "weighted_cost": 1.5556020025600388
+          "weighted_cost": 1.7493349408992174
         },
         {
           "seed": 5,
           "metrics": {
-            "node_overlap": 0.008281603435570892,
-            "node_connector_overlap": 0.02542069715798064,
+            "node_overlap": 0.006305257786806491,
+            "node_connector_overlap": 0.02635893165067456,
             "label_overlap": 0.0,
-            "crossings": 1.127659574468085,
-            "sprawl": 2.713546499319246,
-            "edge_length_cv": 0.5222828819804243,
+            "crossings": 1.0186170212765957,
+            "sprawl": 2.604097078015303,
+            "edge_length_cv": 0.45600725649134544,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6559421834975301
+            "loop_compactness": 0.5094623614827638,
+            "flow_bends": 0.11764705882352941,
+            "loop_straightness": 0.8
           },
-          "weighted_cost": 1.5967020708679436
+          "weighted_cost": 1.8735326297337724
         },
         {
           "seed": 6,
           "metrics": {
-            "node_overlap": 0.008281603435570892,
-            "node_connector_overlap": 0.02490638650656993,
+            "node_overlap": 0.006299147364042278,
+            "node_connector_overlap": 0.024031182977694753,
             "label_overlap": 0.0,
-            "crossings": 1.0904255319148937,
-            "sprawl": 2.679952566248296,
-            "edge_length_cv": 0.5275164218123948,
+            "crossings": 0.9893617021276596,
+            "sprawl": 2.5798152761929267,
+            "edge_length_cv": 0.47564391468778217,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6559728963126994
+            "loop_compactness": 0.5157461335500366,
+            "flow_bends": 0.11764705882352941,
+            "loop_straightness": 0.8
           },
-          "weighted_cost": 1.5556020025600388
+          "weighted_cost": 1.8396005999515261
         },
         {
           "seed": 7,
           "metrics": {
-            "node_overlap": 0.010236040120319643,
-            "node_connector_overlap": 0.03336755295316199,
+            "node_overlap": 0.00830276041069147,
+            "node_connector_overlap": 0.02782907900703134,
             "label_overlap": 0.0,
-            "crossings": 1.0957446808510638,
-            "sprawl": 2.056508037934314,
-            "edge_length_cv": 0.5640050773210747,
+            "crossings": 0.9414893617021277,
+            "sprawl": 2.0455433440560014,
+            "edge_length_cv": 0.46983011799055296,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6623629488016973
+            "loop_compactness": 0.4705403791154808,
+            "flow_bends": 0.11764705882352941,
+            "loop_straightness": 0.8
           },
-          "weighted_cost": 1.5105898149184014
+          "weighted_cost": 1.6725930804007727
         },
         {
           "seed": 42,
           "metrics": {
-            "node_overlap": 0.008271065330485227,
-            "node_connector_overlap": 0.024583103868227194,
+            "node_overlap": 0.006305257786806492,
+            "node_connector_overlap": 0.023858531887311775,
             "label_overlap": 0.0,
-            "crossings": 1.1170212765957446,
-            "sprawl": 2.692592366999346,
-            "edge_length_cv": 0.5518140610998425,
+            "crossings": 1.0558510638297873,
+            "sprawl": 2.6011344357116646,
+            "edge_length_cv": 0.49473966671777525,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6382065363481588
+            "loop_compactness": 0.45250370363083936,
+            "flow_bends": 0.11764705882352941,
+            "loop_straightness": 0.8
           },
-          "weighted_cost": 1.5786863165814315
+          "weighted_cost": 1.8848902809221035
         },
         {
           "seed": 123,
           "metrics": {
-            "node_overlap": 0.008292168427961868,
-            "node_connector_overlap": 0.024170459705975957,
+            "node_overlap": 0.006305257786806491,
+            "node_connector_overlap": 0.02635893165067456,
             "label_overlap": 0.0,
-            "crossings": 1.077127659574468,
-            "sprawl": 2.6865560757965374,
-            "edge_length_cv": 0.5281830172455013,
+            "crossings": 1.0186170212765957,
+            "sprawl": 2.604097078015303,
+            "edge_length_cv": 0.45600725649134544,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6659594711376385
+            "loop_compactness": 0.5094623614827638,
+            "flow_bends": 0.11764705882352941,
+            "loop_straightness": 0.8
           },
-          "weighted_cost": 1.5447357630724692
+          "weighted_cost": 1.8735326297337724
         },
         {
           "seed": 456,
           "metrics": {
-            "node_overlap": 0.010252185009100273,
-            "node_connector_overlap": 0.025699603932980944,
+            "node_overlap": 0.008313379487320145,
+            "node_connector_overlap": 0.03043818135113868,
             "label_overlap": 0.0,
-            "crossings": 1.0877659574468086,
-            "sprawl": 2.100168323368534,
-            "edge_length_cv": 0.5516201540346829,
+            "crossings": 0.9521276595744681,
+            "sprawl": 2.0284642058228726,
+            "edge_length_cv": 0.4697240772395471,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.660669928717128
+            "loop_compactness": 0.4768223574178368,
+            "flow_bends": 0.11764705882352941,
+            "loop_straightness": 0.8
           },
-          "weighted_cost": 1.4989020609050252
+          "weighted_cost": 1.6849480633681657
         },
         {
           "seed": 789,
           "metrics": {
-            "node_overlap": 0.008281603435570892,
-            "node_connector_overlap": 0.024301752059592816,
+            "node_overlap": 0.006305257786806492,
+            "node_connector_overlap": 0.023880710798448255,
             "label_overlap": 0.0,
-            "crossings": 1.101063829787234,
-            "sprawl": 2.682519842903184,
-            "edge_length_cv": 0.5316083063339189,
+            "crossings": 1.0159574468085106,
+            "sprawl": 2.6104826172140685,
+            "edge_length_cv": 0.4894754039643907,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.6557588537040494
+            "loop_compactness": 0.526890651939126,
+            "flow_bends": 0.11764705882352941,
+            "loop_straightness": 0.8
           },
-          "weighted_cost": 1.5658388829987284
+          "weighted_cost": 1.876643258435759
         }
       ],
-      "median_cost": 1.5556020025600388,
+      "median_cost": 1.8565666148426492,
       "spread": [
-        1.5371932397587749,
-        1.5829633394321365
+        1.7332382215164546,
+        1.8743102869092692
       ],
-      "best_of_k_cost": 1.4989020609050252,
-      "best_seed": 456,
-      "median_seed": 2,
-      "worst_seed": 3
+      "best_of_k_cost": 1.6849480633681657,
+      "best_seed": 3,
+      "median_seed": 6,
+      "worst_seed": 0
     },
     {
       "model": "industrial_dynamics",
@@ -4274,194 +4802,218 @@
         {
           "seed": 0,
           "metrics": {
-            "node_overlap": 0.014486599505379649,
-            "node_connector_overlap": 0.009462704885719634,
-            "label_overlap": 0.1264473531239345,
-            "crossings": 0.5698324022346368,
-            "sprawl": 6.888026601078894,
-            "edge_length_cv": 0.6320231547476235,
+            "node_overlap": 0.028738690792974985,
+            "node_connector_overlap": 0.05124641556980498,
+            "label_overlap": 0.0,
+            "crossings": 0.8603351955307262,
+            "sprawl": 2.7139202176054287,
+            "edge_length_cv": 0.6655845813203781,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5062170408776265
+            "loop_compactness": 0.48973275125194426,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6666666666666666
           },
-          "weighted_cost": 1.5355859800769665
+          "weighted_cost": 1.7456641125820365
         },
         {
           "seed": 1,
           "metrics": {
-            "node_overlap": 0.031680355709257084,
-            "node_connector_overlap": 0.028045236400010474,
-            "label_overlap": 0.0,
-            "crossings": 0.5698324022346368,
-            "sprawl": 2.954225611426627,
-            "edge_length_cv": 0.6754874646742942,
+            "node_overlap": 0.01524204971760771,
+            "node_connector_overlap": 0.011941337957154092,
+            "label_overlap": 0.13470682718383342,
+            "crossings": 0.9553072625698324,
+            "sprawl": 5.479561184498017,
+            "edge_length_cv": 0.5739533293346532,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5258402573422091
+            "loop_compactness": 0.49480668555743135,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6666666666666666
           },
-          "weighted_cost": 1.0564406198221195
+          "weighted_cost": 2.4776990552176708
         },
         {
           "seed": 2,
           "metrics": {
-            "node_overlap": 0.031680355709257084,
-            "node_connector_overlap": 0.03508417548359447,
+            "node_overlap": 0.028738690792974985,
+            "node_connector_overlap": 0.03833122664056828,
             "label_overlap": 0.0,
-            "crossings": 0.7094972067039106,
-            "sprawl": 3.0061608018544796,
-            "edge_length_cv": 0.7585493593671089,
+            "crossings": 0.6480446927374302,
+            "sprawl": 2.734698014412557,
+            "edge_length_cv": 0.6037978212862715,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.494566770202818
+            "loop_compactness": 0.5154635281687995,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6666666666666666
           },
-          "weighted_cost": 1.2005195106329145
+          "weighted_cost": 1.5349062909876714
         },
         {
           "seed": 3,
           "metrics": {
-            "node_overlap": 0.028738690792974985,
-            "node_connector_overlap": 0.014309486382098485,
+            "node_overlap": 0.028738690792975013,
+            "node_connector_overlap": 0.040597114630195295,
             "label_overlap": 0.0,
-            "crossings": 0.6703910614525139,
-            "sprawl": 3.569741150401164,
-            "edge_length_cv": 0.695684118344271,
+            "crossings": 0.8491620111731844,
+            "sprawl": 2.7110268081414146,
+            "edge_length_cv": 0.6414205715616035,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5366181980959295
+            "loop_compactness": 0.5118828556068377,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6666666666666666
           },
-          "weighted_cost": 1.2045679031916863
+          "weighted_cost": 1.7321229871340393
         },
         {
           "seed": 4,
           "metrics": {
-            "node_overlap": 0.028738690792974995,
-            "node_connector_overlap": 0.02944243319638048,
-            "label_overlap": 0.0,
-            "crossings": 0.7039106145251397,
-            "sprawl": 3.5734729257601687,
-            "edge_length_cv": 0.6455616202347029,
+            "node_overlap": 0.014500762767488271,
+            "node_connector_overlap": 0.005843052674717507,
+            "label_overlap": 0.050231268456817,
+            "crossings": 1.089385474860335,
+            "sprawl": 5.896945633173063,
+            "edge_length_cv": 0.6392516724928246,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.4786580470952029
+            "loop_compactness": 0.50277865606712,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6666666666666666
           },
-          "weighted_cost": 1.2391035428643127
+          "weighted_cost": 2.607127814487485
         },
         {
           "seed": 5,
           "metrics": {
             "node_overlap": 0.028738690792974985,
-            "node_connector_overlap": 0.024705838442995783,
+            "node_connector_overlap": 0.03340234145379649,
             "label_overlap": 0.0,
-            "crossings": 0.6983240223463687,
-            "sprawl": 3.8865253910553132,
-            "edge_length_cv": 0.7764262787199391,
+            "crossings": 0.7597765363128491,
+            "sprawl": 2.6896286213088136,
+            "edge_length_cv": 0.649016564770906,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5188649524163191
+            "loop_compactness": 0.5155600178231583,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6666666666666666
           },
-          "weighted_cost": 1.2701373287919506
+          "weighted_cost": 1.6327339666173133
         },
         {
           "seed": 6,
           "metrics": {
-            "node_overlap": 0.028738690792974975,
-            "node_connector_overlap": 0.02083093591362247,
+            "node_overlap": 0.0316803557092571,
+            "node_connector_overlap": 0.07187165120137179,
             "label_overlap": 0.0,
-            "crossings": 0.6201117318435754,
-            "sprawl": 3.7668002754320553,
-            "edge_length_cv": 0.7805748660075932,
+            "crossings": 0.659217877094972,
+            "sprawl": 2.191993340313167,
+            "edge_length_cv": 0.6808473537367026,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.4956683701766167
+            "loop_compactness": 0.5226237460504322,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6666666666666666
           },
-          "weighted_cost": 1.1702784786375326
+          "weighted_cost": 1.476884717155074
         },
         {
           "seed": 7,
           "metrics": {
-            "node_overlap": 0.03168035570925709,
-            "node_connector_overlap": 0.04145426456366108,
+            "node_overlap": 0.02564326864198148,
+            "node_connector_overlap": 0.022500899187697838,
             "label_overlap": 0.0,
-            "crossings": 0.48044692737430167,
-            "sprawl": 2.8391197982851173,
-            "edge_length_cv": 0.7178818925582421,
+            "crossings": 0.8324022346368715,
+            "sprawl": 3.3612716499710404,
+            "edge_length_cv": 0.636934626207713,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.4942400367652394
+            "loop_compactness": 0.5536700212856426,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6666666666666666
           },
-          "weighted_cost": 0.9610535366670414
+          "weighted_cost": 1.8409354076416826
         },
         {
           "seed": 42,
           "metrics": {
-            "node_overlap": 0.028738690792974978,
-            "node_connector_overlap": 0.0212577648610663,
+            "node_overlap": 0.014077173299414129,
+            "node_connector_overlap": 0.011590620172461768,
             "label_overlap": 0.0,
-            "crossings": 0.7653631284916201,
-            "sprawl": 3.867919949718295,
-            "edge_length_cv": 0.7796615440131827,
+            "crossings": 0.9217877094972067,
+            "sprawl": 5.433100230635522,
+            "edge_length_cv": 0.5651560939180177,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5466047878336731
+            "loop_compactness": 0.5232375534703375,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6666666666666666
           },
-          "weighted_cost": 1.3388027760759094
+          "weighted_cost": 2.3100372371509885
         },
         {
           "seed": 123,
           "metrics": {
-            "node_overlap": 0.031680355709257084,
-            "node_connector_overlap": 0.03571404959619935,
+            "node_overlap": 0.031680355709257126,
+            "node_connector_overlap": 0.061253576731312716,
             "label_overlap": 0.0,
-            "crossings": 0.6815642458100558,
-            "sprawl": 2.9317383589705512,
-            "edge_length_cv": 0.6890133879825147,
+            "crossings": 0.770949720670391,
+            "sprawl": 2.2024636554666874,
+            "edge_length_cv": 0.6604846197995592,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.48647111464171183
+            "loop_compactness": 0.5277887129238317,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6666666666666666
           },
-          "weighted_cost": 1.1637502656729952
+          "weighted_cost": 1.5821585360404977
         },
         {
           "seed": 456,
           "metrics": {
-            "node_overlap": 0.028738690792974985,
-            "node_connector_overlap": 0.02612448574219411,
+            "node_overlap": 0.031680355709257105,
+            "node_connector_overlap": 0.05264428011455551,
             "label_overlap": 0.0,
-            "crossings": 0.664804469273743,
-            "sprawl": 3.713710637924638,
-            "edge_length_cv": 0.7588690539957207,
+            "crossings": 0.8491620111731844,
+            "sprawl": 2.2161925387452794,
+            "edge_length_cv": 0.6716631900653252,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.5171438453087973
+            "loop_compactness": 0.5326227150881526,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6666666666666666
           },
-          "weighted_cost": 1.2203246709285753
+          "weighted_cost": 1.6564409074479804
         },
         {
           "seed": 789,
           "metrics": {
-            "node_overlap": 0.02873869079297502,
-            "node_connector_overlap": 0.027621922170640616,
+            "node_overlap": 0.02564326864198148,
+            "node_connector_overlap": 0.02281358006160794,
             "label_overlap": 0.0,
-            "crossings": 0.7150837988826816,
-            "sprawl": 3.823902296778259,
-            "edge_length_cv": 0.7585678438387556,
+            "crossings": 0.8994413407821229,
+            "sprawl": 3.2774152064318076,
+            "edge_length_cv": 0.606125352979846,
             "aspect_penalty": 0.0,
             "chain_straightness": 0.0,
-            "loop_compactness": 0.48302889193129095
+            "loop_compactness": 0.511267386135937,
+            "flow_bends": 0.0,
+            "loop_straightness": 0.6666666666666666
           },
-          "weighted_cost": 1.2745918645069458
+          "weighted_cost": 1.8745548518931157
         }
       ],
-      "median_cost": 1.2124462870601307,
+      "median_cost": 1.7388935498580378,
       "spread": [
-        1.1686464253963982,
-        1.2712509627206994
+        1.6200901089731095,
+        1.983425448207584
       ],
-      "best_of_k_cost": 1.1637502656729952,
-      "best_seed": 7,
+      "best_of_k_cost": 1.5821585360404977,
+      "best_seed": 6,
       "median_seed": 3,
-      "worst_seed": 0
+      "worst_seed": 4
     }
   ],
-  "aggregate_cost": 0.6128759799523016
+  "aggregate_cost": 0.8011384042018516
 }

--- a/src/simlin-engine/src/layout/aliases.rs
+++ b/src/simlin-engine/src/layout/aliases.rs
@@ -24,8 +24,12 @@ use super::metadata::ComputedMetadata;
 use super::{LayoutState, format_label_with_line_breaks};
 
 /// A connector longer than this many `horizontal_spacing`s is "long": the
-/// distance at which a ghost copy reads better than a cross-diagram line.
-const GHOST_DISTANCE_FACTOR: f64 = 2.5;
+/// distance at which a ghost copy reads better than a cross-diagram line. Tracks
+/// the force-pass spring length (`SfdpConfig::for_aux_placement` k): "long" is
+/// relative to typical node spacing, so this was lowered alongside k (150 -> 110)
+/// to keep the same ~1.7x-spacing trigger rather than drifting to a larger
+/// relative distance that ghosts almost nothing on the now-tighter layouts.
+const GHOST_DISTANCE_FACTOR: f64 = 1.8;
 
 /// At most this fraction of the model's variables become ghosts (the
 /// hand-drawn corpus shows 14-26%; the cap keeps a pathological model from

--- a/src/simlin-engine/src/layout/config.rs
+++ b/src/simlin-engine/src/layout/config.rs
@@ -113,7 +113,13 @@ impl Default for LayoutConfig {
             module_height: 45.0,
             start_x: 100.0,
             start_y: 100.0,
-            loop_curvature_factor: 0.3,
+            // 0.5 makes a loop's connectors bow into a near-circular arc: for an
+            // n-node loop the ideal takeoff from each chord is ~pi/n, which at a
+            // perpendicular loop center (angle_diff ~90deg) this factor produces
+            // as 90*0.5 = 45deg -- the right arc for the common 3-4 node loop. The
+            // prior 0.3 under-curved, so loops read as near-straight zigzags
+            // rather than visible circles.
+            loop_curvature_factor: 0.5,
             annealing_iterations: 200,
             annealing_temperature: 30.0,
             // The schedule must END COLD between reheats (see
@@ -167,7 +173,7 @@ mod tests {
         assert!((config.start_y - 100.0).abs() < f64::EPSILON);
 
         // Feedback loop
-        assert!((config.loop_curvature_factor - 0.3).abs() < f64::EPSILON);
+        assert!((config.loop_curvature_factor - 0.5).abs() < f64::EPSILON);
 
         // Annealing parameters
         assert_eq!(config.annealing_iterations, 200);

--- a/src/simlin-engine/src/layout/declutter.rs
+++ b/src/simlin-engine/src/layout/declutter.rs
@@ -64,6 +64,18 @@ const MAX_RELAX_ATTEMPTS: usize = 6;
 /// jammed cluster actually needs.
 const JAM_ZOOM_STEP: f64 = 1.3;
 
+/// Most a compaction pass may shrink a layout (a floor on the uniform scale).
+/// Force-directed placement leaves global slack and jam-recovery can over-zoom,
+/// so after overlaps are cleared we pull the diagram back in toward the tightest
+/// still-separated arrangement; this caps how aggressive that is so a sparse
+/// layout cannot collapse to an unreadable knot even if the geometry would allow
+/// it.
+const COMPACT_MIN_SCALE: f64 = 0.4;
+
+/// Binary-search steps for the compaction scale. 2^-18 of the [min,1] range is
+/// far finer than a pixel at any diagram scale.
+const COMPACT_ITERS: usize = 18;
+
 /// Greedy label-side passes inside `choose_label_sides` per outer round.
 const LABEL_SIDE_ROUNDS: usize = 3;
 
@@ -599,6 +611,92 @@ fn relax_positions(elements: &mut [ViewElement], alias_names: &HashMap<i32, Stri
     converged
 }
 
+/// True if any two element footprints (shape box + current label box) are closer
+/// than `SEPARATION_MARGIN` -- i.e. the layout is not cleanly separated. Pure
+/// read-only companion to `relax_positions` (which uses the same footprints), so
+/// the compaction search below can probe a candidate scale without mutating.
+fn layout_has_overlap(elements: &[ViewElement], alias_names: &HashMap<i32, String>) -> bool {
+    let items: Vec<Vec<Rect>> = elements
+        .iter()
+        .filter_map(|e| {
+            let mut rects = Vec::with_capacity(2);
+            if let Some(shape) = node_shape_box(e) {
+                rects.push(shape);
+            }
+            if let Some(lbox) = current_label_box(e, alias_names) {
+                rects.push(lbox);
+            }
+            if rects.is_empty() { None } else { Some(rects) }
+        })
+        .collect();
+    for i in 0..items.len() {
+        for j in (i + 1)..items.len() {
+            for a in &items[i] {
+                for b in &items[j] {
+                    if separation_mtv(a, b, SEPARATION_MARGIN).is_some() {
+                        return true;
+                    }
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Pull a cleanly-separated layout in toward the origin by the largest factor
+/// that keeps every footprint at least `SEPARATION_MARGIN` apart, removing the
+/// global slack a force-directed pass leaves (and any over-zoom from jam
+/// recovery). Uniform scaling preserves all relative geometry, so chains stay
+/// straight and angles unchanged; only the empty space between elements shrinks,
+/// which is exactly what `sprawl` measures. A subsequent `normalize_coordinates`
+/// re-anchors the diagram, so scaling about the origin is immaterial.
+///
+/// Feasibility is monotone in the scale (shrinking can only bring footprints
+/// closer), so a binary search finds the tightest separated scale. A layout with
+/// no slack (already touching at margin) is left unchanged. Must be called on an
+/// already overlap-free layout (the final declutter state); a no-op otherwise.
+fn compact_view(elements: &mut [ViewElement], alias_names: &HashMap<i32, String>) {
+    if elements.len() < 2 || layout_has_overlap(elements, alias_names) {
+        return;
+    }
+
+    // Probe a candidate scale on a throwaway copy: scale positions, re-snap flow
+    // endpoints to the (fixed-size) stocks they moved off of, then test
+    // separation. Flows scale their pipe with the layout, so re-snapping mirrors
+    // the jam-zoom companion and keeps the probe faithful to the applied result.
+    let original = elements.to_vec();
+    let separated_at = |s: f64| -> bool {
+        let mut probe = original.clone();
+        scale_all_positions(&mut probe, s);
+        resnap_flow_endpoints_to_stocks(&mut probe);
+        !layout_has_overlap(&probe, alias_names)
+    };
+
+    // Smallest separated scale. If even the floor is separated, compact straight
+    // to it; otherwise binary-search [floor, 1.0] keeping `hi` feasible (s=1 is,
+    // by precondition) and `lo` infeasible, converging `hi` to the threshold.
+    let best_scale = if separated_at(COMPACT_MIN_SCALE) {
+        COMPACT_MIN_SCALE
+    } else {
+        let mut lo = COMPACT_MIN_SCALE;
+        let mut hi = 1.0;
+        for _ in 0..COMPACT_ITERS {
+            let mid = (lo + hi) / 2.0;
+            if separated_at(mid) {
+                hi = mid;
+            } else {
+                lo = mid;
+            }
+        }
+        hi
+    };
+
+    if best_scale < 1.0 - 1e-9 {
+        scale_all_positions(elements, best_scale);
+        resnap_flow_endpoints_to_stocks(elements);
+    }
+}
+
 /// Declutter a laid-out view in place: deterministically choose label sides and
 /// push overlapping footprints apart so labels and shapes stop colliding. Runs
 /// `OUTER_ROUNDS` of (choose sides -> relax positions) so the side choice can
@@ -638,6 +736,12 @@ pub fn declutter_view(elements: &mut [ViewElement]) {
     // their labels optimal.
     relax_positions(elements, &alias_names);
     optimize_label_sides(elements, &alias_names);
+
+    // Now that the layout is cleanly separated, pull it back in to the tightest
+    // still-separated scale, removing the global slack the force pass left (and
+    // any over-zoom the jam recovery above introduced). This drives `sprawl`
+    // down toward hand-drawn density without ever reintroducing an overlap.
+    compact_view(elements, &alias_names);
 }
 
 #[cfg(test)]
@@ -1155,6 +1259,115 @@ mod tests {
             (f.points[0].y - scaled_edge_y).abs() < 1e-9,
             "endpoint must sit on the scaled stock's bottom edge: {} vs {scaled_edge_y}",
             f.points[0].y
+        );
+    }
+
+    // ── compaction ──
+
+    fn aux_at(uid: i32, x: f64, y: f64, name: &str) -> ViewElement {
+        ViewElement::Aux(crate::datamodel::view_element::Aux {
+            name: name.to_string(),
+            uid,
+            x,
+            y,
+            label_side: LabelSide::Bottom,
+            compat: None,
+        })
+    }
+
+    fn layout_extent(elements: &[ViewElement]) -> f64 {
+        let names = alias_source_names(elements);
+        let mut min_x = f64::INFINITY;
+        let mut max_x = f64::NEG_INFINITY;
+        let mut min_y = f64::INFINITY;
+        let mut max_y = f64::NEG_INFINITY;
+        for e in elements {
+            for r in [node_shape_box(e), current_label_box(e, &names)]
+                .into_iter()
+                .flatten()
+            {
+                min_x = min_x.min(r.left);
+                max_x = max_x.max(r.right);
+                min_y = min_y.min(r.top);
+                max_y = max_y.max(r.bottom);
+            }
+        }
+        (max_x - min_x).max(max_y - min_y)
+    }
+
+    #[test]
+    fn test_compaction_shrinks_sparse_layout_without_overlap() {
+        // Three auxes spread far apart (lots of slack between fixed-size labels).
+        let mut elements = vec![
+            aux_at(1, 0.0, 0.0, "alpha"),
+            aux_at(2, 600.0, 0.0, "beta"),
+            aux_at(3, 0.0, 600.0, "gamma"),
+        ];
+        let names = alias_source_names(&elements);
+        assert!(
+            !layout_has_overlap(&elements, &names),
+            "precondition: the sparse layout is overlap-free"
+        );
+        let before = layout_extent(&elements);
+
+        compact_view(&mut elements, &names);
+
+        let after = layout_extent(&elements);
+        assert!(
+            after < before * 0.9,
+            "compaction should noticeably shrink the layout: {after} vs {before}"
+        );
+        assert!(
+            !layout_has_overlap(&elements, &names),
+            "compaction must never introduce an overlap"
+        );
+    }
+
+    #[test]
+    fn test_compaction_respects_min_scale_floor() {
+        // Hugely sprawled: even at the floor the labels stay far apart, so
+        // compaction is clamped to COMPACT_MIN_SCALE rather than collapsing the
+        // diagram to a knot.
+        let mut elements = vec![aux_at(1, 0.0, 0.0, "alpha"), aux_at(2, 5000.0, 0.0, "beta")];
+        let names = alias_source_names(&elements);
+        compact_view(&mut elements, &names);
+        let ViewElement::Aux(a2) = &elements[1] else {
+            panic!("aux")
+        };
+        // aux 1 is at the origin, so aux 2's x is scaled directly by the factor.
+        let applied = a2.x / 5000.0;
+        assert!(
+            (applied - COMPACT_MIN_SCALE).abs() < 1e-3,
+            "huge slack should compact exactly to the floor {COMPACT_MIN_SCALE}, got {applied}"
+        );
+        assert!(!layout_has_overlap(&elements, &names));
+    }
+
+    #[test]
+    fn test_compaction_keeps_flow_endpoints_attached() {
+        use crate::diagram::constants::STOCK_WIDTH;
+        // A stock with a horizontal flow to a far cloud: compaction pulls the
+        // cloud in, and the re-snap must keep the source endpoint on the stock.
+        let edge_x = 100.0 + STOCK_WIDTH / 2.0;
+        let mut elements = vec![
+            stock_at(1, 100.0, 100.0),
+            flow_attached_to(2, (400.0, 100.0), (edge_x, 100.0), 1, (700.0, 100.0)),
+            aux_at(3, 100.0, 600.0, "far aux"),
+        ];
+        let names = alias_source_names(&elements);
+        compact_view(&mut elements, &names);
+        let ViewElement::Stock(s) = &elements[0] else {
+            panic!("stock")
+        };
+        let ViewElement::Flow(f) = &elements[1] else {
+            panic!("flow")
+        };
+        // The source endpoint stays on the (fixed-size) stock's right edge.
+        let expected_edge = s.x + STOCK_WIDTH / 2.0;
+        assert!(
+            (f.points[0].x - expected_edge).abs() < 1.0,
+            "flow source endpoint must stay attached to the stock edge: {} vs {expected_edge}",
+            f.points[0].x
         );
     }
 }

--- a/src/simlin-engine/src/layout/eval_stats.rs
+++ b/src/simlin-engine/src/layout/eval_stats.rs
@@ -876,6 +876,7 @@ mod tests {
             chain_straightness: 0.0,
             loop_compactness: 0.0,
             flow_bends: 0.0,
+            loop_straightness: 0.0,
         }
     }
 

--- a/src/simlin-engine/src/layout/eval_stats.rs
+++ b/src/simlin-engine/src/layout/eval_stats.rs
@@ -875,6 +875,7 @@ mod tests {
             aspect_penalty: 0.0,
             chain_straightness: 0.0,
             loop_compactness: 0.0,
+            flow_bends: 0.0,
         }
     }
 

--- a/src/simlin-engine/src/layout/layout_selection_tests.rs
+++ b/src/simlin-engine/src/layout/layout_selection_tests.rs
@@ -309,9 +309,9 @@ fn test_select_best_layout_all_nan_keeps_earliest() {
 // ~0.1-0.15 of sprawl-times-weight; the readability terms themselves are near
 // zero on these tiny models.) The regeneration procedure printed these via the
 // GUARD_REGEN lines this test emits.
-const GUARD_POP_COST_CEILING: f64 = 0.24;
-const GUARD_CHAIN_COST_CEILING: f64 = 0.57;
-const GUARD_TWO_STOCK_COST_CEILING: f64 = 0.16;
+const GUARD_POP_COST_CEILING: f64 = 0.32;
+const GUARD_CHAIN_COST_CEILING: f64 = 0.17;
+const GUARD_TWO_STOCK_COST_CEILING: f64 = 0.25;
 
 /// Lay `project`'s `main` model out at the fixed seed 42 and return its
 /// calibrated `weighted_cost`. Seeding explicitly (rather than relying on the

--- a/src/simlin-engine/src/layout/metrics.rs
+++ b/src/simlin-engine/src/layout/metrics.rs
@@ -1238,6 +1238,16 @@ mod tests {
         })
     }
 
+    fn arc_link(uid: i32, from_uid: i32, to_uid: i32, angle: f64) -> ViewElement {
+        ViewElement::Link(view_element::Link {
+            uid,
+            from_uid,
+            to_uid,
+            shape: LinkShape::Arc(angle),
+            polarity: None,
+        })
+    }
+
     /// A flow valve at `(x, y)` with a two-point polyline whose endpoints attach
     /// to `from_uid` and `to_uid` (a stock--flow--stock segment). The point
     /// coordinates are irrelevant to `loop_compactness` (which uses node-box
@@ -2608,6 +2618,72 @@ mod tests {
         ]);
         let m = compute_layout_metrics(&view, &cfg());
         assert_eq!(m.loop_compactness, 0.0);
+    }
+
+    // --- loop_straightness (loop connectors drawn as visible curves) ---
+
+    /// A square 4-node loop wired with STRAIGHT links scores high
+    /// loop_straightness: the loop's causal connectors are drawn as flat chords,
+    /// so the loop reads as a zig-zag, not a circle.
+    #[test]
+    fn test_loop_straightness_straight_loop_is_high() {
+        let view = make_view(vec![
+            aux(1, "a", 0.0, 0.0),
+            aux(2, "b", 300.0, 0.0),
+            aux(3, "c", 300.0, 300.0),
+            aux(4, "d", 0.0, 300.0),
+            straight_link(11, 1, 2),
+            straight_link(12, 2, 3),
+            straight_link(13, 3, 4),
+            straight_link(14, 4, 1),
+        ]);
+        let m = compute_layout_metrics(&view, &cfg());
+        assert!(
+            m.loop_straightness > 0.9,
+            "a loop drawn with straight chords should score near 1, got {}",
+            m.loop_straightness
+        );
+    }
+
+    /// The SAME square loop wired with ARC links that bow well outward scores
+    /// near zero: every loop connector is drawn as a visible curve.
+    #[test]
+    fn test_loop_straightness_curved_loop_is_low() {
+        // 45deg takeoff arcs bow ~0.2 (a quarter-circle), above the target bow.
+        let view = make_view(vec![
+            aux(1, "a", 0.0, 0.0),
+            aux(2, "b", 300.0, 0.0),
+            aux(3, "c", 300.0, 300.0),
+            aux(4, "d", 0.0, 300.0),
+            arc_link(11, 1, 2, 45.0),
+            arc_link(12, 2, 3, 45.0),
+            arc_link(13, 3, 4, 45.0),
+            arc_link(14, 4, 1, 45.0),
+        ]);
+        let m = compute_layout_metrics(&view, &cfg());
+        assert!(
+            m.loop_straightness < m.loop_compactness.max(0.5),
+            "a curved loop should score lower loop_straightness than a straight one"
+        );
+        assert!(
+            m.loop_straightness < 0.5,
+            "a loop drawn with well-bowed arcs should score low, got {}",
+            m.loop_straightness
+        );
+    }
+
+    /// A pure chain (no cycle) has no loop connector, so loop_straightness is 0.
+    #[test]
+    fn test_loop_straightness_no_loop_is_zero() {
+        let view = make_view(vec![
+            aux(1, "a", 0.0, 0.0),
+            aux(2, "b", 200.0, 0.0),
+            aux(3, "c", 400.0, 0.0),
+            straight_link(10, 1, 2),
+            straight_link(11, 2, 3),
+        ]);
+        let m = compute_layout_metrics(&view, &cfg());
+        assert_eq!(m.loop_straightness, 0.0);
     }
 
     #[test]

--- a/src/simlin-engine/src/layout/metrics.rs
+++ b/src/simlin-engine/src/layout/metrics.rs
@@ -97,6 +97,14 @@ pub struct LayoutMetrics {
     /// require an `L`/`Z` detour. 0.0 when the view has no flows.
     #[serde(default)]
     pub flow_bends: f64,
+    /// Mean bow shortfall over the causal connectors that participate in a
+    /// feedback loop: 0.0 = every loop connector is drawn with at least the
+    /// target curvature (the loop reads as a visible circle), 1.0 = loop
+    /// connectors are straight (the loop collapses to a zig-zag). A Goodhart
+    /// guard complementing `loop_compactness` (which scores node arrangement, not
+    /// the drawn connector curvature). 0.0 when there is no loop connector.
+    #[serde(default)]
+    pub loop_straightness: f64,
 }
 
 /// Per-term weights for the scalar an optimizer minimizes.
@@ -122,6 +130,8 @@ pub struct MetricWeights {
     pub loop_compactness: f64,
     #[serde(default)]
     pub flow_bends: f64,
+    #[serde(default)]
+    pub loop_straightness: f64,
 }
 
 impl Default for MetricWeights {
@@ -160,6 +170,11 @@ impl Default for MetricWeights {
     ///     placements where a flow's two stocks line up (a clean straight pipe)
     ///     instead of an `L`/`Z` detour. A convention aid like
     ///     `loop_compactness`, kept well below the readability family.
+    ///   * `loop_straightness` is a low 0.1: a Goodhart guard that keeps feedback
+    ///     loops drawn as visible curves. `apply_loop_curvature` curves loop
+    ///     connectors deterministically so a healthy layout scores ~0 here; the
+    ///     weight exists so the metric can never reward flattening a loop back
+    ///     into a zig-zag. Below the readability family by construction.
     ///   * `chain_straightness` stays 0.0: it is reserved (not yet computed), so
     ///     it carries no weight.
     fn default() -> Self {
@@ -168,12 +183,13 @@ impl Default for MetricWeights {
             node_connector_overlap: 1.0,
             label_overlap: 1.0,
             crossings: 1.0,
-            sprawl: 0.1,
+            sprawl: 0.2,
             edge_length_cv: 0.0,
             aspect_penalty: 0.0,
             chain_straightness: 0.0,
-            loop_compactness: 0.25,
+            loop_compactness: 0.4,
             flow_bends: 0.15,
+            loop_straightness: 0.1,
         }
     }
 }
@@ -191,6 +207,7 @@ impl LayoutMetrics {
             + self.chain_straightness * w.chain_straightness
             + self.loop_compactness * w.loop_compactness
             + self.flow_bends * w.flow_bends
+            + self.loop_straightness * w.loop_straightness
     }
 }
 
@@ -745,6 +762,120 @@ fn compute_loop_compactness(view: &datamodel::StockFlow) -> f64 {
     }
 }
 
+// --- loop_straightness (are feedback-loop connectors drawn as visible curves) -
+//
+// loop_compactness above scores how circular a loop's NODE arrangement is, but
+// not whether the connectors between those nodes are actually drawn as arcs. A
+// loop can have well-spread node centers yet still read as a zig-zag if its
+// causal connectors are straight chords. This term measures exactly that: the
+// shortfall of each loop connector's drawn curvature below a target bow. It is
+// primarily a Goodhart guard -- `apply_loop_curvature` curves loop connectors
+// deterministically, so a healthy layout scores ~0; if any future change flattens
+// loop connectors, this term (and the metric) rises, so the optimizer can never
+// trade away the curvature that makes a loop legible. Flow pipes in a loop are
+// exempt: they are orthogonal by convention, never arced.
+
+/// Target bow ratio (max perpendicular deviation / chord length) for a loop's
+/// causal connectors. A quarter-circle arc -- a clearly visible loop curve --
+/// has a bow of ~0.21; 0.15 treats moderate curvature as "enough" so the term
+/// only fires on connectors drawn (near-)straight.
+const LOOP_LINK_TARGET_BOW: f64 = 0.15;
+
+/// Maximum perpendicular deviation of a polyline from its straight chord
+/// (first -> last point), divided by the chord length. 0 for a straight two-point
+/// line; ~0.21 for a quarter-circle arc. Returns 0 for a degenerate (near-zero)
+/// chord so the ratio is always finite.
+fn polyline_bow_ratio(polyline: &[Point]) -> f64 {
+    if polyline.len() < 3 {
+        return 0.0;
+    }
+    let a = polyline[0];
+    let b = polyline[polyline.len() - 1];
+    let cx = b.x - a.x;
+    let cy = b.y - a.y;
+    let chord = (cx * cx + cy * cy).sqrt();
+    if chord < 1e-9 {
+        return 0.0;
+    }
+    let mut max_perp = 0.0_f64;
+    for p in &polyline[1..polyline.len() - 1] {
+        // Perpendicular distance from p to the infinite line through a,b.
+        let perp = (cx * (a.y - p.y) - cy * (a.x - p.x)).abs() / chord;
+        max_perp = max_perp.max(perp);
+    }
+    max_perp / chord
+}
+
+/// Map each directed causal connector (Link) `from_uid -> to_uid` to the polyline
+/// the renderer draws for it, so loop-straightness can look up the drawn
+/// curvature of a loop edge. Flows are not included (loop edges through a flow
+/// valve have no Link and are correctly skipped).
+fn link_polylines(
+    view: &datamodel::StockFlow,
+) -> std::collections::HashMap<(i32, i32), Vec<Point>> {
+    let mut uid_elements: std::collections::HashMap<i32, &ViewElement> =
+        std::collections::HashMap::new();
+    for elem in &view.elements {
+        uid_elements.insert(elem.get_uid(), elem);
+    }
+    let not_arrayed = |_: &str| false;
+    let mut out: std::collections::HashMap<(i32, i32), Vec<Point>> =
+        std::collections::HashMap::new();
+    for elem in &view.elements {
+        if let ViewElement::Link(link) = elem
+            && let (Some(&from), Some(&to)) = (
+                uid_elements.get(&link.from_uid),
+                uid_elements.get(&link.to_uid),
+            )
+        {
+            let polyline = connector_polyline(link, from, to, &not_arrayed, ARC_POLYLINE_SAMPLES);
+            if polyline.len() >= 2 {
+                out.insert((link.from_uid, link.to_uid), polyline);
+            }
+        }
+    }
+    out
+}
+
+/// `loop_straightness`: mean bow shortfall over the causal connectors that
+/// participate in a feedback loop. 0.0 = every loop connector is drawn with at
+/// least the target curvature (the loop reads as a visible circle); 1.0 = loop
+/// connectors are straight (the loop collapses to a zig-zag). 0.0 when the view
+/// has no loop with a causal connector. Deterministic and PURE; reuses the same
+/// loop graph / cycle enumeration as loop_compactness.
+fn compute_loop_straightness(view: &datamodel::StockFlow) -> f64 {
+    let graph = build_loop_graph(view);
+    let cycles = enumerate_simple_cycles(&graph);
+    if cycles.is_empty() {
+        return 0.0;
+    }
+    let polys = link_polylines(view);
+    let mut seen: HashSet<(i32, i32)> = HashSet::new();
+    let mut total = 0.0;
+    let mut count = 0usize;
+    for cycle in &cycles {
+        let n = cycle.len();
+        for k in 0..n {
+            let edge = (cycle[k], cycle[(k + 1) % n]);
+            let Some(poly) = polys.get(&edge) else {
+                continue; // a flow-pipe edge (no Link): exempt
+            };
+            if !seen.insert(edge) {
+                continue; // count each loop connector once
+            }
+            let bow = polyline_bow_ratio(poly);
+            let shortfall = (LOOP_LINK_TARGET_BOW - bow).max(0.0) / LOOP_LINK_TARGET_BOW;
+            total += shortfall;
+            count += 1;
+        }
+    }
+    if count == 0 {
+        0.0
+    } else {
+        total / count as f64
+    }
+}
+
 /// Compute the layout quality metrics for a completed view.
 ///
 /// PURE: takes data, returns scalars, performs no I/O. The `_config` parameter
@@ -1006,6 +1137,9 @@ pub fn compute_layout_metrics(
     // --- loop_compactness (isoperimetric feedback-loop quality) ---
     let loop_compactness = compute_loop_compactness(view);
 
+    // --- loop_straightness (loop connectors drawn as visible curves) ---
+    let loop_straightness = compute_loop_straightness(view);
+
     // --- flow_bends (mean right-angle bends per flow pipe) ---
     let flow_bends = {
         let mut total_bends = 0usize;
@@ -1035,6 +1169,7 @@ pub fn compute_layout_metrics(
         chain_straightness: 0.0,
         loop_compactness,
         flow_bends,
+        loop_straightness,
     }
 }
 
@@ -1972,6 +2107,7 @@ mod tests {
             chain_straightness: 7.0,
             loop_compactness: 8.0,
             flow_bends: 9.0,
+            loop_straightness: 11.0,
         };
         let w = MetricWeights {
             node_overlap: 10.0,
@@ -1984,6 +2120,7 @@ mod tests {
             chain_straightness: 80.0,
             loop_compactness: 90.0,
             flow_bends: 100.0,
+            loop_straightness: 110.0,
         };
         let expected = 1.5 * 10.0
             + 2.0 * 20.0
@@ -1994,7 +2131,8 @@ mod tests {
             + 6.0 * 70.0
             + 7.0 * 80.0
             + 8.0 * 90.0
-            + 9.0 * 100.0;
+            + 9.0 * 100.0
+            + 11.0 * 110.0;
         assert!((m.weighted_cost(&w) - expected).abs() < 1e-9);
     }
 
@@ -2093,6 +2231,20 @@ mod tests {
             w.node_overlap
         );
 
+        // loop_straightness is a Goodhart guard for loop curvature: positive but
+        // well below the dominant family.
+        assert!(
+            w.loop_straightness > 0.0,
+            "loop_straightness should guard loop curvature, got {}",
+            w.loop_straightness
+        );
+        assert!(
+            w.loop_straightness < w.node_overlap,
+            "loop_straightness ({}) must stay below the dominant node_overlap ({})",
+            w.loop_straightness,
+            w.node_overlap
+        );
+
         // `weighted_cost` under the default is still the exact linear combination
         // (the default is now meaningful, not inert): verify against an explicit
         // Σ wᵢ·termᵢ over a hand-set metrics value.
@@ -2107,6 +2259,7 @@ mod tests {
             chain_straightness: 0.0,
             loop_compactness: 0.8,
             flow_bends: 1.0,
+            loop_straightness: 0.6,
         };
         let expected = m.node_overlap * w.node_overlap
             + m.node_connector_overlap * w.node_connector_overlap
@@ -2117,7 +2270,8 @@ mod tests {
             + m.aspect_penalty * w.aspect_penalty
             + m.chain_straightness * w.chain_straightness
             + m.loop_compactness * w.loop_compactness
-            + m.flow_bends * w.flow_bends;
+            + m.flow_bends * w.flow_bends
+            + m.loop_straightness * w.loop_straightness;
         assert!(
             (m.weighted_cost(&w) - expected).abs() < 1e-12,
             "weighted_cost under the default must equal Σ wᵢ·termᵢ: got {} expected {}",
@@ -2139,6 +2293,7 @@ mod tests {
         assert!(m.chain_straightness.is_finite());
         assert!(m.loop_compactness.is_finite());
         assert!(m.flow_bends.is_finite());
+        assert!(m.loop_straightness.is_finite());
     }
 
     fn assert_all_zero(m: &LayoutMetrics) {
@@ -2152,6 +2307,7 @@ mod tests {
         assert_eq!(m.chain_straightness, 0.0);
         assert_eq!(m.loop_compactness, 0.0);
         assert_eq!(m.flow_bends, 0.0);
+        assert_eq!(m.loop_straightness, 0.0);
     }
 
     #[test]

--- a/src/simlin-engine/src/layout/metrics.rs
+++ b/src/simlin-engine/src/layout/metrics.rs
@@ -90,6 +90,13 @@ pub struct LayoutMetrics {
     /// collapsed/collinear loops. 0.0 when the view has no cycle of >= 3 nodes.
     /// Computed and reported now; weight stays 0 until Phase 4 calibration.
     pub loop_compactness: f64,
+    /// Mean number of right-angle bends per flow pipe (a straight pipe has 0, an
+    /// `L` has 1, a `Z` has 2). Flows are orthogonalized before scoring, so this
+    /// rewards placements where the two stocks a flow connects are naturally
+    /// aligned (a straight pipe, 0 bends) over diagonally-offset stocks that
+    /// require an `L`/`Z` detour. 0.0 when the view has no flows.
+    #[serde(default)]
+    pub flow_bends: f64,
 }
 
 /// Per-term weights for the scalar an optimizer minimizes.
@@ -113,6 +120,8 @@ pub struct MetricWeights {
     pub aspect_penalty: f64,
     pub chain_straightness: f64,
     pub loop_compactness: f64,
+    #[serde(default)]
+    pub flow_bends: f64,
 }
 
 impl Default for MetricWeights {
@@ -146,6 +155,11 @@ impl Default for MetricWeights {
     ///   * `loop_compactness` is a low 0.25: it gently REWARDS drawing feedback
     ///     loops as visible circles (a readability aid), but must never dominate
     ///     the overlap/crossings family, so it stays well below 1.0.
+    ///   * `flow_bends` is a low 0.15: flows are always orthogonalized, so this
+    ///     never repairs a defect -- it only nudges the optimizer toward
+    ///     placements where a flow's two stocks line up (a clean straight pipe)
+    ///     instead of an `L`/`Z` detour. A convention aid like
+    ///     `loop_compactness`, kept well below the readability family.
     ///   * `chain_straightness` stays 0.0: it is reserved (not yet computed), so
     ///     it carries no weight.
     fn default() -> Self {
@@ -159,6 +173,7 @@ impl Default for MetricWeights {
             aspect_penalty: 0.0,
             chain_straightness: 0.0,
             loop_compactness: 0.25,
+            flow_bends: 0.15,
         }
     }
 }
@@ -175,6 +190,7 @@ impl LayoutMetrics {
             + self.aspect_penalty * w.aspect_penalty
             + self.chain_straightness * w.chain_straightness
             + self.loop_compactness * w.loop_compactness
+            + self.flow_bends * w.flow_bends
     }
 }
 
@@ -990,6 +1006,23 @@ pub fn compute_layout_metrics(
     // --- loop_compactness (isoperimetric feedback-loop quality) ---
     let loop_compactness = compute_loop_compactness(view);
 
+    // --- flow_bends (mean right-angle bends per flow pipe) ---
+    let flow_bends = {
+        let mut total_bends = 0usize;
+        let mut flow_count = 0usize;
+        for e in &view.elements {
+            if let ViewElement::Flow(f) = e {
+                flow_count += 1;
+                total_bends += crate::layout::orthogonal::flow_bend_count(&f.points);
+            }
+        }
+        if flow_count > 0 {
+            total_bends as f64 / flow_count as f64
+        } else {
+            0.0
+        }
+    };
+
     LayoutMetrics {
         node_overlap,
         node_connector_overlap,
@@ -1001,6 +1034,7 @@ pub fn compute_layout_metrics(
         // reserved; computed in a future rung
         chain_straightness: 0.0,
         loop_compactness,
+        flow_bends,
     }
 }
 
@@ -1937,6 +1971,7 @@ mod tests {
             aspect_penalty: 6.0,
             chain_straightness: 7.0,
             loop_compactness: 8.0,
+            flow_bends: 9.0,
         };
         let w = MetricWeights {
             node_overlap: 10.0,
@@ -1948,6 +1983,7 @@ mod tests {
             aspect_penalty: 70.0,
             chain_straightness: 80.0,
             loop_compactness: 90.0,
+            flow_bends: 100.0,
         };
         let expected = 1.5 * 10.0
             + 2.0 * 20.0
@@ -1957,7 +1993,8 @@ mod tests {
             + 0.25 * 60.0
             + 6.0 * 70.0
             + 7.0 * 80.0
-            + 8.0 * 90.0;
+            + 8.0 * 90.0
+            + 9.0 * 100.0;
         assert!((m.weighted_cost(&w) - expected).abs() < 1e-9);
     }
 
@@ -2042,6 +2079,20 @@ mod tests {
             w.node_overlap
         );
 
+        // flow_bends nudges toward straight pipes (aligned stocks), a convention
+        // aid: positive but well below the dominant family.
+        assert!(
+            w.flow_bends > 0.0,
+            "flow_bends should nudge toward straight flows, got {}",
+            w.flow_bends
+        );
+        assert!(
+            w.flow_bends < w.node_overlap,
+            "flow_bends ({}) must stay below the dominant node_overlap ({})",
+            w.flow_bends,
+            w.node_overlap
+        );
+
         // `weighted_cost` under the default is still the exact linear combination
         // (the default is now meaningful, not inert): verify against an explicit
         // Σ wᵢ·termᵢ over a hand-set metrics value.
@@ -2055,6 +2106,7 @@ mod tests {
             aspect_penalty: 1.5,
             chain_straightness: 0.0,
             loop_compactness: 0.8,
+            flow_bends: 1.0,
         };
         let expected = m.node_overlap * w.node_overlap
             + m.node_connector_overlap * w.node_connector_overlap
@@ -2064,7 +2116,8 @@ mod tests {
             + m.edge_length_cv * w.edge_length_cv
             + m.aspect_penalty * w.aspect_penalty
             + m.chain_straightness * w.chain_straightness
-            + m.loop_compactness * w.loop_compactness;
+            + m.loop_compactness * w.loop_compactness
+            + m.flow_bends * w.flow_bends;
         assert!(
             (m.weighted_cost(&w) - expected).abs() < 1e-12,
             "weighted_cost under the default must equal Σ wᵢ·termᵢ: got {} expected {}",
@@ -2085,6 +2138,7 @@ mod tests {
         assert!(m.aspect_penalty.is_finite());
         assert!(m.chain_straightness.is_finite());
         assert!(m.loop_compactness.is_finite());
+        assert!(m.flow_bends.is_finite());
     }
 
     fn assert_all_zero(m: &LayoutMetrics) {
@@ -2097,6 +2151,7 @@ mod tests {
         assert_eq!(m.aspect_penalty, 0.0);
         assert_eq!(m.chain_straightness, 0.0);
         assert_eq!(m.loop_compactness, 0.0);
+        assert_eq!(m.flow_bends, 0.0);
     }
 
     #[test]

--- a/src/simlin-engine/src/layout/mod.rs
+++ b/src/simlin-engine/src/layout/mod.rs
@@ -14,6 +14,7 @@ pub mod graph;
 pub mod metadata;
 pub mod metrics;
 mod objective;
+mod orthogonal;
 pub mod placement;
 pub mod sfdp;
 pub mod text;
@@ -4097,6 +4098,13 @@ pub fn fresh_layout(
     // Phase 5: Normalize coordinates
     normalize_coordinates(&mut state.elements, DIAGRAM_ORIGIN_MARGIN);
 
+    // Phase 5b: Orthogonalize flow pipes. Placement positions stocks freely, so
+    // a flow between two stocks offset in both axes would render as a diagonal;
+    // SD convention draws flows with horizontal/vertical segments only. This
+    // runs last (after declutter/normalize) so nothing re-diagonalizes it, and
+    // before scoring so the metric sees the real pipe geometry.
+    orthogonal::orthogonalize_flow_pipes(&mut state.elements);
+
     // Phase 6: Apply feedback loop curvature
     apply_loop_curvature(&mut state, config, model, metadata);
 
@@ -5744,6 +5752,10 @@ pub fn incremental_layout(
     // Step 8: Polish
     optimize_labels(&mut state, model, &metadata);
     apply_loop_curvature(&mut state, &config, model, &metadata);
+    // Guarantee flows stay orthogonal after re-snapping endpoints to moved
+    // stocks (only rewrites pipes that actually went diagonal; hand-routed
+    // orthogonal flows are left untouched).
+    orthogonal::orthogonalize_flow_pipes(&mut state.elements);
 
     validate_view_completeness(&state, model)?;
 

--- a/src/simlin-engine/src/layout/mod.rs
+++ b/src/simlin-engine/src/layout/mod.rs
@@ -705,6 +705,15 @@ fn place_new_chain_elements(
     }
 
     for flow_ident in &new_elements.new_flows {
+        // A flow between two EXISTING stocks belongs at their midpoint (the valve
+        // sits on the pipe between them), not offset to the side -- and it is
+        // pinned there during settle (see `settle_new_elements`), because as a
+        // free SFDP node with rest length k it would be pushed far from the
+        // midpoint whenever the two stocks are closer together than k.
+        if let Some(mid) = stock_to_stock_flow_midpoint(state, metadata, flow_ident, new_set) {
+            result.insert(flow_ident.clone(), mid);
+            continue;
+        }
         let connected = connected_existing_positions(state, metadata, flow_ident, new_set);
         if connected.is_empty() {
             let pos = Position::new(bbox_max.x + 200.0, bbox_max.y + offset_y);
@@ -718,6 +727,33 @@ fn place_new_chain_elements(
             );
         }
     }
+}
+
+/// The midpoint of a flow's two stocks when BOTH already exist (are not new), or
+/// `None` otherwise (a cloud flow, or a flow into/out of a new stock, which the
+/// chain/rigid-group machinery positions instead). This is the canonical valve
+/// position for an incrementally-added stock-to-stock flow.
+fn stock_to_stock_flow_midpoint(
+    state: &LayoutState,
+    metadata: &ComputedMetadata,
+    flow_ident: &str,
+    new_set: &HashSet<&str>,
+) -> Option<Position> {
+    let (from_stock, to_stock) = metadata.connected_stocks(flow_ident);
+    let from_stock = from_stock?;
+    let to_stock = to_stock?;
+    if new_set.contains(from_stock) || new_set.contains(to_stock) {
+        return None;
+    }
+    let a = state
+        .uid_manager
+        .get_uid(from_stock)
+        .and_then(|uid| state.positions.get(&uid).copied())?;
+    let b = state
+        .uid_manager
+        .get_uid(to_stock)
+        .and_then(|uid| state.positions.get(&uid).copied())?;
+    Some(chain::stock_pair_valve_position(a, b, 0, 1))
 }
 
 /// Run SFDP + annealing with existing elements pinned and only new
@@ -758,13 +794,24 @@ pub fn settle_new_elements(
     // Build constrained graph: pin existing elements, make new chains rigid groups
     let mut constrained_builder = ConstrainedGraphBuilder::new(full_graph);
 
-    // Pin all existing (non-new) nodes
-    let existing_node_ids: Vec<String> = var_to_node
+    // Pin all existing (non-new) nodes, plus any NEW flow that connects two
+    // existing stocks: its valve is fixed at the stock midpoint
+    // (`stock_to_stock_flow_midpoint`), so letting it float as an SFDP node
+    // (rest length k) would push it far off whenever the stocks are closer than
+    // k. The rest of a genuinely new chain still settles normally.
+    let mut pinned_node_ids: Vec<String> = var_to_node
         .iter()
         .filter(|(ident, _)| !new_ident_set.contains(ident.as_str()))
         .map(|(_, node_id)| node_id.clone())
         .collect();
-    constrained_builder.pin(&existing_node_ids);
+    for flow_ident in &new_elements.new_flows {
+        if stock_to_stock_flow_midpoint(state, metadata, flow_ident, &new_ident_set).is_some()
+            && let Some(node_id) = var_to_node.get(flow_ident)
+        {
+            pinned_node_ids.push(node_id.clone());
+        }
+    }
+    constrained_builder.pin(&pinned_node_ids);
 
     // Add rigid groups for new chain elements (same pattern as run_sfdp_with_rigid_chains)
     for (_stocks, _flows, all_vars) in chains_data {

--- a/src/simlin-engine/src/layout/orthogonal.rs
+++ b/src/simlin-engine/src/layout/orthogonal.rs
@@ -1,0 +1,442 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+//! Final-pass orthogonalization of flow pipes.
+//!
+//! System-dynamics convention draws a flow (a stock-to-stock rate) as a "pipe"
+//! made of horizontal and vertical segments only -- never a diagonal. The
+//! placement and chain passes position stocks freely, so a flow between two
+//! stocks that share neither an x nor a y coordinate would otherwise render as
+//! a straight diagonal line. This pass rewrites any such pipe into an
+//! axis-aligned poly-line (an `L` with one bend, or a `Z` with two), so the
+//! orthogonality invariant holds structurally regardless of where placement put
+//! the stocks.
+//!
+//! The pass is deliberately conservative and idempotent:
+//!
+//! * a pipe whose every segment is already axis-aligned is left untouched (so a
+//!   hand-routed flow preserved by the incremental path is never clobbered, and
+//!   re-running the pass is a no-op);
+//! * only pipes that actually contain a diagonal segment are rebuilt, and they
+//!   are rebuilt from their two *attached* endpoints (the faces the placement /
+//!   resnap passes already chose), inserting bends so each segment leaves its
+//!   stock face perpendicular.
+//!
+//! The valve (the flow's `(x, y)`) is left where the layout put it. For the
+//! common stock-to-stock case (both endpoints on left/right faces) the rebuilt
+//! `Z` route's middle segment passes through the valve column, so the valve
+//! still sits on the rendered pipe.
+
+use std::collections::HashMap;
+
+use crate::datamodel::ViewElement;
+use crate::datamodel::view_element::FlowPoint;
+use crate::diagram::constants::{STOCK_HEIGHT, STOCK_WIDTH};
+
+/// Tolerance (in diagram units) for deciding whether two coordinates are equal
+/// (a segment is axis-aligned) or a point sits on a stock face.
+const EPS: f64 = 1e-6;
+
+/// Which face of a stock an attached endpoint sits on.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum Face {
+    /// A left or right (vertical) face: the segment leaving it is horizontal.
+    Horizontal,
+    /// A top or bottom (horizontal) face: the segment leaving it is vertical.
+    Vertical,
+}
+
+/// True when the segment `(a) -> (b)` is axis-aligned (horizontal or vertical).
+fn segment_is_orthogonal(a: &FlowPoint, b: &FlowPoint) -> bool {
+    (a.x - b.x).abs() < EPS || (a.y - b.y).abs() < EPS
+}
+
+/// True when every segment of `points` is axis-aligned.
+fn pipe_is_orthogonal(points: &[FlowPoint]) -> bool {
+    points
+        .windows(2)
+        .all(|w| segment_is_orthogonal(&w[0], &w[1]))
+}
+
+/// The face a stock-attached endpoint sits on, derived from its offset from the
+/// stock center. After resnap an endpoint lies exactly on a face, so the
+/// dominant offset axis identifies the face; we fall back to the larger
+/// (aspect-normalized) offset if neither lands exactly on an edge.
+fn face_of(p: &FlowPoint, stock: (f64, f64)) -> Face {
+    let half_w = STOCK_WIDTH / 2.0;
+    let half_h = STOCK_HEIGHT / 2.0;
+    let dx = (p.x - stock.0).abs();
+    let dy = (p.y - stock.1).abs();
+    let on_vertical_edge = (dx - half_w).abs() < EPS && dy <= half_h + EPS;
+    let on_horizontal_edge = (dy - half_h).abs() < EPS && dx <= half_w + EPS;
+    if on_vertical_edge && !on_horizontal_edge {
+        Face::Horizontal
+    } else if on_horizontal_edge && !on_vertical_edge {
+        Face::Vertical
+    } else {
+        // Not exactly on a single edge (a corner, or moved): pick the face the
+        // aspect-normalized rule would, matching `resnap_flow_endpoints`.
+        if half_h * dx >= half_w * dy {
+            Face::Horizontal
+        } else {
+            Face::Vertical
+        }
+    }
+}
+
+/// Build the axis-aligned interior between `from` and `to`, given each endpoint's
+/// face (if it is attached to a stock) and the valve position. Returns the full
+/// poly-line including `from` and `to`.
+///
+/// * both Horizontal faces -> `Z` with a vertical middle segment at the valve's
+///   x (so the valve sits on the pipe);
+/// * both Vertical faces -> `Z` with a horizontal middle segment at the valve's
+///   y;
+/// * one of each -> a single-bend `L`;
+/// * a free (cloud / unattached) endpoint -> the bend is driven by the attached
+///   end's face so its segment still leaves the stock perpendicular.
+fn route_orthogonal(
+    from: FlowPoint,
+    to: FlowPoint,
+    from_face: Option<Face>,
+    to_face: Option<Face>,
+    valve: (f64, f64),
+) -> Vec<FlowPoint> {
+    let bend = |x: f64, y: f64| FlowPoint {
+        x,
+        y,
+        attached_to_uid: None,
+    };
+    let (fx, fy) = (from.x, from.y);
+    let (tx, ty) = (to.x, to.y);
+
+    let points = match (from_face, to_face) {
+        (Some(Face::Horizontal), Some(Face::Horizontal)) => {
+            vec![from, bend(valve.0, fy), bend(valve.0, ty), to]
+        }
+        (Some(Face::Vertical), Some(Face::Vertical)) => {
+            vec![from, bend(fx, valve.1), bend(tx, valve.1), to]
+        }
+        (Some(Face::Horizontal), Some(Face::Vertical)) => {
+            vec![from, bend(tx, fy), to]
+        }
+        (Some(Face::Vertical), Some(Face::Horizontal)) => {
+            vec![from, bend(fx, ty), to]
+        }
+        // One end free: route perpendicular to the attached end's face.
+        (Some(Face::Horizontal), None) => vec![from, bend(tx, fy), to],
+        (Some(Face::Vertical), None) => vec![from, bend(fx, ty), to],
+        (None, Some(Face::Horizontal)) => vec![from, bend(fx, ty), to],
+        (None, Some(Face::Vertical)) => vec![from, bend(tx, fy), to],
+        // Neither attached: a plain L through the valve corner.
+        (None, None) => vec![from, bend(tx, fy), to],
+    };
+
+    dedup_collinear(points)
+}
+
+/// Drop duplicate and collinear interior points so a degenerate route (e.g. a
+/// `Z` whose two stocks happen to share a row) collapses to the simplest
+/// poly-line.
+fn dedup_collinear(points: Vec<FlowPoint>) -> Vec<FlowPoint> {
+    if points.len() <= 2 {
+        return points;
+    }
+    let mut out: Vec<FlowPoint> = Vec::with_capacity(points.len());
+    for p in points {
+        // Drop a point coincident with the previous one.
+        if let Some(last) = out.last()
+            && (last.x - p.x).abs() < EPS
+            && (last.y - p.y).abs() < EPS
+        {
+            continue;
+        }
+        // Drop the middle of three collinear points.
+        if out.len() >= 2 {
+            let a = &out[out.len() - 2];
+            let b = &out[out.len() - 1];
+            let collinear_h = (a.y - b.y).abs() < EPS && (b.y - p.y).abs() < EPS;
+            let collinear_v = (a.x - b.x).abs() < EPS && (b.x - p.x).abs() < EPS;
+            if collinear_h || collinear_v {
+                out.pop();
+            }
+        }
+        out.push(p);
+    }
+    out
+}
+
+/// Rewrite every diagonal flow pipe in `elements` into axis-aligned segments.
+///
+/// Reads stock centers from `elements` (so it must run after positions are
+/// final). Flows whose pipes are already orthogonal are left untouched.
+pub(crate) fn orthogonalize_flow_pipes(elements: &mut [ViewElement]) {
+    let stocks: HashMap<i32, (f64, f64)> = elements
+        .iter()
+        .filter_map(|e| match e {
+            ViewElement::Stock(s) => Some((s.uid, (s.x, s.y))),
+            _ => None,
+        })
+        .collect();
+
+    for elem in elements.iter_mut() {
+        let ViewElement::Flow(f) = elem else { continue };
+        if f.points.len() < 2 || pipe_is_orthogonal(&f.points) {
+            continue;
+        }
+
+        let from = f.points.first().unwrap().clone();
+        let to = f.points.last().unwrap().clone();
+        let from_face = from
+            .attached_to_uid
+            .and_then(|uid| stocks.get(&uid))
+            .map(|&s| face_of(&from, s));
+        let to_face = to
+            .attached_to_uid
+            .and_then(|uid| stocks.get(&uid))
+            .map(|&s| face_of(&to, s));
+
+        f.points = route_orthogonal(from, to, from_face, to_face, (f.x, f.y));
+    }
+}
+
+/// The number of genuine bends (interior vertices that change the pipe's
+/// direction) across all flows. A straight pipe has 0; an `L` has 1; a `Z` has
+/// 2. Used by the layout-quality metric to prefer naturally-aligned stocks
+/// (which need no bend) over misaligned ones.
+pub(crate) fn flow_bend_count(points: &[FlowPoint]) -> usize {
+    if points.len() < 3 {
+        return 0;
+    }
+    let mut bends = 0;
+    for w in points.windows(3) {
+        let (a, b, c) = (&w[0], &w[1], &w[2]);
+        // b is a bend unless a, b, c are collinear.
+        let collinear_h = (a.y - b.y).abs() < EPS && (b.y - c.y).abs() < EPS;
+        let collinear_v = (a.x - b.x).abs() < EPS && (b.x - c.x).abs() < EPS;
+        if !(collinear_h || collinear_v) {
+            bends += 1;
+        }
+    }
+    bends
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::datamodel::view_element::{Flow, LabelSide, Stock};
+
+    fn fp(x: f64, y: f64, attached: Option<i32>) -> FlowPoint {
+        FlowPoint {
+            x,
+            y,
+            attached_to_uid: attached,
+        }
+    }
+
+    fn stock(uid: i32, x: f64, y: f64) -> ViewElement {
+        ViewElement::Stock(Stock {
+            name: format!("s{uid}"),
+            uid,
+            x,
+            y,
+            label_side: LabelSide::Bottom,
+            compat: None,
+        })
+    }
+
+    fn flow(uid: i32, vx: f64, vy: f64, points: Vec<FlowPoint>) -> ViewElement {
+        ViewElement::Flow(Flow {
+            name: format!("f{uid}"),
+            uid,
+            x: vx,
+            y: vy,
+            label_side: LabelSide::Bottom,
+            points,
+            compat: None,
+            label_compat: None,
+        })
+    }
+
+    fn flow_points(elem: &ViewElement) -> &[FlowPoint] {
+        match elem {
+            ViewElement::Flow(f) => &f.points,
+            _ => panic!("not a flow"),
+        }
+    }
+
+    fn assert_orthogonal(points: &[FlowPoint]) {
+        for w in points.windows(2) {
+            assert!(
+                segment_is_orthogonal(&w[0], &w[1]),
+                "segment ({:.1},{:.1})->({:.1},{:.1}) is diagonal",
+                w[0].x,
+                w[0].y,
+                w[1].x,
+                w[1].y
+            );
+        }
+    }
+
+    /// Two stocks on the same row -> the flow is already a horizontal pipe and
+    /// must be left exactly as-is.
+    #[test]
+    fn aligned_horizontal_flow_is_untouched() {
+        let half_w = STOCK_WIDTH / 2.0;
+        let mut elements = vec![
+            stock(1, 100.0, 100.0),
+            stock(2, 300.0, 100.0),
+            flow(
+                3,
+                200.0,
+                100.0,
+                vec![
+                    fp(100.0 + half_w, 100.0, Some(1)),
+                    fp(300.0 - half_w, 100.0, Some(2)),
+                ],
+            ),
+        ];
+        let before = flow_points(&elements[2]).to_vec();
+        orthogonalize_flow_pipes(&mut elements);
+        assert_eq!(flow_points(&elements[2]), before.as_slice());
+    }
+
+    /// Two stocks offset in both x and y, both endpoints snapped to left/right
+    /// faces -> a Z route with a vertical middle segment through the valve.
+    #[test]
+    fn diagonal_stock_pair_becomes_orthogonal_z() {
+        let half_w = STOCK_WIDTH / 2.0;
+        // A at (100,100), B at (300,250). Both endpoints on horizontal faces.
+        let mut elements = vec![
+            stock(1, 100.0, 100.0),
+            stock(2, 300.0, 250.0),
+            flow(
+                3,
+                200.0,
+                175.0,
+                vec![
+                    fp(100.0 + half_w, 100.0, Some(1)),
+                    fp(300.0 - half_w, 250.0, Some(2)),
+                ],
+            ),
+        ];
+        orthogonalize_flow_pipes(&mut elements);
+        let pts = flow_points(&elements[2]);
+        assert_orthogonal(pts);
+        assert!(pts.len() >= 3, "expected a bend, got {} points", pts.len());
+        // Endpoints stay attached to their stocks.
+        assert_eq!(pts.first().unwrap().attached_to_uid, Some(1));
+        assert_eq!(pts.last().unwrap().attached_to_uid, Some(2));
+        // The valve (200,175) lies on the vertical middle segment x=200.
+        assert!(pts.iter().any(|p| (p.x - 200.0).abs() < EPS));
+    }
+
+    /// One endpoint on a horizontal face, the other on a vertical face -> a
+    /// single-bend L.
+    #[test]
+    fn mixed_faces_become_single_bend_l() {
+        let half_w = STOCK_WIDTH / 2.0;
+        let half_h = STOCK_HEIGHT / 2.0;
+        // A exits its right face; B is entered from its top face.
+        let mut elements = vec![
+            stock(1, 100.0, 100.0),
+            stock(2, 300.0, 300.0),
+            flow(
+                3,
+                200.0,
+                200.0,
+                vec![
+                    fp(100.0 + half_w, 100.0, Some(1)),
+                    fp(300.0, 300.0 - half_h, Some(2)),
+                ],
+            ),
+        ];
+        orthogonalize_flow_pipes(&mut elements);
+        let pts = flow_points(&elements[2]);
+        assert_orthogonal(pts);
+        assert_eq!(pts.len(), 3, "an L should have exactly one bend");
+        assert_eq!(flow_bend_count(pts), 1);
+    }
+
+    /// Re-running the pass on an already-orthogonalized pipe changes nothing.
+    #[test]
+    fn orthogonalization_is_idempotent() {
+        let half_w = STOCK_WIDTH / 2.0;
+        let mut elements = vec![
+            stock(1, 100.0, 100.0),
+            stock(2, 300.0, 250.0),
+            flow(
+                3,
+                200.0,
+                175.0,
+                vec![
+                    fp(100.0 + half_w, 100.0, Some(1)),
+                    fp(300.0 - half_w, 250.0, Some(2)),
+                ],
+            ),
+        ];
+        orthogonalize_flow_pipes(&mut elements);
+        let once = flow_points(&elements[2]).to_vec();
+        orthogonalize_flow_pipes(&mut elements);
+        let twice = flow_points(&elements[2]).to_vec();
+        assert_eq!(once, twice);
+    }
+
+    /// A stock-to-cloud diagonal flow (only one attached endpoint) still
+    /// becomes orthogonal.
+    #[test]
+    fn stock_to_cloud_diagonal_becomes_orthogonal() {
+        let half_w = STOCK_WIDTH / 2.0;
+        let mut elements = vec![
+            stock(1, 100.0, 100.0),
+            // last point is unattached (a cloud sink), offset in both axes.
+            flow(
+                3,
+                160.0,
+                140.0,
+                vec![fp(100.0 + half_w, 100.0, Some(1)), fp(220.0, 180.0, None)],
+            ),
+        ];
+        orthogonalize_flow_pipes(&mut elements);
+        let pts = flow_points(&elements[1]);
+        assert_orthogonal(pts);
+    }
+
+    #[test]
+    fn flow_bend_count_counts_direction_changes() {
+        // Straight: 0 bends.
+        assert_eq!(
+            flow_bend_count(&[fp(0.0, 0.0, None), fp(100.0, 0.0, None)]),
+            0
+        );
+        // L: 1 bend.
+        assert_eq!(
+            flow_bend_count(&[
+                fp(0.0, 0.0, None),
+                fp(100.0, 0.0, None),
+                fp(100.0, 50.0, None),
+            ]),
+            1
+        );
+        // Z: 2 bends.
+        assert_eq!(
+            flow_bend_count(&[
+                fp(0.0, 0.0, None),
+                fp(50.0, 0.0, None),
+                fp(50.0, 50.0, None),
+                fp(100.0, 50.0, None),
+            ]),
+            2
+        );
+        // Collinear interior point: not a bend.
+        assert_eq!(
+            flow_bend_count(&[
+                fp(0.0, 0.0, None),
+                fp(50.0, 0.0, None),
+                fp(100.0, 0.0, None),
+            ]),
+            0
+        );
+    }
+}

--- a/src/simlin-engine/src/layout/sfdp.rs
+++ b/src/simlin-engine/src/layout/sfdp.rs
@@ -107,13 +107,17 @@ impl SfdpConfig {
     /// so every layout was cut off mid-flight rather than settled.
     pub fn for_aux_placement() -> Self {
         Self {
-            // The ideal edge length must leave room for LABELS, not just node
-            // shapes: a converged layout puts connected nodes ~k apart, and a
-            // typical two-line variable label is 100-150 units wide. At the
-            // pre-quiescence k of 75 the equilibrium piled labels on top of
-            // each other (the non-converging schedule masked this by cutting
-            // layouts off mid-expansion).
-            k: 150.0,
+            // The ideal edge length needs SOME room for labels, but it no longer
+            // has to leave room for the WHOLE label: the deterministic declutter
+            // (which runs after placement) pushes apart exactly the pairs whose
+            // labels collide, so the equilibrium can pack tighter than the widest
+            // label and let declutter open up only where needed. The historical
+            // k of 75 piled labels up because the declutter did not yet exist (or
+            // converge); at 110 the force pass settles connected nodes about a
+            // label-width apart, near the density of hand-drawn diagrams, and
+            // declutter cleans up the residual collisions -- markedly less sprawl
+            // than the old label-oblivious k of 150.
+            k: 110.0,
             max_iterations: 5000,
             convergence_threshold: 0.001,
             initial_step_size: 1.0,
@@ -127,8 +131,11 @@ impl SfdpConfig {
     /// relative to each other (`chain::compute_chain_positions`): larger ideal
     /// edge length and weaker attraction than aux placement.
     pub fn for_chain_positioning() -> Self {
+        // Slightly larger than aux placement: a chain occupies more than a single
+        // node, so its centers want a bit more separation. Lowered from 150 in
+        // step with aux placement (declutter opens up colliding chain labels).
         Self {
-            k: 150.0,
+            k: 130.0,
             max_iterations: 5000,
             convergence_threshold: 0.001,
             initial_step_size: 1.0,


### PR DESCRIPTION
## Summary

Fixes three layout-quality defects the hill-climb metric had let through, and closes the underlying gap: the metric was a proxy the optimizer gamed (so "generated beats the hand-drawn references" read as a win when it's the Goodhart tell). The conventions the references obey are now either structural guarantees or metric terms.

Validated against the layout eval harness (per-term breakdown + rendered contact sheet) on all 23 corpus models.

## The three issues

**1. Diagonal flows (e.g. thyroid).** A flow between two stocks offset in both x and y rendered as a straight diagonal — `create_flow_view_element` built every stock→stock pipe as just `[from_edge, to_edge]`. SD convention draws flows with horizontal/vertical segments only.
- New `layout/orthogonal.rs`: a final, idempotent pass that rewrites any diagonal pipe into an axis-aligned `L` (one bend) or `Z` (two), routed from the two attached endpoints by which stock face each sits on. Conservative — only rebuilds pipes that actually went diagonal, so hand-routed/already-orthogonal flows are untouched. Runs last in `fresh_layout` and after resnap in the incremental path, so nothing can re-diagonalize it.
- New `flow_bends` metric term (weight 0.15): flows are always orthogonalized, so it never repairs a defect — it nudges best-of-k selection toward placements where a flow's two stocks line up (a clean straight pipe) over an `L`/`Z` detour.

**2. Lost loop curvature (e.g. dp_logistic_growth).** Feedback loops drew as near-straight zig-zags instead of visible circles.
- `loop_curvature_factor` 0.3 → 0.5: a perpendicular loop center now yields a 45° takeoff, the right arc for the common 3–4 node loop.
- New `loop_straightness` metric term (weight 0.1): mean bow shortfall over a loop's causal connectors — a Goodhart guard. Curvature is applied deterministically so a healthy layout scores ~0, but the metric can now never reward flattening a loop back into a zig-zag.
- `loop_compactness` 0.25 → 0.4 to push circular node arrangement.

**3. Too spread out (e.g. wonderland).** Generated layouts sprawled 1.5–4× more than the references.
- Lower SFDP spring length `k` 150 → 110 (aux placement) / 130 (chain positioning). k=150 was label-oblivious (room for the *whole* widest label); the deterministic declutter now separates exactly the colliding labels after placement, so the force pass can settle near hand-drawn density. Per-term eval confirms `label_overlap` stays ~0 across the corpus (no return of the historical k=75 pile-up — that predated the declutter) while sprawl drops toward references (wonderland 1.9→1.5, ai_edited 2.4→1.6).
- `compact_view`: after declutter clears overlaps, binary-search the tightest uniform scale that keeps every footprint separated and pull the layout in to it (provably can't reintroduce an overlap; floored so a sparse layout can't collapse to a knot).
- Track the ghost distance threshold to `k` (factor 2.5 → 1.8): "long connector" is relative to node spacing.
- `sprawl` weight 0.1 → 0.2.

## Also

- A new stock-to-stock flow added incrementally is now pinned at its stock midpoint during settle (it was a free SFDP node, so once compaction/lower-k brought its two stocks closer than `k` it was pushed far off the pipe).
- Guard ceilings regenerated for the new weights; new metric fields carry `#[serde(default)]` so the committed baseline still deserializes; eval baseline re-seeded as the new anchor.

## Validation

- 435 layout lib + 37 integration tests pass (determinism + flow-attachment tripwires included).
- Per-term eval: sprawl down toward references, `label_overlap` flat (~0), flows orthogonal, loops curved.
- Rendered contact sheet confirms: thyroid flows orthogonal + attached, dp_logistic loops visible, wonderland compact, no flow detachment.

## Known caveats (documented in commits)

- `compact_view` is mostly inert in practice — uniform shrink is blocked by any single tight pair (declutter relaxes some pair to exactly the margin); `k` is what actually compacts. Kept because it's safe and helps the no-tight-pair / sparse cases.
- On dense models `loop_straightness` reads high because curvature is only applied to LTM-detected loops while the metric scores all connector-graph cycles. Accepted (matches hand-drawn practice; low weight; doesn't distort selection).
