### PR TITLE
Frontend audit: fix React/state/CSS bugs in src/app and src/diagram

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@
 - [dev/typescript.md](dev/typescript.md) -- TypeScript/React development standards
 - [dev/python.md](dev/python.md) -- Python (pysimlin) development standards
 - [dev/workflow.md](dev/workflow.md) -- Problem-solving philosophy and TDD workflow
+- [dev/frontend-audit-2026-06.md](dev/frontend-audit-2026-06.md) -- June 2026 frontend bug audit of src/app and src/diagram: findings, fix status, tracked follow-ups
 
 ## Project Management
 

--- a/docs/dev/frontend-audit-2026-06.md
+++ b/docs/dev/frontend-audit-2026-06.md
@@ -1,0 +1,83 @@
+# Frontend audit: src/app and src/diagram (June 2026)
+
+A multi-agent audit of the frontend TypeScript/React/CSS code in `src/app` and
+`src/diagram`, focused on real bugs (not function-component conversion). Eight
+area/dimension reviewers swept the code; every finding was then adversarially
+verified by an independent agent before being accepted. 51 raw findings were
+reduced to the confirmed list below (10 were refuted in verification).
+
+Status legend: **fixed** (in the PR introducing this doc), **deferred**
+(tracked but intentionally not fixed here).
+
+## High severity
+
+| # | Finding | Location | Status |
+|---|---------|----------|--------|
+| H1 | Undo/redo does not discard the redo branch when a new edit follows an undo: `updateProject` prepends to the full history instead of `history.slice(projectOffset)`, so undo after edit-after-undo restores sibling states from the abandoned branch | `Editor.tsx` `updateProject` | fixed |
+| H2 | Pan/zoom/momentum/panel-resize flood the 5-entry undo history: `queueViewUpdate` calls `updateProject`, which always prepends a snapshot; viewBox/zoom are serialized into the protobuf so every momentum frame is a distinct snapshot, evicting real edits | `Editor.tsx` `queueViewUpdate` | fixed |
+| H3 | `flowStillBeingCreated` is set on flow creation and never reset (the cancel branch re-sets it to `true`, a typo for `false`); a later Escape-cancel of an unrelated rename calls `onDeleteSelection()` and deletes that variable | `drawing/Canvas.tsx` `handleEditingNameDone` | fixed |
+| H4 | Details panels keyed by `projectVersion`/`projectOffset` remount on every view bump (+0.001 per pan frame, +0.01 per engine round-trip); a mid-typing autosave completion or undo/redo discards in-progress Slate edits and refires the async LaTeX load | `Editor.tsx` `getDetails` | fixed |
+| H5 | Long KaTeX equations overflow the details card: KaTeX `.base` spans are atomic inline-blocks with `white-space: nowrap`, which `overflow-wrap: anywhere` on the ancestor cannot break; `.eqnPreview` is a flex container with `min-width: auto` and no `overflow-x` | `VariableDetails.module.css` | fixed |
+| H6 | `reset.css` (global `box-sizing: border-box`) is absent from the app's compiled CSS bundle, so `.searchBar` (content-box width + `padding: 0 8px`) renders 16px wider than the details `.card`, misaligning their left edges | `Editor.module.css` + bundling | fixed (defensive `box-sizing`); bundling gap tracked |
+| H7 | `HostedWebEditor` initial load rejection is swallowed (network error, non-JSON body, missing `pb`/`version`), leaving a permanently blank editor with no message | `HostedWebEditor.tsx` | fixed |
+| H8 | The account menu's Logout item only closes the menu; no signOut/navigation/fetch is ever invoked, so users cannot sign out. (Server-side `DELETE /session` is itself a stub.) | `app/Home.tsx` | fixed (client side); server stub tracked |
+
+## Medium severity
+
+| # | Finding | Location | Status |
+|---|---------|----------|--------|
+| M1 | Equation preview feeds raw equation text to `katex.renderToString` during the async LaTeX load window and when the engine can't produce LaTeX, mangling `_` into subscripts etc. | `VariableDetails.tsx` | fixed |
+| M2 | A variable with only a non-fatal unit warning is forced out of the LaTeX preview into the raw editor (`showPreview` gates on `unitErrors` presence, contradicting `variableDetailsView` semantics) | `VariableDetails.tsx` | fixed |
+| M3 | Error highlighting only applies to line 0 and treats engine byte offsets as UTF-16 indices; multi-line equations (including the `{apply-to-all:}\n` prefix) and non-ASCII content mis-highlight. Caret-from-preview-click has the same byte/UTF-16 conflation. Stray `console.log(err)` ships to production | `VariableDetails.tsx`, `equation-caret.ts` | fixed |
+| M4 | `Dialog` exposes `disableEscapeKeyDown` but backdrop clicks always dismiss; in `NewUser`, a backdrop click with a non-empty username submits the PATCH while bypassing the terms-agreement guard on the Submit button | `components/Dialog.tsx`, `app/NewUser.tsx` | fixed |
+| M5 | `Autocomplete` portaled listbox position computed once at open; goes stale when the scrollable details panel scrolls or the window resizes | `components/Autocomplete.tsx` | fixed |
+| M6 | `Login`: `fetchSignInMethodsForEmail` and `sendPasswordResetEmail` lack the try/catch that all sibling auth handlers have; rejections are unhandled and the UI gives no feedback | `app/Login.tsx` | fixed |
+| M7 | Multi-line label `<tspan>`s keyed by line text produce duplicate React keys for repeated lines (severity lowered to low in verification; flat stateless list) | `drawing/Label.tsx` | fixed |
+
+## Low severity
+
+| # | Finding | Location | Status |
+|---|---------|----------|--------|
+| L1 | `LookupEditor`: datapoint count of 1 divides by `size - 1 == 0`, producing NaN x and y that can be saved into the table | `LookupEditor.tsx` | fixed |
+| L2 | Login error states never clear while the user edits the field | `app/Login.tsx` | fixed |
+| L3 | `Home.getProjects`: fired from the constructor, no error catch, no unmount guard (StrictMode double-construction is the reliable trigger) | `app/Home.tsx` | fixed |
+| L4 | `ErrorDetails` list items rendered without React keys | `ErrorDetails.tsx` | fixed |
+| L5 | Editor passes freshly-allocated no-op handlers to PureComponent Canvas in readOnly/embedded mode, defeating its memoization | `Editor.tsx` | fixed |
+| L6 | Untracked `setTimeout`s in module-navigation handlers can run against an unmounted Editor (every other deferred callback is tracked/guarded) | `Editor.tsx` | fixed |
+| L7 | Flow cloud-end retraction applies x and y shifts independently, double-shifting diagonal final segments by sqrt(2)*CloudRadius | `drawing/Flow.tsx` | fixed |
+| L8 | Flow arrowhead angle defaults to 0 (pointing right) when the final segment is zero-length (`atan2(0,0)`) | `drawing/Flow.tsx` | fixed |
+| L9 | Connector aux arc-intersection uses `tan(r/circ.r)`, the same asymptote hazard the stock branch was already fixed to avoid (`atan`) | `drawing/Connector.tsx` | fixed |
+| L10 | `centerVariable` hardcodes the small panel width and `handleZoomChange` the large one, ignoring the 420px medium breakpoint | `Editor.tsx` | fixed |
+| L11 | `Checkbox` onChange type drops Radix `'indeterminate'`; normalize to boolean | `components/Checkbox.tsx` | fixed |
+| L12 | `TextField` spreads downshift inputProps after `id`, breaking label association for a labeled Autocomplete | `components/TextField.tsx` | fixed |
+| L13 | `Menu` anchors Radix to a `position: fixed` proxy span at a memoized rect; the span goes stale if the true anchor moves while open | `components/Menu.tsx` | deferred |
+| L14 | Component library CSS modules hardcode light colors with no dark-mode overrides (latent: editor chrome is not dark-themed today) | `components/*.module.css` | deferred |
+| L15 | Autocomplete dropdown options don't clip/ellipsize long variable names | `components/Autocomplete.module.css` | fixed |
+
+## Deferred / tracked separately
+
+- **reset.css missing from the app CSS bundle**: `src/diagram/index.ts` has a
+  side-effect `import './reset.css'`, but the universal `box-sizing` rule does
+  not survive into `src/app/build/static/css/*`. The panels now declare
+  `box-sizing: border-box` explicitly (defense in depth), but the bundling gap
+  means *all* of reset.css's body/typography defaults are absent app-wide.
+- **Server `DELETE /session` is a stub**: client-side logout (Firebase
+  `signOut`) is wired up, but the session cookie is not invalidated
+  server-side.
+- **Engine round-trip per view-change event**: every wheel tick, momentum
+  animation frame, and pinch update runs `applyPatch` + `serializeProtobuf` +
+  full project JSON re-parse through the WASM engine. Excluding these from
+  undo history (H2) removes the worst symptom; debouncing the persistence is
+  follow-up work.
+- **Dark-mode coverage for the component library** (L14): needs a pass over
+  ~10 CSS modules plus a decision about theming editor chrome.
+- **`Menu` anchor-tracking** (L13): consumer today is short-lived; fix
+  alongside a positioning-library adoption rather than ad hoc.
+
+## Verified-and-rejected findings (for the record)
+
+Ten findings were refuted in adversarial verification, including: `loadSim`'s
+non-functional setState appends (benign in practice), `StaticDiagram` WASM
+handle leak (unreachable path), `HostedWebEditor` not reloading on prop change
+(hosts always remount via key/full navigation), and the snapshot-card object
+URL leak (the Snapshotter UI is commented out; dead code).

--- a/docs/dev/frontend-audit-2026-06.md
+++ b/docs/dev/frontend-audit-2026-06.md
@@ -20,7 +20,7 @@ Status legend: **fixed** (in the PR introducing this doc), **deferred**
 | H5 | Long KaTeX equations overflow the details card: KaTeX `.base` spans are atomic inline-blocks with `white-space: nowrap`, which `overflow-wrap: anywhere` on the ancestor cannot break; `.eqnPreview` is a flex container with `min-width: auto` and no `overflow-x` | `VariableDetails.module.css` | fixed |
 | H6 | `reset.css` (global `box-sizing: border-box`) is absent from the app's compiled CSS bundle, so `.searchBar` (content-box width + `padding: 0 8px`) renders 16px wider than the details `.card`, misaligning their left edges | `Editor.module.css` + bundling | fixed (defensive `box-sizing`); bundling gap tracked |
 | H7 | `HostedWebEditor` initial load rejection is swallowed (network error, non-JSON body, missing `pb`/`version`), leaving a permanently blank editor with no message | `HostedWebEditor.tsx` | fixed |
-| H8 | The account menu's Logout item only closes the menu; no signOut/navigation/fetch is ever invoked, so users cannot sign out. (Server-side `DELETE /session` is itself a stub.) | `app/Home.tsx` | fixed (client side); server stub tracked |
+| H8 | The account menu's Logout item only closes the menu; no signOut/navigation/fetch is ever invoked, so users cannot sign out. (Server-side `DELETE /session` was itself a stub that never responded.) | `app/Home.tsx`, `server/authn.ts` | fixed (client + server) |
 
 ## Medium severity
 
@@ -56,23 +56,26 @@ Status legend: **fixed** (in the PR introducing this doc), **deferred**
 
 ## Deferred / tracked separately
 
-- **reset.css missing from the app CSS bundle**: `src/diagram/index.ts` has a
-  side-effect `import './reset.css'`, but the universal `box-sizing` rule does
-  not survive into `src/app/build/static/css/*`. The panels now declare
-  `box-sizing: border-box` explicitly (defense in depth), but the bundling gap
-  means *all* of reset.css's body/typography defaults are absent app-wide.
-- **Server `DELETE /session` is a stub**: client-side logout (Firebase
-  `signOut`) is wired up, but the session cookie is not invalidated
-  server-side.
-- **Engine round-trip per view-change event**: every wheel tick, momentum
-  animation frame, and pinch update runs `applyPatch` + `serializeProtobuf` +
-  full project JSON re-parse through the WASM engine. Excluding these from
-  undo history (H2) removes the worst symptom; debouncing the persistence is
-  follow-up work.
-- **Dark-mode coverage for the component library** (L14): needs a pass over
-  ~10 CSS modules plus a decision about theming editor chrome.
-- **`Menu` anchor-tracking** (L13): consumer today is short-lived; fix
-  alongside a positioning-library adoption rather than ad hoc.
+- **reset.css missing from the app CSS bundle** (tracked: [#708](https://github.com/bpowers/simlin/issues/708)):
+  `src/diagram/index.ts` has a side-effect `import './reset.css'`, but the
+  universal `box-sizing` rule did not survive into `src/app/build/static/css/*`.
+  An explicit entry-point import restores it (verified in the rebuilt bundle)
+  and the panels declare `box-sizing: border-box` themselves (defense in
+  depth); the underlying tree-shaking behavior is the tracked follow-up.
+- ~~Server `DELETE /session` is a stub~~: fixed in this PR -- the handler now
+  terminates the passport session via `req.logout()` and seshcookie rewrites
+  the cookie (it previously never even wrote a response).
+- **Engine round-trip per view-change event** (tracked: [#707](https://github.com/bpowers/simlin/issues/707)):
+  every wheel tick, momentum animation frame, and pinch update runs
+  `applyPatch` + `serializeProtobuf` + full project JSON re-parse through the
+  WASM engine. Excluding these from undo history (H2) removes the worst
+  symptom; debouncing the persistence is the tracked follow-up.
+- **Dark-mode coverage for the component library** (L14, tracked:
+  [#709](https://github.com/bpowers/simlin/issues/709)): needs a pass over
+  ~16 CSS modules plus a decision about theming editor chrome.
+- **`Menu` anchor-tracking** (L13, tracked:
+  [#710](https://github.com/bpowers/simlin/issues/710)): consumer today is
+  short-lived; fix alongside a positioning-library adoption rather than ad hoc.
 
 ## Verified-and-rejected findings (for the record)
 

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -51,11 +51,22 @@ class UserInfoSingleton {
   private fetch(): void {
     const resultPromise = fetch('/api/user', { credentials: 'same-origin' });
     const worker = async (): Promise<[User | undefined, number]> => {
-      const response = await resultPromise;
-      const status = response.status;
-      const user = status >= 200 && status < 400 ? await response.json() : undefined;
+      try {
+        const response = await resultPromise;
+        const status = response.status;
+        const user = status >= 200 && status < 400 ? await response.json() : undefined;
 
-      return [user, status];
+        return [user, status];
+      } catch (err) {
+        // A network-level failure means "we don't know the user"; callers
+        // already treat a non-2xx status as not-authenticated, so report
+        // status 0 the same way. Catching here also matters because the
+        // promise can sit unconsumed until the next get() (invalidate()
+        // fires a fetch nothing immediately awaits) -- a rejection would
+        // surface later as an unhandled rejection.
+        console.error('fetching /api/user failed:', err);
+        return [undefined, 0];
+      }
     };
     this.resultPromise = worker();
   }
@@ -266,8 +277,17 @@ export class InnerApp extends React.PureComponent<{}, AppState> {
     } catch (err) {
       console.error('logout: firebase signOut failed:', err);
     }
-    await userInfo.invalidate();
+    // Drop the local user BEFORE refreshing the cached /api/user info: the
+    // UI must return to the login screen even if the refresh fails, and
+    // invalidate() can rethrow a pending request's rejection (it awaits any
+    // in-flight fetch), which would otherwise escape Home's fire-and-forget
+    // call as an unhandled rejection.
     this.setState({ user: undefined, isNewUser: undefined, firebaseIdToken: null });
+    try {
+      await userInfo.invalidate();
+    } catch (err) {
+      console.error('logout: refreshing cached user info failed:', err);
+    }
   };
 
   getBaseURL(): string {

--- a/src/app/App.tsx
+++ b/src/app/App.tsx
@@ -9,6 +9,7 @@ import {
   getAuth,
   connectAuthEmulator,
   onAuthStateChanged,
+  signOut,
   Auth as FirebaseAuth,
   User as FirebaseUser,
 } from '@firebase/auth';
@@ -245,6 +246,30 @@ export class InnerApp extends React.PureComponent<{}, AppState> {
     });
   };
 
+  // Sign the user out: clear the server session cookie, then the Firebase
+  // client auth state, then drop the cached/in-memory user so the top-level
+  // auth gate renders Login again. Each step is best-effort -- even if the
+  // network calls fail we still clear local state rather than leaving the
+  // user stuck "logged in" with no way out.
+  handleLogout = async (): Promise<void> => {
+    try {
+      await fetch(`${this.getBaseURL()}/session`, {
+        credentials: 'same-origin',
+        method: 'DELETE',
+        cache: 'no-cache',
+      });
+    } catch (err) {
+      console.error('logout: clearing the server session failed:', err);
+    }
+    try {
+      await signOut(this.state.auth);
+    } catch (err) {
+      console.error('logout: firebase signOut failed:', err);
+    }
+    await userInfo.invalidate();
+    this.setState({ user: undefined, isNewUser: undefined, firebaseIdToken: null });
+  };
+
   getBaseURL(): string {
     return '';
   }
@@ -268,7 +293,7 @@ export class InnerApp extends React.PureComponent<{}, AppState> {
     const location = useLocation()[0];
 
     const isNewProject = location === '/new';
-    return <Home isNewProject={isNewProject} user={defined(this.state.user)} />;
+    return <Home isNewProject={isNewProject} user={defined(this.state.user)} onLogout={this.handleLogout} />;
   };
 
   render() {

--- a/src/app/Home.tsx
+++ b/src/app/Home.tsx
@@ -37,6 +37,7 @@ interface HomeProps {
   user: User;
   isNewProject: boolean;
   onNewProjectDone?: () => void;
+  onLogout: () => void;
 }
 
 const AnchorOrigin = {
@@ -47,6 +48,13 @@ const AnchorOrigin = {
 class Home extends React.Component<HomeProps, HomeState> {
   state: HomeState;
 
+  // Pending setTimeout(0) handle for the deferred getProjects(), plus an
+  // unmount flag: the fetch can resolve after a route change unmounts Home,
+  // and a StrictMode-discarded render-phase instance must never fire the
+  // request at all (it never reaches componentDidMount).
+  private getProjectsTimer: ReturnType<typeof setTimeout> | null = null;
+  private unmounted = false;
+
   constructor(props: HomeProps) {
     super(props);
 
@@ -54,18 +62,43 @@ class Home extends React.Component<HomeProps, HomeState> {
       anchorEl: undefined,
       projects: [],
     };
+    // getProjects is kicked off in componentDidMount, not here: a constructor
+    // side effect also runs for StrictMode's discarded render-phase instance.
+  }
 
-    setTimeout(this.getProjects);
+  componentDidMount() {
+    this.unmounted = false;
+    this.getProjectsTimer = setTimeout(() => {
+      this.getProjectsTimer = null;
+      void this.getProjects();
+    });
+  }
+
+  componentWillUnmount() {
+    this.unmounted = true;
+    if (this.getProjectsTimer !== null) {
+      clearTimeout(this.getProjectsTimer);
+      this.getProjectsTimer = null;
+    }
   }
 
   getProjects = async (): Promise<void> => {
-    const response = await fetch('/api/projects', { credentials: 'same-origin' });
-    const status = response.status;
-    if (!(status >= 200 && status < 400)) {
-      console.log("couldn't fetch projects.");
+    let projects: Project[];
+    try {
+      const response = await fetch('/api/projects', { credentials: 'same-origin' });
+      const status = response.status;
+      if (!(status >= 200 && status < 400)) {
+        console.error(`couldn't fetch projects: HTTP ${status}`);
+        return;
+      }
+      projects = (await response.json()) as Project[];
+    } catch (err) {
+      console.error("couldn't fetch projects:", err);
       return;
     }
-    const projects = (await response.json()) as Project[];
+    if (this.unmounted) {
+      return;
+    }
     this.setState({
       projects,
     });
@@ -75,6 +108,11 @@ class Home extends React.Component<HomeProps, HomeState> {
     this.setState({
       anchorEl: undefined,
     });
+  };
+
+  handleLogout = () => {
+    this.handleClose();
+    this.props.onLogout();
   };
 
   handleMenu = (event: React.MouseEvent<HTMLElement>) => {
@@ -178,7 +216,7 @@ class Home extends React.Component<HomeProps, HomeState> {
                 open={open}
                 onClose={this.handleClose}
               >
-                <MenuItem onClick={this.handleClose}>Logout</MenuItem>
+                <MenuItem onClick={this.handleLogout}>Logout</MenuItem>
               </Menu>
             </div>
           </Toolbar>

--- a/src/app/Login.tsx
+++ b/src/app/Login.tsx
@@ -111,14 +111,17 @@ export class Login extends React.Component<LoginProps, LoginState> {
   emailLoginClick = () => {
     this.setState({ emailLoginFlow: 'showEmail' });
   };
+  // Editing a field clears its stale error: once the user starts correcting
+  // the value, keeping the old red message would be misleading (it described
+  // the previous submission, not the text on screen).
   onFullNameChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ fullName: event.target.value });
+    this.setState({ fullName: event.target.value, fullNameError: undefined });
   };
   onPasswordChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ password: event.target.value });
+    this.setState({ password: event.target.value, passwordError: undefined });
   };
   onEmailChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
-    this.setState({ email: event.target.value });
+    this.setState({ email: event.target.value, emailError: undefined });
   };
   onEmailCancel = () => {
     this.setState({ emailLoginFlow: undefined });
@@ -130,7 +133,19 @@ export class Login extends React.Component<LoginProps, LoginState> {
       return;
     }
 
-    const methods = await fetchSignInMethodsForEmail(this.props.auth, email);
+    // fetchSignInMethodsForEmail rejects on network errors, rate limiting,
+    // and Firebase's email-enumeration protection; the sibling auth handlers
+    // all surface failures, so this one must too (it used to escape as an
+    // unhandled rejection and the form just sat there).
+    let methods: string[];
+    try {
+      methods = await fetchSignInMethodsForEmail(this.props.auth, email);
+    } catch (err) {
+      this.setState({
+        emailError: err instanceof Error ? err.message : 'unable to look up that email address; try again',
+      });
+      return;
+    }
     if (methods.includes('password')) {
       this.setState({ emailLoginFlow: 'showPassword' });
     } else if (methods.length === 0) {
@@ -157,7 +172,16 @@ export class Login extends React.Component<LoginProps, LoginState> {
       return;
     }
 
-    await sendPasswordResetEmail(this.props.auth, email);
+    try {
+      await sendPasswordResetEmail(this.props.auth, email);
+    } catch (err) {
+      // Stay on the recovery card with a visible error rather than advancing
+      // as if the reset email had been sent.
+      this.setState({
+        emailError: err instanceof Error ? err.message : 'sending the recovery email failed; try again',
+      });
+      return;
+    }
 
     this.setState({
       emailLoginFlow: 'showPassword',

--- a/src/app/NewUser.tsx
+++ b/src/app/NewUser.tsx
@@ -92,6 +92,12 @@ export class NewUser extends React.Component<NewUserProps, NewUserState> {
       this.setState({
         errorMsg: 'Simlin requires a non-empty username',
       });
+    } else if (!this.state.agreedToTerms) {
+      // Enter (and previously a backdrop click) routes here too -- it must
+      // not bypass the agreed-to-terms gate that disables the Submit button.
+      this.setState({
+        errorMsg: 'Please agree to the Terms and Privacy Policy to continue',
+      });
     } else {
       setTimeout(this.setUsername);
     }
@@ -115,7 +121,13 @@ export class NewUser extends React.Component<NewUserProps, NewUserState> {
     );
     return (
       <div>
-        <Dialog open={true} disableEscapeKeyDown={true} onClose={this.handleClose} aria-labelledby="form-dialog-title">
+        <Dialog
+          open={true}
+          disableEscapeKeyDown={true}
+          disableBackdropClick={true}
+          onClose={this.handleClose}
+          aria-labelledby="form-dialog-title"
+        >
           <DialogTitle id="form-dialog-title">Welcome!</DialogTitle>
           <DialogContent>
             <DialogContentText>Please choose a username (think of this like a GitHub username).</DialogContentText>

--- a/src/app/index.tsx
+++ b/src/app/index.tsx
@@ -4,6 +4,11 @@
 
 import * as React from 'react';
 import { createRoot } from 'react-dom/client';
+// The reset must be imported explicitly: it is a side-effect import inside
+// @simlin/diagram's index, which production tree-shaking has been observed to
+// drop from the emitted CSS bundle -- silently losing the universal
+// box-sizing: border-box and body defaults app-wide.
+import '@simlin/diagram/reset.css';
 import 'katex/dist/katex.min.css';
 import '@simlin/diagram/theme.css';
 

--- a/src/app/tests/app.test.tsx
+++ b/src/app/tests/app.test.tsx
@@ -21,6 +21,7 @@ jest.mock(
     // Return a fresh unsubscribe stub per call so the lifecycle tests can
     // assert componentWillUnmount tears the subscription down.
     onAuthStateChanged: jest.fn(() => jest.fn()),
+    signOut: jest.fn(async () => {}),
   }),
   { virtual: true },
 );
@@ -78,7 +79,7 @@ import * as React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import { Router } from 'wouter';
 import { memoryLocation } from 'wouter/memory-location';
-import { onAuthStateChanged } from '@firebase/auth';
+import { onAuthStateChanged, signOut } from '@firebase/auth';
 
 import { App, InnerApp } from '../App';
 
@@ -285,5 +286,44 @@ describe('InnerApp.componentDidMount() / componentWillUnmount() lifecycle', () =
     jest.runAllTimers();
 
     expect(getUserInfoSpy).not.toHaveBeenCalled();
+  });
+});
+
+describe('InnerApp.handleLogout', () => {
+  beforeEach(() => {
+    fetchMock.mockClear();
+  });
+
+  test('clears the server session, firebase auth state, and the local user', async () => {
+    setLocation('/');
+    const ref = React.createRef<InnerApp>();
+    const { unmount } = render(
+      <Router hook={memoryLocation({ path: '/', static: true }).hook}>
+        <InnerApp ref={ref} />
+      </Router>,
+    );
+    expect(ref.current).not.toBeNull();
+
+    // Seed a signed-in user, as if getUserInfo had succeeded.
+    ref.current!.setState({
+      user: { id: 'alice' } as unknown as import('../User').User,
+      authUnknown: false,
+    });
+    fetchMock.mockClear();
+
+    await ref.current!.handleLogout();
+
+    // The server session must be torn down...
+    const deleteCall = fetchMock.mock.calls.find(
+      (call) => (call as unknown[])[1] && ((call as unknown[])[1] as { method?: string }).method === 'DELETE',
+    );
+    expect(deleteCall).toBeDefined();
+    expect((deleteCall as unknown[])[0]).toBe('/session');
+    // ...the firebase client signed out...
+    expect(signOut).toHaveBeenCalled();
+    // ...and the local user dropped so the auth gate shows Login again.
+    expect(ref.current!.state.user).toBeUndefined();
+
+    unmount();
   });
 });

--- a/src/app/tests/app.test.tsx
+++ b/src/app/tests/app.test.tsx
@@ -326,4 +326,47 @@ describe('InnerApp.handleLogout', () => {
 
     unmount();
   });
+
+  test('still clears the local user when every network step rejects', async () => {
+    // Every step of handleLogout is best-effort: a transient network
+    // failure during DELETE /session or the /api/user cache refresh
+    // (userInfo.invalidate can rethrow a pending request's rejection) must
+    // neither escape as an unhandled rejection from Home's fire-and-forget
+    // call nor leave the UI stuck signed in.
+    setLocation('/');
+    const ref = React.createRef<InnerApp>();
+    const { unmount } = render(
+      <Router hook={memoryLocation({ path: '/', static: true }).hook}>
+        <InnerApp ref={ref} />
+      </Router>,
+    );
+    expect(ref.current).not.toBeNull();
+
+    ref.current!.setState({
+      user: { id: 'alice' } as unknown as import('../User').User,
+      authUnknown: false,
+    });
+
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    fetchMock.mockClear();
+    fetchMock.mockRejectedValue(new Error('network down'));
+
+    let threw: unknown;
+    try {
+      await ref.current!.handleLogout();
+    } catch (e) {
+      threw = e;
+    }
+    // Let any stray microtasks settle (an unhandled rejection would fail
+    // the test via Jest's unhandled-rejection reporting).
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(threw).toBeUndefined();
+    expect(ref.current!.state.user).toBeUndefined();
+
+    consoleSpy.mockRestore();
+    fetchMock.mockReset();
+    fetchMock.mockImplementation(async () => ({ status: 401, async json() { return {}; } }) as unknown as Response);
+    unmount();
+  });
 });

--- a/src/app/tests/home.test.tsx
+++ b/src/app/tests/home.test.tsx
@@ -1,0 +1,151 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+// Tests for Home: the Logout menu item must actually invoke the logout
+// callback (it used to only close the menu, leaving users with no way to
+// sign out), and the deferred getProjects() fetch must be StrictMode-safe
+// (no constructor side effects), cancel on unmount, and survive a network
+// rejection without an unhandled rejection.
+
+// Replace the diagram component library with light passthroughs; we only
+// need clickable buttons and a Menu that renders its children when open.
+jest.mock(
+  '@simlin/diagram',
+  () => {
+    const React = require('react');
+    // eslint-disable-next-line react/display-name
+    const Pass = (name: string) => (props: { children?: React.ReactNode }) =>
+      React.createElement('div', { 'data-component': name }, props.children);
+    const IconButton = ({
+      children,
+      onClick,
+    }: {
+      children?: React.ReactNode;
+      onClick?: (e: unknown) => void;
+    } & Record<string, unknown>) => React.createElement('button', { onClick }, children);
+    const Menu = ({ open, children }: { open: boolean; children?: React.ReactNode }) =>
+      open ? React.createElement('div', { role: 'menu' }, children) : null;
+    const MenuItem = ({ onClick, children }: { onClick?: () => void; children?: React.ReactNode }) =>
+      React.createElement('button', { role: 'menuitem', onClick }, children);
+    return {
+      AppBar: Pass('AppBar'),
+      Button: Pass('Button'),
+      ImageList: Pass('ImageList'),
+      ImageListItem: Pass('ImageListItem'),
+      IconButton,
+      Menu,
+      MenuItem,
+      Paper: Pass('Paper'),
+      Toolbar: Pass('Toolbar'),
+      Avatar: () => null,
+      AccountCircleIcon: () => React.createElement('span', null, 'account'),
+      MenuIcon: () => React.createElement('span', null, 'hamburger'),
+    };
+  },
+  { virtual: true },
+);
+
+jest.mock('../NewProject', () => ({
+  NewProject: () => null,
+}));
+
+import * as React from 'react';
+import { render, fireEvent, screen, act } from '@testing-library/react';
+
+import Home from '../Home';
+import { User } from '../User';
+
+const user: User = {
+  id: 'alice',
+  displayName: 'Alice',
+  email: 'alice@example.com',
+  photoUrl: undefined,
+  provider: 'google',
+} as unknown as User;
+
+function mockFetch(impl: () => Promise<unknown>): jest.Mock {
+  const mock = jest.fn(impl);
+  (globalThis as { fetch?: unknown }).fetch = mock;
+  return mock;
+}
+
+const okProjects = () =>
+  Promise.resolve({
+    status: 200,
+    json: async () => [],
+  });
+
+afterEach(() => {
+  delete (globalThis as { fetch?: unknown }).fetch;
+  jest.useRealTimers();
+});
+
+describe('Home logout', () => {
+  it('clicking Logout invokes onLogout and closes the menu', () => {
+    jest.useFakeTimers();
+    mockFetch(okProjects);
+    const onLogout = jest.fn();
+    render(<Home user={user} isNewProject={false} onLogout={onLogout} />);
+
+    // Open the account menu (second icon button; the first is the hamburger).
+    const buttons = screen.getAllByRole('button');
+    fireEvent.click(buttons[buttons.length - 1]);
+
+    fireEvent.click(screen.getByText('Logout'));
+
+    expect(onLogout).toHaveBeenCalledTimes(1);
+    expect(screen.queryByText('Logout')).toBeNull();
+  });
+});
+
+describe('Home.getProjects lifecycle', () => {
+  it('does not fetch from the constructor alone (StrictMode safety)', () => {
+    jest.useFakeTimers();
+    const fetchMock = mockFetch(okProjects);
+
+    // Constructing without mounting must not schedule the fetch.
+    new (Home as unknown as new (props: unknown) => unknown)({ user, isNewProject: false, onLogout: () => {} });
+    jest.runAllTimers();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fetches after mount', async () => {
+    jest.useFakeTimers();
+    const fetchMock = mockFetch(okProjects);
+    render(<Home user={user} isNewProject={false} onLogout={() => {}} />);
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('cancels the deferred fetch when unmounted before it fires', () => {
+    jest.useFakeTimers();
+    const fetchMock = mockFetch(okProjects);
+    const { unmount } = render(<Home user={user} isNewProject={false} onLogout={() => {}} />);
+
+    unmount();
+    jest.runAllTimers();
+
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('survives a network rejection without an unhandled rejection', async () => {
+    jest.useFakeTimers();
+    mockFetch(() => Promise.reject(new Error('offline')));
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+
+    render(<Home user={user} isNewProject={false} onLogout={() => {}} />);
+    await act(async () => {
+      jest.runAllTimers();
+    });
+
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});

--- a/src/app/tests/login.test.tsx
+++ b/src/app/tests/login.test.tsx
@@ -52,6 +52,27 @@ jest.mock(
     // eslint-disable-next-line react/display-name
     const Pass = (name: string) => (props: { children?: React.ReactNode }) =>
       React.createElement('div', { 'data-component': name }, props.children);
+    // A TextField stub with a real <input> (so tests can type into it via
+    // its label) that renders helperText so error messages are queryable.
+    const TextField = ({
+      label,
+      value,
+      onChange,
+      helperText,
+    }: {
+      label?: string;
+      value?: string;
+      onChange?: (e: unknown) => void;
+      helperText?: string;
+    } & Record<string, unknown>) =>
+      React.createElement(
+        'div',
+        null,
+        React.createElement('input', { 'aria-label': label, value: value ?? '', onChange }),
+        helperText ? React.createElement('p', null, helperText) : null,
+      );
+    const TextLink = ({ children, onClick }: { children?: React.ReactNode; onClick?: () => void }) =>
+      React.createElement('a', { onClick, role: 'link' }, children);
     return {
       AppleIcon: () => null,
       EmailIcon: () => null,
@@ -60,8 +81,8 @@ jest.mock(
       Card: Pass('Card'),
       CardActions: Pass('CardActions'),
       CardContent: Pass('CardContent'),
-      TextLink: Pass('TextLink'),
-      TextField: Pass('TextField'),
+      TextLink,
+      TextField,
     };
   },
   { virtual: true },
@@ -82,6 +103,8 @@ import { Login } from '../Login';
 
 const firebaseAuth = jest.requireMock('@firebase/auth') as {
   signInWithRedirect: jest.Mock;
+  fetchSignInMethodsForEmail: jest.Mock;
+  sendPasswordResetEmail: jest.Mock;
 };
 
 function makeAuth() {
@@ -164,5 +187,63 @@ describe('Login showProviderRedirect flow', () => {
     });
     expect(screen.queryByText('Sign in with Google')).not.toBeNull();
     expect(screen.getByRole('alert').textContent).toMatch(/popup blocked by browser/i);
+  });
+});
+
+describe('Login email-flow error handling', () => {
+  beforeEach(() => {
+    firebaseAuth.fetchSignInMethodsForEmail.mockReset();
+    firebaseAuth.sendPasswordResetEmail.mockReset();
+  });
+
+  test('a rejected fetchSignInMethodsForEmail surfaces a visible error', async () => {
+    firebaseAuth.fetchSignInMethodsForEmail.mockRejectedValueOnce(new Error('too many requests'));
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    fireEvent.click(screen.getByText('Sign in with email'));
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a@example.com' } });
+    fireEvent.click(screen.getByText('Next'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/too many requests/i)).not.toBeNull();
+    });
+  });
+
+  test('a rejected sendPasswordResetEmail keeps the recovery card with a visible error', async () => {
+    firebaseAuth.fetchSignInMethodsForEmail.mockResolvedValueOnce(['password']);
+    firebaseAuth.sendPasswordResetEmail.mockRejectedValueOnce(new Error('quota exceeded'));
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    fireEvent.click(screen.getByText('Sign in with email'));
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a@example.com' } });
+    fireEvent.click(screen.getByText('Next'));
+    await waitFor(() => {
+      expect(screen.queryByText('Trouble signing in?')).not.toBeNull();
+    });
+
+    fireEvent.click(screen.getByText('Trouble signing in?'));
+    fireEvent.click(screen.getByText('Send'));
+
+    await waitFor(() => {
+      // Still on the recovery card (it did NOT advance to the password form)
+      // and the failure is visible.
+      expect(screen.queryByText('Recover password')).not.toBeNull();
+      expect(screen.queryByText(/quota exceeded/i)).not.toBeNull();
+    });
+  });
+
+  test('editing the email field clears a stale email error', async () => {
+    render(<Login disabled={false} auth={makeAuth()} />);
+    fireEvent.click(screen.getByText('Sign in with email'));
+
+    // Submit with an empty email to produce a validation error.
+    fireEvent.click(screen.getByText('Next'));
+    await waitFor(() => {
+      expect(screen.queryByText(/Enter your email address/i)).not.toBeNull();
+    });
+
+    // Typing into the field must clear the stale message.
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a' } });
+    expect(screen.queryByText(/Enter your email address/i)).toBeNull();
   });
 });

--- a/src/app/tests/new-user.test.tsx
+++ b/src/app/tests/new-user.test.tsx
@@ -1,0 +1,108 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+// NewUser's onboarding dialog gates Submit on agreeing to the terms, but
+// Enter in the username field (and previously a backdrop click) routed to
+// handleClose, which submitted the PATCH without checking the agreement.
+// These tests pin the gate: no terms, no PATCH.
+
+jest.mock(
+  '@simlin/diagram',
+  () => {
+    const React = require('react');
+    // eslint-disable-next-line react/display-name
+    const Pass = (name: string) => (props: { children?: React.ReactNode }) =>
+      React.createElement('div', { 'data-component': name }, props.children);
+    const Button = ({
+      children,
+      onClick,
+      disabled,
+    }: {
+      children?: React.ReactNode;
+      onClick?: () => void;
+      disabled?: boolean;
+    } & Record<string, unknown>) => React.createElement('button', { onClick, disabled }, children);
+    const TextField = ({
+      label,
+      onChange,
+      onKeyPress,
+    }: {
+      label?: string;
+      onChange?: (e: unknown) => void;
+      onKeyPress?: (e: unknown) => void;
+    } & Record<string, unknown>) => React.createElement('input', { 'aria-label': label, onChange, onKeyPress });
+    const Checkbox = ({ checked, onChange }: { checked?: boolean; onChange?: (checked: boolean) => void }) =>
+      React.createElement('input', {
+        type: 'checkbox',
+        checked: !!checked,
+        onChange: (e: { target: { checked: boolean } }) => onChange && onChange(e.target.checked),
+      });
+    const FormControlLabel = ({ control, label }: { control?: React.ReactNode; label?: React.ReactNode }) =>
+      React.createElement('label', null, control, label);
+    return {
+      Button,
+      Dialog: Pass('Dialog'),
+      DialogActions: Pass('DialogActions'),
+      DialogContent: Pass('DialogContent'),
+      DialogContentText: Pass('DialogContentText'),
+      DialogTitle: Pass('DialogTitle'),
+      TextField,
+      FormControlLabel,
+      Checkbox,
+    };
+  },
+  { virtual: true },
+);
+
+import * as React from 'react';
+import { render, fireEvent, screen, waitFor } from '@testing-library/react';
+
+import { NewUser } from '../NewUser';
+import { User } from '../User';
+
+const user = { id: 'temp-123', displayName: 'Alice' } as unknown as User;
+
+function mockFetch(): jest.Mock {
+  const mock = jest.fn(async () => ({ status: 200, json: async () => ({}) }));
+  (globalThis as { fetch?: unknown }).fetch = mock;
+  return mock;
+}
+
+afterEach(() => {
+  delete (globalThis as { fetch?: unknown }).fetch;
+});
+
+describe('NewUser terms-of-service gate', () => {
+  it('Enter with a username but no terms agreement does NOT submit', async () => {
+    const fetchMock = mockFetch();
+    render(<NewUser user={user} onUsernameChanged={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'alice' } });
+    fireEvent.keyPress(screen.getByLabelText('Username'), { key: 'Enter', charCode: 13 });
+
+    // The deferred setUsername runs via setTimeout; give it a chance to
+    // (incorrectly) fire before asserting it did not.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(screen.queryByText(/agree to the Terms/i)).not.toBeNull();
+  });
+
+  it('Enter with username and terms agreement submits the PATCH', async () => {
+    const fetchMock = mockFetch();
+    render(<NewUser user={user} onUsernameChanged={() => {}} />);
+
+    fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'alice' } });
+    fireEvent.click(screen.getByRole('checkbox'));
+    fireEvent.keyPress(screen.getByLabelText('Username'), { key: 'Enter', charCode: 13 });
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    });
+    const [url, init] = fetchMock.mock.calls[0] as [string, { method: string; body: string }];
+    expect(url).toBe('/api/user');
+    expect(init.method).toBe('PATCH');
+    expect(JSON.parse(init.body)).toMatchObject({ username: 'alice', agreeToTermsAndPrivacyPolicy: true });
+  });
+});

--- a/src/diagram/CLAUDE.md
+++ b/src/diagram/CLAUDE.md
@@ -1,7 +1,5 @@
 # @simlin/diagram
 
-Last verified: 2026-05-15
-
 React components for model visualization and editing. Designed as a general-purpose SD model editor toolkit without dependencies on the Simlin app or server API.
 
 For global development standards, see the root [CLAUDE.md](/CLAUDE.md).
@@ -55,6 +53,8 @@ Material-style UI component library (40+ components): Accordion, AppBar, Button,
 
 - **Optimistic view updates**: `updateView()` and `queueViewUpdate()` in Editor.tsx call `setView(view)` + increment `projectVersion` synchronously before awaiting the engine round-trip. Any new handler that modifies the view must go through these methods to avoid flicker.
 - **updateProject preserves the live view**: `Editor.updateProject()` rebuilds `activeProject` from the engine's serialized JSON, but then merges via `preserveLiveView()` so that the active model's view comes from `state.activeProject` (the most recent optimistic `setView`). Without this, a slow engine round-trip racing with a newer pan/move would snap the diagram back to the engine's older view. The live view is round-tripped through JSON to re-link element `var` refs and stock inflow/outflow UIDs against the incoming variables.
+- **View-only updates never record undo history**: `updateProject(serialized, { recordHistory: false, scheduleSave: false })` (the `queueViewUpdate` path -- pan/zoom/momentum frames, panel resizes) refreshes `activeProject` and bumps `projectVersion` but must not touch `projectHistory`/`projectOffset`: viewBox/zoom are serialized into the protobuf, so recording them would let a single momentum flick evict every real edit from the 5-entry undo buffer. Real edits go through `advanceProjectHistory` (project-history.ts), which discards the redo branch when editing after an undo.
+- **Details panels are keyed by `projectGeneration`, not `projectVersion`**: VariableDetails/ModuleDetails seed their Slate editors from props in their constructors, so key-driven remounts are what refreshes them. `projectGeneration` increments exactly when project content changes (history-recording `updateProject` calls and undo/redo); keying on `projectVersion` remounted an open panel on every pan frame and autosave completion, discarding in-progress edits.
 - **Link drag arc ownership**: During any single-link arrowhead drag (creation or reattachment), Canvas.tsx's `connector()` has exclusive control over the arc. `applyGroupMovement` is intentionally given `arcPoint: undefined` during link drags so `processLinks` does not interfere. The last-rendered arc is cached in `draggedLinkArc` and used at mouse-up for exact visual consistency.
 - **Collinear defense in Connector geometry**: `takeoffθ()` and `arcCircle()` catch `circleFromPoints` throws for collinear points (cursor on the source-to-target line). Any code passing user cursor positions as arc points must handle this gracefully or go through these functions.
 - **Module navigation stack**: `Editor.modelStack` is an immutable array of `ModuleStackEntry`. Each entry stores the child model name, module ident, and the parent's selection/viewBox/zoom for restoration. `currentModelName(stack)` returns the active model. All navigation goes through `pushModule`/`popModule`/`navigateToLevel` pure functions.

--- a/src/diagram/Editor.module.css
+++ b/src/diagram/Editor.module.css
@@ -57,6 +57,10 @@
   right: 8px;
   height: 48px;
   width: var(--panel-width-sm);
+  /* Explicit border-box: the global reset is not reliably present in every
+     host bundle, and without it the 8px horizontal padding makes this box
+     16px wider than the details card it must align with. */
+  box-sizing: border-box;
   display: flex;
   align-items: center;
   gap: 8px;
@@ -84,6 +88,7 @@
   right: 8px;
   height: 48px;
   width: var(--panel-width-sm);
+  box-sizing: border-box;
 }
 
 .varDetails {

--- a/src/diagram/Editor.tsx
+++ b/src/diagram/Editor.tsx
@@ -84,9 +84,42 @@ import { BreadcrumbBar } from './BreadcrumbBar';
 import styles from './Editor.module.css';
 
 const MaxUndoSize = 5;
-// These must stay in sync with --panel-width-sm and --panel-width-lg in theme.css
+// These must stay in sync with --panel-width-sm/-md/-lg in theme.css (and the
+// media-query breakpoints in Editor.module.css).
 const SearchbarWidthSm = 359;
+const SearchbarWidthMd = 420;
 const SearchbarWidthLg = 480;
+
+// The effective right-panel width at the current viewport, mirroring the
+// media queries in Editor.module.css. Used by viewport-centering math, which
+// previously hardcoded one width and was wrong at the other breakpoints.
+function panelWidth(): number {
+  if (typeof window === 'undefined') {
+    return SearchbarWidthSm;
+  }
+  const w = window.innerWidth;
+  if (w >= 1200) {
+    return SearchbarWidthLg;
+  } else if (w >= 900) {
+    return SearchbarWidthMd;
+  }
+  return SearchbarWidthSm;
+}
+
+// Stable no-op handlers for the read-only/embedded Canvas. Canvas is a
+// PureComponent: allocating fresh arrow functions per render would defeat
+// its shallow prop comparison and force a full re-render of every layer on
+// every Editor render.
+const noopRename = (_oldName: string, _newName: string): void => {};
+const noopSetSelection = (_selected: ReadonlySet<UID>): void => {};
+const noopMoveSelection = (_position: Point): void => {};
+const noopMoveFlow = (_e: FlowViewElement, _t: number, _p: Point): void => {};
+const noopMoveLabel = (_u: UID, _s: 'top' | 'left' | 'bottom' | 'right'): void => {};
+const noopAttachLink = (_element: LinkViewElement, _to: string): void => {};
+const noopCreateVariable = (_element: ViewElement): void => {};
+const noop = (): void => {};
+const noopViewBoxChange = (_viewBox: Rect, _zoom: number): void => {};
+const noopDrillIntoModule = (_moduleIdent: string, _targetModelName: string): void => {};
 
 function convertErrorDetails(
   errors: ErrorDetail[],
@@ -1651,7 +1684,7 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     const cy = element.y;
 
     const viewCy = view.viewBox.height / 2 / zoom;
-    const viewCx = (view.viewBox.width - SearchbarWidthSm) / 2 / zoom;
+    const viewCx = (view.viewBox.width - panelWidth()) / 2 / zoom;
 
     const viewBox: Rect = {
       ...view.viewBox,
@@ -1683,22 +1716,18 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     // Stdlib models are read-only: disable all mutation handlers while
     // keeping selection, viewbox, and drill-in navigation active.
     const readOnly = embedded || isStdlibModel(this.state.modelName);
-    const onRenameVariable = !readOnly ? this.handleRename : (_oldName: string, _newName: string): void => {};
-    const onSetSelection = !embedded ? this.handleSelection : (_selected: ReadonlySet<UID>): void => {};
-    const onMoveSelection = !readOnly ? this.handleSelectionMove : (_position: Point): void => {};
-    const onMoveFlow = !readOnly ? this.handleFlowAttach : (_e: ViewElement, _t: number, _p: Point): void => {};
-    const onMoveLabel = !readOnly
-      ? this.handleMoveLabel
-      : (_u: UID, _s: 'top' | 'left' | 'bottom' | 'right'): void => {};
-    const onAttachLink = !readOnly ? this.handleLinkAttach : (_element: ViewElement, _to: string): void => {};
-    const onCreateVariable = !readOnly ? this.handleCreateVariable : (_element: ViewElement): void => {};
-    const onClearSelectedTool = !readOnly ? this.handleClearSelectedTool : () => {};
-    const onDeleteSelection = !readOnly ? this.handleSelectionDelete : () => {};
-    const onShowVariableDetails = !readOnly ? this.handleShowVariableDetails : () => {};
-    const onViewBoxChange = !embedded ? this.handleViewBoxChange : () => {};
-    const onDrillIntoModule = !embedded
-      ? this.handleDrillIntoModule
-      : (_moduleIdent: string, _targetModelName: string): void => {};
+    const onRenameVariable = !readOnly ? this.handleRename : noopRename;
+    const onSetSelection = !embedded ? this.handleSelection : noopSetSelection;
+    const onMoveSelection = !readOnly ? this.handleSelectionMove : noopMoveSelection;
+    const onMoveFlow = !readOnly ? this.handleFlowAttach : noopMoveFlow;
+    const onMoveLabel = !readOnly ? this.handleMoveLabel : noopMoveLabel;
+    const onAttachLink = !readOnly ? this.handleLinkAttach : noopAttachLink;
+    const onCreateVariable = !readOnly ? this.handleCreateVariable : noopCreateVariable;
+    const onClearSelectedTool = !readOnly ? this.handleClearSelectedTool : noop;
+    const onDeleteSelection = !readOnly ? this.handleSelectionDelete : noop;
+    const onShowVariableDetails = !readOnly ? this.handleShowVariableDetails : noop;
+    const onViewBoxChange = !embedded ? this.handleViewBoxChange : noopViewBoxChange;
+    const onDrillIntoModule = !embedded ? this.handleDrillIntoModule : noopDrillIntoModule;
 
     return (
       <Canvas
@@ -1851,8 +1880,15 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       selectedTool: isStdlibModel(newModelName) ? undefined : this.state.selectedTool,
     });
     // Refresh errors for the newly active model so warning dots and the
-    // error panel reflect the child model's state immediately.
-    setTimeout(() => void this.refreshCachedErrors());
+    // error panel reflect the child model's state immediately. Guarded on
+    // `unmounted` like every other deferred callback in this class -- the
+    // Editor remounts on route changes and EditorHost path swaps, and these
+    // callbacks call setState / engine methods.
+    setTimeout(() => {
+      if (!this.unmounted) {
+        void this.refreshCachedErrors();
+      }
+    });
   };
 
   handleNavigateBack = (): void => {
@@ -1871,13 +1907,20 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     // The parent model's view already exists in the project; we just need to
     // apply the saved viewBox and zoom back onto it.
     setTimeout(async () => {
+      if (this.unmounted) {
+        return;
+      }
       const view = this.getView();
       if (view) {
         await this.queueViewUpdate({ ...view, viewBox: result.restoredViewBox, zoom: result.restoredZoom });
       }
     });
     // Refresh errors for the restored model
-    setTimeout(() => void this.refreshCachedErrors());
+    setTimeout(() => {
+      if (!this.unmounted) {
+        void this.refreshCachedErrors();
+      }
+    });
   };
 
   handleNavigateToLevel = (targetLevel: number): void => {
@@ -1894,13 +1937,20 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     });
     // Restore the target level's viewport asynchronously
     setTimeout(async () => {
+      if (this.unmounted) {
+        return;
+      }
       const view = this.getView();
       if (view) {
         await this.queueViewUpdate({ ...view, viewBox: result.restoredViewBox, zoom: result.restoredZoom });
       }
     });
     // Refresh errors for the target level's model
-    setTimeout(() => void this.refreshCachedErrors());
+    setTimeout(() => {
+      if (!this.unmounted) {
+        void this.refreshCachedErrors();
+      }
+    });
   };
 
   handleSearchChange = async (_event: React.SyntheticEvent | null, newValue: string | null) => {
@@ -2903,7 +2953,7 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     const view = defined(this.getView());
     const oldViewBox = view.viewBox;
 
-    const widthAdjust = this.state.showDetails ? SearchbarWidthLg : 0;
+    const widthAdjust = this.state.showDetails ? panelWidth() : 0;
 
     const oldViewWidth = (oldViewBox.width - widthAdjust) / view.zoom;
     const oldViewHeight = oldViewBox.height / view.zoom;

--- a/src/diagram/Editor.tsx
+++ b/src/diagram/Editor.tsx
@@ -76,6 +76,7 @@ import { UpdateCloudAndFlow } from './drawing/Flow';
 import { applyGroupMovement } from './group-movement';
 import { detectUndoRedo, isEditableElement } from './keyboard-shortcuts';
 import { preserveLiveView } from './merge-live-view';
+import { advanceProjectHistory } from './project-history';
 import { type ModuleStackEntry, currentModelName, pushModule, popModule, navigateToLevel, isStdlibModel } from './module-navigation';
 import { countModelInstances } from './module-details-utils';
 import { BreadcrumbBar } from './BreadcrumbBar';
@@ -520,7 +521,11 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     await this.refreshCachedErrors();
   }
 
-  async updateProject(serializedProject: Readonly<Uint8Array>, scheduleSave = true) {
+  async updateProject(
+    serializedProject: Readonly<Uint8Array>,
+    opts: { scheduleSave?: boolean; recordHistory?: boolean } = {},
+  ) {
+    const { scheduleSave = true, recordHistory = true } = opts;
     if (this.state.projectHistory.length > 0) {
       const current = this.state.projectHistory[this.state.projectOffset];
       if (uint8ArraysEqual(serializedProject, current)) {
@@ -549,18 +554,29 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     // the visible "pan jumps back and forth" effect.
     activeProject = preserveLiveView(activeProject, this.state.activeProject, this.state.modelName);
 
-    const priorHistory = this.state.projectHistory.slice();
-
     // fractionally increase the version -- the server will only send back integer versions,
     // but this will ensure we can use a simple version check in the Canvas to invalidate caches.
     const projectVersion = this.state.projectVersion + 0.01;
 
-    this.setState({
-      projectHistory: [serializedProject, ...priorHistory].slice(0, MaxUndoSize),
-      activeProject,
-      projectVersion,
-      projectOffset: 0,
-    });
+    if (recordHistory) {
+      const nextHistory = advanceProjectHistory(
+        { projectHistory: this.state.projectHistory, projectOffset: this.state.projectOffset },
+        serializedProject,
+        MaxUndoSize,
+      );
+      this.setState({
+        projectHistory: nextHistory.projectHistory,
+        projectOffset: nextHistory.projectOffset,
+        activeProject,
+        projectVersion,
+      });
+    } else {
+      // View-only updates (pan/zoom) refresh the rendered project but must
+      // not consume undo slots or move the undo cursor: viewBox/zoom are
+      // serialized into the protobuf, so recording them would let a single
+      // momentum flick evict every real edit from the small history buffer.
+      this.setState({ activeProject, projectVersion });
+    }
     if (scheduleSave) {
       this.scheduleSave();
     }
@@ -1602,7 +1618,7 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
         return;
       }
 
-      await this.updateProject(await engine.serializeProtobuf(), false);
+      await this.updateProject(await engine.serializeProtobuf(), { scheduleSave: false, recordHistory: false });
     } else {
       // there exists a race where we need to center/update the viewBox when
       // displaying a newly imported model, but the async wasm stuff doesn't

--- a/src/diagram/Editor.tsx
+++ b/src/diagram/Editor.tsx
@@ -195,6 +195,13 @@ interface EditorState {
   flowStillBeingCreated: boolean;
   drawerOpen: boolean;
   projectVersion: number;
+  // Incremented exactly when project *content* changes (real edits and
+  // undo/redo) -- not on view-only updates or save-version bookkeeping.
+  // Used to key the details panels, which seed their Slate editors from
+  // props in their constructors and rely on key-driven remounts to refresh;
+  // keying them on projectVersion remounted an open panel on every pan
+  // frame and autosave completion, discarding in-progress edits.
+  projectGeneration: number;
   snapshotBlob: Blob | undefined;
   variableDetailsActiveTab: number;
   cachedErrors: CachedErrorDetails;
@@ -304,6 +311,7 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       flowStillBeingCreated: false,
       drawerOpen: false,
       projectVersion: props.initialProjectVersion,
+      projectGeneration: 0,
       snapshotBlob: undefined,
       variableDetailsActiveTab: 0,
       cachedErrors: {
@@ -569,6 +577,7 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
         projectOffset: nextHistory.projectOffset,
         activeProject,
         projectVersion,
+        projectGeneration: this.state.projectGeneration + 1,
       });
     } else {
       // View-only updates (pan/zoom) refresh the rendered project but must
@@ -2538,7 +2547,7 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
       return (
         <div className={styles.varDetails}>
           <ModuleDetails
-            key={`md-${this.state.projectVersion}-${this.state.projectOffset}-${ident}`}
+            key={`md-${this.state.projectGeneration}-${ident}`}
             variable={variable}
             viewElement={namedElement}
             project={defined(this.project())}
@@ -2560,7 +2569,7 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     return (
       <div className={styles.varDetails}>
         <VariableDetails
-          key={`vd-${this.state.projectVersion}-${this.state.projectOffset}-${ident}`}
+          key={`vd-${this.state.projectGeneration}-${ident}`}
           variable={variable}
           viewElement={namedElement}
           getLatexEquation={this.getLatexEquation}
@@ -2850,7 +2859,9 @@ export class Editor extends React.PureComponent<EditorProps, EditorState> {
     projectOffset = Math.max(projectOffset, 0);
     const serializedProject = defined(this.state.projectHistory[projectOffset]);
     const projectVersion = this.state.projectVersion + 0.01;
-    this.setState({ projectOffset, projectVersion });
+    // Undo/redo restores different project content, so the details panels
+    // must remount to re-seed from the restored variables.
+    this.setState({ projectOffset, projectVersion, projectGeneration: this.state.projectGeneration + 1 });
 
     this.undoRedoTimer = setTimeout(async () => {
       this.undoRedoTimer = null;

--- a/src/diagram/ErrorDetails.module.css
+++ b/src/diagram/ErrorDetails.module.css
@@ -1,5 +1,7 @@
 .card {
   width: var(--panel-width-sm);
+  /* Match .searchBar: see VariableDetails.module.css */
+  box-sizing: border-box;
   border-radius: 4px;
   background: #fff;
   box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2), 0px 1px 1px 0px rgba(0,0,0,0.14), 0px 1px 3px 0px rgba(0,0,0,0.12);

--- a/src/diagram/ErrorDetails.tsx
+++ b/src/diagram/ErrorDetails.tsx
@@ -28,26 +28,30 @@ export class ErrorDetails extends React.PureComponent<ErrorDetailsProps> {
         modelErrors.length > 0
       )
     ) {
-      errors.push(<div className={styles.list}>simulation error: {errorCodeDescription(simError.code)}</div>);
+      errors.push(
+        <div key="sim" className={styles.list}>
+          simulation error: {errorCodeDescription(simError.code)}
+        </div>,
+      );
     }
     if (modelErrors.length > 0) {
-      for (const err of modelErrors) {
+      modelErrors.forEach((err, i) => {
         if (err.code === ErrorCode.VariablesHaveErrors && varErrors.size > 0) {
-          continue;
+          return;
         }
         const details = err.details;
         errors.push(
-          <div className={styles.list}>
+          <div key={`model-${i}-${err.code}`} className={styles.list}>
             model error: {errorCodeDescription(err.code)}
             {details ? `: ${details}` : undefined}
           </div>,
         );
-      }
+      });
     }
     for (const [ident, errs] of varErrors) {
       for (const err of errs) {
         errors.push(
-          <div className={styles.list}>
+          <div key={`var-${ident}-${err.code}-${err.start}`} className={styles.list}>
             variable "{ident}" error: {errorCodeDescription(err.code)}
           </div>,
         );
@@ -57,7 +61,7 @@ export class ErrorDetails extends React.PureComponent<ErrorDetailsProps> {
       for (const err of errs) {
         const details = err.details;
         errors.push(
-          <div className={styles.list}>
+          <div key={`unit-${ident}-${err.code}-${err.start}`} className={styles.list}>
             variable "{ident}" unit error: {errorCodeDescription(err.code)}
             {details ? `: ${details}` : undefined}
           </div>,

--- a/src/diagram/HostedWebEditor.tsx
+++ b/src/diagram/HostedWebEditor.tsx
@@ -174,23 +174,36 @@ export class HostedWebEditor extends React.PureComponent<HostedWebEditorProps, H
     window.location.assign(url);
   }
 
+  // Must never reject: the componentDidMount caller is fire-and-forget, so a
+  // thrown error would become an unhandled rejection and leave the editor
+  // permanently blank (render() shows nothing until projectBinary is set and
+  // only serviceErrors produce a message).
   async loadProject(): Promise<void> {
     const base = this.getBaseURL();
     const apiPath = `${base}/api/projects/${this.props.username}/${this.props.projectName}`;
-    const response = await fetch(apiPath);
-    if (response.status >= 400) {
-      this.appendModelError(`unable to load ${apiPath}`);
-      return;
+    try {
+      const response = await fetch(apiPath);
+      if (response.status >= 400) {
+        this.appendModelError(`unable to load ${apiPath}`);
+        return;
+      }
+
+      const projectResponse = (await response.json()) as { pb?: unknown; version?: unknown };
+      if (typeof projectResponse?.pb !== 'string' || typeof projectResponse?.version !== 'number') {
+        this.appendModelError(`malformed project response from ${apiPath}`);
+        return;
+      }
+
+      const projectBinary = toUint8Array(projectResponse.pb);
+
+      this.setState({
+        projectBinary,
+        projectVersion: projectResponse.version,
+      });
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.appendModelError(`unable to load ${apiPath}: ${msg}`);
     }
-
-    const projectResponse = await response.json();
-
-    const projectBinary = toUint8Array(projectResponse.pb);
-
-    this.setState({
-      projectBinary,
-      projectVersion: defined(projectResponse.version) as number,
-    });
   }
 
   render(): React.ReactNode {

--- a/src/diagram/LookupEditor.tsx
+++ b/src/diagram/LookupEditor.tsx
@@ -24,6 +24,18 @@ export interface GFTable {
   y: Float64Array;
 }
 
+// The x value for point i of a `size`-point table linearly spanning
+// [xMin, xMax]. A single-point table maps to xMin -- the naive
+// `i / (size - 1)` is 0/0 === NaN for size 1, and a NaN x poisons the
+// lookup()-based resampling (every interpolation read returns NaN) and can
+// then be saved into the table.
+export function xAtTableIndex(i: number, size: number, xMin: number, xMax: number): number {
+  if (size <= 1) {
+    return xMin;
+  }
+  return (i / (size - 1)) * (xMax - xMin) + xMin;
+}
+
 function tableFrom(gf: GraphicalFunction): GFTable | undefined {
   const xpts = gf.xPoints;
   const xscale = gf.xScale;
@@ -43,7 +55,7 @@ function tableFrom(gf: GraphicalFunction): GFTable | undefined {
     // either the x points have been explicitly specified, or
     // it is a linear mapping of points between xmin and xmax,
     // inclusive
-    const xVal = xpts ? at(xpts, i) : (i / (size - 1)) * (xmax - xmin) + xmin;
+    const xVal = xpts ? at(xpts, i) : xAtTableIndex(i, size, xmin, xmax);
     xList[i] = xVal;
     yList[i] = at(ypts, i);
   }
@@ -221,7 +233,7 @@ export class LookupEditor extends React.PureComponent<LookupEditorProps, LookupE
     }
 
     for (let i = 0; i < table.size; i++) {
-      newTable.x[i] = (i / (size - 1)) * (xMax - xMin) + xMin;
+      newTable.x[i] = xAtTableIndex(i, size, xMin, xMax);
     }
 
     return newTable;
@@ -283,7 +295,7 @@ export class LookupEditor extends React.PureComponent<LookupEditorProps, LookupE
     }
 
     for (let i = 0; i < size; i++) {
-      const xVal = (i / (size - 1)) * (xMax - xMin) + xMin;
+      const xVal = xAtTableIndex(i, size, xMin, xMax);
       newTable.x[i] = xVal;
       newTable.y[i] = lookup(oldTable, xVal);
     }

--- a/src/diagram/ModuleDetails.module.css
+++ b/src/diagram/ModuleDetails.module.css
@@ -4,6 +4,8 @@
 
 .card {
   width: var(--panel-width-sm);
+  /* Match .searchBar: see VariableDetails.module.css */
+  box-sizing: border-box;
   max-height: calc(100vh - 18px);
   overflow-y: auto;
   scrollbar-gutter: stable;

--- a/src/diagram/VariableDetails.module.css
+++ b/src/diagram/VariableDetails.module.css
@@ -1,5 +1,8 @@
 .card {
   width: var(--panel-width-sm);
+  /* Match .searchBar: both must compute as border-box so their edges align
+     regardless of whether the global reset is present in the host bundle. */
+  box-sizing: border-box;
   max-height: calc(100vh - 18px);
   overflow-y: auto;
   scrollbar-gutter: stable;
@@ -44,6 +47,16 @@
   transition: opacity 120ms ease-in-out;
   display: flex;
   align-items: center;
+  /* Fallback for genuinely unbreakable content (one very long identifier):
+     scroll horizontally instead of spilling past the card's right edge. */
+  overflow-x: auto;
+}
+
+/* Flex items default to min-width: auto and refuse to shrink below their
+   content size, which would push wide KaTeX output past the card edge
+   instead of letting it wrap/scroll. */
+.eqnPreview > * {
+  min-width: 0;
 }
 
 .eqnPreview :global(.katex-display) {
@@ -58,6 +71,15 @@
   overflow-wrap: anywhere;
   word-break: break-word;
   max-width: 100%;
+}
+
+/* KaTeX packs math into inline-block .base spans that carry
+   white-space: nowrap from katex.css -- atomic boxes that overflow-wrap on
+   an ancestor cannot break inside. Allow line breaks within them so long
+   equations wrap at the card edge. */
+.eqnPreview :global(.katex .base) {
+  white-space: normal;
+  width: auto;
 }
 
 /* Raw equation text shown while the engine LaTeX loads (or when the engine

--- a/src/diagram/VariableDetails.module.css
+++ b/src/diagram/VariableDetails.module.css
@@ -60,6 +60,14 @@
   max-width: 100%;
 }
 
+/* Raw equation text shown while the engine LaTeX loads (or when the engine
+   can't produce LaTeX). Plain text, never routed through KaTeX. */
+.eqnPlain {
+  font-family: 'Roboto Mono', monospace;
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .unitsEditor {
   background-color: rgba(245, 245, 245);
   border-radius: 4px;

--- a/src/diagram/VariableDetails.tsx
+++ b/src/diagram/VariableDetails.tsx
@@ -5,7 +5,7 @@
 import * as React from 'react';
 
 import { LineChart, ChartSeries } from './LineChart';
-import { createEditor, Descendant, Text, Transforms } from 'slate';
+import { createEditor, Descendant, Transforms } from 'slate';
 import { withHistory } from 'slate-history';
 import { Editable, ReactEditor, RenderLeafProps, Slate, withReact } from 'slate-react';
 import Button from './components/Button';
@@ -27,6 +27,13 @@ import { at } from '@simlin/core/collections';
 import { plainDeserialize, plainSerialize } from './drawing/common';
 import { CustomElement, FormattedText, CustomEditor } from './drawing/SlateEditor';
 import { caretOffsetForClick, caretOffsetWithinSpan, RenderedGlyph } from './equation-caret';
+import {
+  HighlightRange,
+  applyToAllPrefix,
+  byteOffsetToUtf16,
+  highlightSpansForLines,
+  slatePointForOffset,
+} from './equation-highlight';
 import { LookupEditor } from './LookupEditor';
 import { variableDetailsView } from './variable-details-display';
 import { errorCodeDescription } from '@simlin/engine';
@@ -74,10 +81,16 @@ function scalarEquationFor(variable: Variable): string {
   if (variable.equation.type === 'scalar') {
     return variable.equation.equation;
   } else if (variable.equation.type === 'applyToAll') {
-    return '{apply-to-all:}\n' + variable.equation.equation;
+    return applyToAllPrefix + variable.equation.equation;
   } else {
     return "{ TODO: arrayed variable editing isn't supported yet}";
   }
+}
+
+// Engine error offsets are byte offsets into the raw equation; the displayed
+// string may carry the apply-to-all prefix in front of it.
+function rawEquationStart(displayed: string, isUnits: boolean): number {
+  return !isUnits && displayed.startsWith(applyToAllPrefix) ? applyToAllPrefix.length : 0;
 }
 
 function highlightErrors(
@@ -86,47 +99,33 @@ function highlightErrors(
   unitErrors: readonly UnitError[] | undefined,
   isUnits: boolean,
 ): CustomElement[] {
-  const result = descendantsFromString(s);
+  const rawStart = rawEquationStart(s, isUnits);
+
+  let range: HighlightRange | undefined;
   if (!isUnits && errors && errors.length > 0) {
     const err = at(errors, 0);
-    console.log(err);
     if (err.end > 0) {
-      const children = defined(result[0]).children as Array<Text>;
-      const textChild: string = defined(children[0]).text;
-
-      const beforeText = textChild.substring(0, err.start);
-      const errText = textChild.substring(err.start, err.end);
-      const afterText = textChild.substring(err.end);
-
-      defined(result[0]).children = [{ text: beforeText }, { text: errText, error: true }, { text: afterText }];
+      range = { startByte: err.start, endByte: err.end, kind: 'error' };
     }
   } else if (unitErrors && unitErrors.length > 0) {
     for (const err of unitErrors) {
+      // Consistency errors point into the equation; definition errors point
+      // into the units string. Only apply the range to the field it targets.
       if (isUnits === err.isConsistencyError) {
         continue;
       }
-      const children = defined(result[0]).children as Array<Text>;
-      const textChild: string = defined(children[0]).text;
-      const end = err.end === 0 ? textChild.length : err.end;
-
-      const beforeText = textChild.substring(0, err.start);
-      const errText = textChild.substring(err.start, end);
-      const afterText = textChild.substring(end);
-
-      const highlighted: FormattedText = isUnits ? { text: errText, error: true } : { text: errText, warning: true };
-      defined(result[0]).children = [{ text: beforeText }, highlighted, { text: afterText }];
-
+      // end === 0 is the engine's "to the end of the text" convention;
+      // byteOffsetToUtf16 clamps, so any large value reads as "the end".
+      const endByte = err.end === 0 ? Number.MAX_SAFE_INTEGER : err.end;
+      range = { startByte: err.start, endByte, kind: isUnits ? 'error' : 'warning' };
       break;
     }
   }
 
-  return result;
+  return highlightSpansForLines(s, rawStart, range).map(
+    (children): CustomElement => ({ type: 'equation', children }),
+  );
 }
-
-// LaTeX provided by engine (Ast::to_latex, with \htmlData{eqnloc=…} source
-// annotations). When the engine couldn't produce LaTeX, the preview falls back
-// to rendering the raw equation text (a trivial passthrough, no annotations).
-const passthroughLatex = (s: string) => s;
 
 // KaTeX needs `trust` enabled to honor `\htmlData`. Scope it to that one
 // command so a user identifier that smuggled in a `\href`/`\url`/etc. is still
@@ -192,8 +191,15 @@ function caretOffsetForPreviewClick(
     const isOperatorGap = annotated.dataset.oploc !== undefined;
     const range = parseLocAttr(isOperatorGap ? annotated.dataset.oploc : annotated.dataset.eqnloc);
     if (range) {
+      // eqnloc/oploc carry byte offsets into the raw equation; convert to
+      // UTF-16 indices in the displayed string (which may be prefixed for
+      // apply-to-all equations) before mapping the click.
+      const rawStart = rawEquationStart(equationStr, false);
+      const raw = equationStr.slice(rawStart);
+      const spanStart = rawStart + byteOffsetToUtf16(raw, range[0]);
+      const spanEnd = rawStart + byteOffsetToUtf16(raw, range[1]);
       const glyphs = collectRenderedGlyphs(annotated);
-      return caretOffsetWithinSpan(glyphs, clientX, clientY, equationStr, range[0], range[1], isOperatorGap);
+      return caretOffsetWithinSpan(glyphs, clientX, clientY, equationStr, spanStart, spanEnd, isOperatorGap);
     }
   }
   const glyphs = collectRenderedGlyphs(host);
@@ -387,8 +393,6 @@ export class VariableDetails extends React.PureComponent<VariableDetailsProps, V
       initialUnits !== stringFromDescendants(this.state.unitsContents) ||
       initialDocs !== stringFromDescendants(this.state.notesContents);
 
-    const errors = this.props.variable.errors;
-    const unitErrors = this.props.variable.unitErrors;
     const detailsView = variableDetailsView(this.props.variable);
     // Unit errors are non-fatal warnings: the variable still simulates and has
     // data. They are rendered beneath the chart (or alongside equation errors)
@@ -422,31 +426,41 @@ export class VariableDetails extends React.PureComponent<VariableDetailsProps, V
       );
     }
 
-    const showPreview = !errors && !unitErrors && !this.state.editingEquation;
+    // Only genuine equation/compile errors force the raw editor open (so the
+    // highlight is visible); non-fatal unit warnings keep the preview, the
+    // same way they keep the chart (see variableDetailsView).
+    const showPreview = detailsView.equationErrors.length === 0 && !this.state.editingEquation;
 
     const equationStr = stringFromDescendants(equationContents);
-    let latexHTML = '';
-    if (showPreview) {
+    let latexHTML: string | undefined;
+    if (showPreview && this.state.latexEquation !== undefined) {
       try {
-        const latex = this.state.latexEquation ?? passthroughLatex(equationStr);
         // `displayMode` so it renders block-style; `trust` (scoped to
-        // \htmlData) so the engine's source-range annotations survive. Long
-        // equations wrap via the .eqnPreview CSS (overflow-wrap: anywhere).
-        latexHTML = katex.renderToString(latex, { throwOnError: false, displayMode: true, trust: katexTrust });
+        // \htmlData) so the engine's source-range annotations survive.
+        latexHTML = katex.renderToString(this.state.latexEquation, {
+          throwOnError: false,
+          displayMode: true,
+          trust: katexTrust,
+        });
       } catch {
-        // fall back to plain text
-        latexHTML = '';
+        latexHTML = undefined;
       }
     }
 
     return (
       <div className={styles.cardContent}>
         {showPreview ? (
-          <div
-            className={styles.eqnPreview}
-            onClick={(e) => this.handlePreviewClick(e, equationStr)}
-            dangerouslySetInnerHTML={{ __html: latexHTML }}
-          />
+          <div className={styles.eqnPreview} onClick={(e) => this.handlePreviewClick(e, equationStr)}>
+            {latexHTML !== undefined ? (
+              <span dangerouslySetInnerHTML={{ __html: latexHTML }} />
+            ) : (
+              // While the engine LaTeX is loading -- or when the engine can't
+              // produce LaTeX at all -- show the raw equation as plain text.
+              // Feeding raw text to katex.renderToString would mangle it:
+              // identifiers like revenue_per_unit render `_` as subscripts.
+              <span className={styles.eqnPlain}>{equationStr}</span>
+            )}
+          </div>
         ) : (
           <Slate
             editor={this.state.equationEditor}
@@ -461,7 +475,10 @@ export class VariableDetails extends React.PureComponent<VariableDetailsProps, V
               autoFocus
               onBlur={() => {
                 this.handleEquationSave();
-                if (!this.props.variable.errors && !this.props.variable.unitErrors) {
+                // Stay in editing mode only for genuine equation errors --
+                // the same gating as showPreview; unit warnings render under
+                // the chart and shouldn't pin the raw editor open.
+                if (!this.props.variable.errors || this.props.variable.errors.length === 0) {
                   this.setState({ editingEquation: false });
                 }
               }}
@@ -534,9 +551,13 @@ export class VariableDetails extends React.PureComponent<VariableDetailsProps, V
         try {
           const editor = this.state.equationEditor;
           ReactEditor.focus(editor);
+          // The Slate document is one element per line; convert the flat
+          // offset to a (line, column) point so multi-line equations place
+          // the caret on the right line.
+          const point = slatePointForOffset(equationStr, offset);
           Transforms.select(editor, {
-            anchor: { path: [0, 0], offset },
-            focus: { path: [0, 0], offset },
+            anchor: { path: [...point.path], offset: point.offset },
+            focus: { path: [...point.path], offset: point.offset },
           });
         } catch {
           // ignore if selection fails; the user can click to place the caret

--- a/src/diagram/components/Autocomplete.module.css
+++ b/src/diagram/components/Autocomplete.module.css
@@ -23,6 +23,11 @@
   cursor: pointer;
   font-family: "Roboto", "Helvetica", "Arial", sans-serif;
   font-size: 1rem;
+  /* The listbox is sized to the input; ellipsize long variable names rather
+     than letting them widen or wrap the row. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .optionHighlighted {

--- a/src/diagram/components/Autocomplete.tsx
+++ b/src/diagram/components/Autocomplete.tsx
@@ -78,8 +78,8 @@ export default function Autocomplete(props: AutocompleteProps) {
     },
   });
 
-  React.useEffect(() => {
-    if (isOpen && wrapperRef.current) {
+  const updateDropdownPosition = React.useCallback(() => {
+    if (wrapperRef.current) {
       const rect = wrapperRef.current.getBoundingClientRect();
       setDropdownPosition({
         top: rect.bottom + window.scrollY,
@@ -87,7 +87,24 @@ export default function Autocomplete(props: AutocompleteProps) {
         width: rect.width,
       });
     }
-  }, [isOpen]);
+  }, []);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    updateDropdownPosition();
+    // The listbox is portaled to document.body, so it doesn't move with the
+    // input. Recompute while open: capture-phase scroll catches scrolls of
+    // any ancestor (e.g. the scrollable details panel hosting the wiring
+    // table), not just the window.
+    window.addEventListener('scroll', updateDropdownPosition, true);
+    window.addEventListener('resize', updateDropdownPosition);
+    return () => {
+      window.removeEventListener('scroll', updateDropdownPosition, true);
+      window.removeEventListener('resize', updateDropdownPosition);
+    };
+  }, [isOpen, updateDropdownPosition]);
 
   const inputProps = getInputProps() as React.InputHTMLAttributes<HTMLInputElement>;
   const params: AutocompleteRenderInputParams = {

--- a/src/diagram/components/Checkbox.tsx
+++ b/src/diagram/components/Checkbox.tsx
@@ -29,7 +29,9 @@ export default function Checkbox(props: CheckboxProps): React.ReactElement {
       style={style}
       checked={checked}
       defaultChecked={defaultChecked}
-      onCheckedChange={onChange}
+      // Radix's CheckedState is boolean | 'indeterminate'; normalize so the
+      // (checked: boolean) contract our callers type against actually holds.
+      onCheckedChange={onChange ? (state) => onChange(state === true) : undefined}
       disabled={disabled}
       name={name}
     >

--- a/src/diagram/components/Dialog.tsx
+++ b/src/diagram/components/Dialog.tsx
@@ -12,6 +12,11 @@ export interface DialogProps {
   open: boolean;
   onClose?: () => void;
   disableEscapeKeyDown?: boolean;
+  // Block dismissal via clicks/interaction outside the dialog. A truly modal
+  // dialog (e.g. mandatory onboarding) needs this in addition to
+  // disableEscapeKeyDown -- Radix otherwise treats a backdrop click as a
+  // close request and routes it to onClose.
+  disableBackdropClick?: boolean;
   'aria-labelledby'?: string;
   className?: string;
   style?: React.CSSProperties;
@@ -19,7 +24,7 @@ export interface DialogProps {
 }
 
 export function Dialog(props: DialogProps): React.ReactElement {
-  const { open, onClose, disableEscapeKeyDown, className, style, children } = props;
+  const { open, onClose, disableEscapeKeyDown, disableBackdropClick, className, style, children } = props;
   const ariaLabelledBy = props['aria-labelledby'];
 
   return (
@@ -39,6 +44,16 @@ export function Dialog(props: DialogProps): React.ReactElement {
           aria-labelledby={ariaLabelledBy}
           onEscapeKeyDown={(event) => {
             if (disableEscapeKeyDown) {
+              event.preventDefault();
+            }
+          }}
+          onPointerDownOutside={(event) => {
+            if (disableBackdropClick) {
+              event.preventDefault();
+            }
+          }}
+          onInteractOutside={(event) => {
+            if (disableBackdropClick) {
               event.preventDefault();
             }
           }}

--- a/src/diagram/components/TextField.tsx
+++ b/src/diagram/components/TextField.tsx
@@ -126,7 +126,6 @@ export default class TextField extends React.PureComponent<TextFieldProps, TextF
             <div className={styles.inputContainer}>
               {startAdornment}
               <input
-                id={inputId}
                 className={styles.standardInput}
                 value={value}
                 onChange={onChange}
@@ -140,6 +139,12 @@ export default class TextField extends React.PureComponent<TextFieldProps, TextF
                 onKeyPress={onKeyPress}
                 {...rest}
                 {...restInputProps}
+                // After the spreads: restInputProps (downshift's
+                // getInputProps() when used inside Autocomplete) must win for
+                // value/onChange/keyboard handling, but the rendered id has
+                // to stay inputId so <label htmlFor={inputId}> keeps pointing
+                // at this input.
+                id={inputId}
               />
             </div>
           </div>
@@ -170,7 +175,6 @@ export default class TextField extends React.PureComponent<TextFieldProps, TextF
           <div className={styles.inputContainer}>
             {startAdornment}
             <input
-              id={inputId}
               className={styles.outlinedInput}
               value={value}
               onChange={onChange}
@@ -184,6 +188,9 @@ export default class TextField extends React.PureComponent<TextFieldProps, TextF
               onKeyPress={onKeyPress}
               {...rest}
               {...restInputProps}
+              // See the standard variant: id must survive the spreads so the
+              // label association holds.
+              id={inputId}
             />
           </div>
         </div>

--- a/src/diagram/drawing/Canvas.tsx
+++ b/src/diagram/drawing/Canvas.tsx
@@ -2102,10 +2102,10 @@ export class Canvas extends React.PureComponent<CanvasProps, CanvasState> {
     }
 
     if (isCancel) {
+      // Cancelling the initial name edit of a just-created flow deletes the
+      // flow; the flag itself is reset by clearPointerState (via
+      // pointerStateReset) so a later rename-cancel can't re-trigger this.
       if (this.state.flowStillBeingCreated) {
-        this.setState({
-          flowStillBeingCreated: true,
-        });
         this.props.onDeleteSelection();
       }
       this.clearPointerState();

--- a/src/diagram/drawing/Connector.tsx
+++ b/src/diagram/drawing/Connector.tsx
@@ -223,7 +223,11 @@ export function intersectElementArc(element: ViewElement, circ: Circle, inv: boo
     r = 0;
   }
 
-  const offθ = tan(r / circ.r);
+  // atan (not tan), mirroring the stock/module branch above: a tight arc
+  // between nearby elements can push r/circ.r past tan's π/2 asymptote,
+  // where tan goes huge or flips sign and swings the arrowhead to the wrong
+  // side. atan is bounded and monotonic for all ratios.
+  const offθ = Math.atan(r / circ.r);
   const elementCenterθ = atan2(cy - circ.y, cx - circ.x);
 
   return {

--- a/src/diagram/drawing/Flow.tsx
+++ b/src/diagram/drawing/Flow.tsx
@@ -20,9 +20,6 @@ import { jsFormatNumber as ff } from '../render-common';
 
 import styles from './Flow.module.css';
 
-const atan2 = Math.atan2;
-const PI = Math.PI;
-
 type Side = 'left' | 'right' | 'top' | 'bottom';
 
 /**
@@ -1521,6 +1518,54 @@ export function UpdateFlow(
   return [flowEl, []];
 }
 
+/**
+ * Pull a cloud-terminated flow's endpoint back by `radius` along the
+ * direction of the final segment, so the arrowhead lands on the cloud's
+ * edge rather than at its center. The retraction follows the segment's unit
+ * vector: for orthogonal segments this matches a single-axis shift, while a
+ * diagonal segment retracts by exactly `radius` (applying independent x and
+ * y shifts would over-retract by sqrt(2)*radius). A zero-length final
+ * segment is returned unchanged.
+ */
+export function retractFinalPointIntoCloud(pts: readonly Point[], radius: number): readonly Point[] {
+  const lastPt = at(pts, pts.length - 1);
+  const prevPt = at(pts, pts.length - 2);
+  const dx = lastPt.x - prevPt.x;
+  const dy = lastPt.y - prevPt.y;
+  const len = Math.sqrt(dx * dx + dy * dy);
+  if (len === 0) {
+    return pts;
+  }
+  return arrayWith(pts, pts.length - 1, {
+    ...lastPt,
+    x: lastPt.x - (radius * dx) / len,
+    y: lastPt.y - (radius * dy) / len,
+  });
+}
+
+/**
+ * Direction, in degrees [0, 360), of the last non-degenerate segment ending
+ * at the flow's final point. Walks backward past coincident points --
+ * atan2(0, 0) is 0, which would otherwise read a zero-length final segment
+ * as "pointing right". Returns undefined when every point coincides.
+ */
+export function finalSegmentAngle(pts: readonly Point[]): number | undefined {
+  const lastPt = at(pts, pts.length - 1);
+  for (let i = pts.length - 2; i >= 0; i--) {
+    const p = at(pts, i);
+    const dx = lastPt.x - p.x;
+    const dy = lastPt.y - p.y;
+    if (dx !== 0 || dy !== 0) {
+      let theta = (Math.atan2(dy, dx) * 180) / Math.PI;
+      if (theta < 0) {
+        theta += 360;
+      }
+      return theta;
+    }
+  }
+  return undefined;
+}
+
 export function flowBounds(element: FlowViewElement): Rect {
   const cx = element.x;
   const cy = element.y;
@@ -1695,21 +1740,7 @@ export class Flow extends React.PureComponent<FlowProps> {
     }
 
     if (sink.type === 'cloud' && !isMovingArrow) {
-      const x = at(pts, pts.length - 1).x;
-      const y = at(pts, pts.length - 1).y;
-      const prevX = at(pts, pts.length - 2).x;
-      const prevY = at(pts, pts.length - 2).y;
-
-      if (prevX < x) {
-        pts = arrayWith(pts, pts.length - 1, { ...pts[pts.length - 1], x: x - CloudRadius });
-      } else if (prevX > x) {
-        pts = arrayWith(pts, pts.length - 1, { ...pts[pts.length - 1], x: x + CloudRadius });
-      }
-      if (prevY < y) {
-        pts = arrayWith(pts, pts.length - 1, { ...pts[pts.length - 1], y: y - CloudRadius });
-      } else if (prevY > y) {
-        pts = arrayWith(pts, pts.length - 1, { ...pts[pts.length - 1], y: y + CloudRadius });
-      }
+      pts = retractFinalPointIntoCloud(pts, CloudRadius);
     }
 
     const finalAdjust = 7.5;
@@ -1719,13 +1750,12 @@ export class Flow extends React.PureComponent<FlowProps> {
       let x = at(pts, j).x;
       let y = at(pts, j).y;
       if (j === pts.length - 1) {
-        const dx = x - at(pts, j - 1).x;
-        const dy = y - at(pts, j - 1).y;
-        let theta = (atan2(dy, dx) * 180) / PI;
-        if (theta < 0) {
-          theta += 360;
-        }
-        if (theta >= 315 || theta < 45) {
+        // Walk back past coincident points: a degenerate (zero-length) final
+        // segment must not read as "pointing right" via atan2(0, 0) === 0.
+        const theta = finalSegmentAngle(pts);
+        if (theta === undefined) {
+          arrowTheta = 0;
+        } else if (theta >= 315 || theta < 45) {
           x -= finalAdjust;
           arrowTheta = 0;
         } else if (theta >= 45 && theta < 135) {

--- a/src/diagram/drawing/Label.tsx
+++ b/src/diagram/drawing/Label.tsx
@@ -209,7 +209,11 @@ export class Label extends React.PureComponent<LabelPropsFull> {
               dy = `${-(lineSpacing * (linesCount - 1))}px`;
             }
             return (
-              <tspan key={l} x={x} dy={dy}>
+              // Keyed by index, not line text: repeated lines (e.g. a label
+              // edited to "x\nx") would otherwise produce duplicate keys.
+              // Index keys are safe here -- a flat, fully-rebuilt list with
+              // no per-line state.
+              <tspan key={i} x={x} dy={dy}>
                 {l}
               </tspan>
             );

--- a/src/diagram/equation-highlight.ts
+++ b/src/diagram/equation-highlight.ts
@@ -1,0 +1,121 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+// Pure helpers for mapping engine-reported source ranges onto the equation
+// text shown in the details panel.
+//
+// Two coordinate mismatches have to be bridged:
+//
+//  1. The Rust engine reports error and `eqnloc` offsets as *byte* offsets
+//     into the UTF-8 encoding of the equation, while JavaScript strings are
+//     indexed by UTF-16 code units. They agree only for pure-ASCII text.
+//  2. The panel sometimes displays a decorated version of the raw equation
+//     (apply-to-all equations are shown with an `{apply-to-all:}` line
+//     prepended), so a raw-equation offset must additionally be shifted to
+//     its position in the displayed string, which may span multiple lines
+//     (one Slate element per line).
+
+import type { FormattedText } from './drawing/SlateEditor';
+
+/** Displayed-string prefix for apply-to-all arrayed equations. Engine offsets
+ *  are relative to the raw equation, which begins after this prefix. */
+export const applyToAllPrefix = '{apply-to-all:}\n';
+
+/**
+ * Convert a byte offset into the UTF-8 encoding of `s` to a UTF-16 code-unit
+ * index. Offsets that land inside a multi-byte character snap to the end of
+ * that character; offsets past the end of the string clamp to `s.length`.
+ */
+export function byteOffsetToUtf16(s: string, byteOffset: number): number {
+  if (byteOffset <= 0) {
+    return 0;
+  }
+  let bytes = 0;
+  let i = 0;
+  while (i < s.length && bytes < byteOffset) {
+    const cp = s.codePointAt(i) as number;
+    bytes += cp <= 0x7f ? 1 : cp <= 0x7ff ? 2 : cp <= 0xffff ? 3 : 4;
+    i += cp > 0xffff ? 2 : 1;
+  }
+  return i;
+}
+
+export interface HighlightRange {
+  /** byte offset into the raw equation (inclusive) */
+  readonly startByte: number;
+  /** byte offset into the raw equation (exclusive) */
+  readonly endByte: number;
+  readonly kind: 'error' | 'warning';
+}
+
+/**
+ * Split `displayed` into lines (one Slate element per line, matching
+ * plainDeserialize) and apply `range` -- byte offsets into the raw equation,
+ * which begins at UTF-16 index `rawStart` within `displayed` -- as
+ * error/warning marks on the covered text. Lines (or line parts) outside the
+ * range come back as plain text spans.
+ */
+export function highlightSpansForLines(
+  displayed: string,
+  rawStart: number,
+  range: HighlightRange | undefined,
+): FormattedText[][] {
+  const lines = displayed.split('\n');
+
+  if (!range) {
+    return lines.map((line) => [{ text: line }]);
+  }
+
+  const raw = displayed.slice(rawStart);
+  const start = rawStart + byteOffsetToUtf16(raw, range.startByte);
+  const end = rawStart + byteOffsetToUtf16(raw, range.endByte);
+  const mark: Partial<FormattedText> = range.kind === 'error' ? { error: true } : { warning: true };
+
+  const result: FormattedText[][] = [];
+  let lineStart = 0;
+  for (const line of lines) {
+    const lineEnd = lineStart + line.length;
+    // Overlap of [start, end) with this line's [lineStart, lineEnd).
+    const hlStart = Math.max(start, lineStart);
+    const hlEnd = Math.min(end, lineEnd);
+    if (hlStart < hlEnd) {
+      const spans: FormattedText[] = [];
+      const before = displayed.slice(lineStart, hlStart);
+      const marked = displayed.slice(hlStart, hlEnd);
+      const after = displayed.slice(hlEnd, lineEnd);
+      if (before) spans.push({ text: before });
+      spans.push({ text: marked, ...mark });
+      if (after) spans.push({ text: after });
+      result.push(spans);
+    } else {
+      result.push([{ text: line }]);
+    }
+    lineStart = lineEnd + 1; // skip the newline
+  }
+  return result;
+}
+
+export interface SlatePoint {
+  readonly path: readonly [number, number];
+  readonly offset: number;
+}
+
+/**
+ * Convert a flat UTF-16 offset into `displayed` to a Slate point in the
+ * one-element-per-line document produced by plainDeserialize. Out-of-range
+ * offsets clamp to the document's start/end.
+ */
+export function slatePointForOffset(displayed: string, offset: number): SlatePoint {
+  const lines = displayed.split('\n');
+  let remaining = Math.max(0, Math.min(displayed.length, offset));
+  for (let i = 0; i < lines.length; i++) {
+    const len = lines[i].length;
+    if (remaining <= len) {
+      return { path: [i, 0], offset: remaining };
+    }
+    remaining -= len + 1; // the newline separating this line from the next
+  }
+  const lastLine = lines.length - 1;
+  return { path: [lastLine, 0], offset: lines[lastLine].length };
+}

--- a/src/diagram/project-history.ts
+++ b/src/diagram/project-history.ts
@@ -1,0 +1,39 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+/**
+ * Pure logic for the Editor's undo history.
+ *
+ * `projectHistory` is a newest-first array of serialized project snapshots;
+ * `projectOffset` indexes the currently-displayed snapshot (0 = newest,
+ * larger = further back in time). Undo increments the offset, redo
+ * decrements it.
+ */
+
+export interface ProjectHistoryState {
+  readonly projectHistory: readonly Readonly<Uint8Array>[];
+  readonly projectOffset: number;
+}
+
+/**
+ * Record a new snapshot as the head of the history.
+ *
+ * When the user has undone (offset > 0) and then edits, the entries at
+ * indices [0, offset) were created *after* the snapshot the edit was made
+ * from -- they are the abandoned redo branch, not ancestors of the new
+ * state. Standard undo semantics discard them so the history stays a linear
+ * ancestry of the current state; keeping them would make a later undo jump
+ * to sibling states the user already navigated away from.
+ */
+export function advanceProjectHistory(
+  current: ProjectHistoryState,
+  snapshot: Readonly<Uint8Array>,
+  maxSize: number,
+): ProjectHistoryState {
+  const ancestry = current.projectHistory.slice(current.projectOffset);
+  return {
+    projectHistory: [snapshot, ...ancestry].slice(0, maxSize),
+    projectOffset: 0,
+  };
+}

--- a/src/diagram/selection-logic.ts
+++ b/src/diagram/selection-logic.ts
@@ -75,6 +75,10 @@ export interface PointerStateReset {
   isDragSelecting: false;
   isMovingCanvas: false;
   isEditingName: false;
+  // Cleared here so that once name editing ends (commit or cancel), a later
+  // Escape-cancel of an unrelated rename can't see a stale `true` and delete
+  // that variable via the cancel-of-newly-created-flow path.
+  flowStillBeingCreated: false;
   dragSelectionPoint: undefined;
   inCreation: undefined;
   inCreationCloud: undefined;
@@ -91,6 +95,7 @@ export function pointerStateReset(): PointerStateReset {
     isDragSelecting: false,
     isMovingCanvas: false,
     isEditingName: false,
+    flowStillBeingCreated: false,
     dragSelectionPoint: undefined,
     inCreation: undefined,
     inCreationCloud: undefined,

--- a/src/diagram/tests/autocomplete.test.tsx
+++ b/src/diagram/tests/autocomplete.test.tsx
@@ -157,3 +157,81 @@ describe('Autocomplete', () => {
     });
   });
 });
+
+describe('Autocomplete dropdown positioning', () => {
+  test('repositions the portaled listbox when an ancestor scrolls while open', async () => {
+    render(
+      <Autocomplete
+        value={null}
+        options={['apple', 'apricot']}
+        onChange={() => {}}
+        renderInput={(params) => (
+          <div ref={params.InputProps.ref} data-testid="wrapper">
+            <input {...params.inputProps} data-testid="autocomplete-input" />
+          </div>
+        )}
+      />,
+    );
+
+    // jsdom has no layout: stub the wrapper's rect and move it between calls,
+    // simulating the input shifting as its scrollable container scrolls.
+    const wrapper = screen.getByTestId('wrapper');
+    const rect = { top: 100, bottom: 120, left: 10, right: 210, width: 200, height: 20, x: 10, y: 100, toJSON: () => ({}) };
+    const rectMock = jest.fn(() => ({ ...rect }) as DOMRect);
+    wrapper.getBoundingClientRect = rectMock;
+
+    // Typing opens the dropdown; the position is computed from the rect.
+    fireEvent.change(screen.getByTestId('autocomplete-input'), { target: { value: 'ap' } });
+    let listbox: HTMLElement | null = null;
+    await waitFor(() => {
+      listbox = document.querySelector('ul[role="listbox"]');
+      expect(listbox).not.toBeNull();
+      expect((listbox as HTMLElement).style.top).toBe('120px');
+    });
+
+    // The container scrolls: the input is now 60px higher on screen. A
+    // capture-phase scroll listener must recompute the portal position.
+    rect.top = 40;
+    rect.bottom = 60;
+    await act(async () => {
+      fireEvent.scroll(document.body);
+    });
+
+    await waitFor(() => {
+      expect((document.querySelector('ul[role="listbox"]') as HTMLElement).style.top).toBe('60px');
+    });
+  });
+
+  test('repositions the portaled listbox on window resize while open', async () => {
+    render(
+      <Autocomplete
+        value={null}
+        options={['apple', 'apricot']}
+        onChange={() => {}}
+        renderInput={(params) => (
+          <div ref={params.InputProps.ref} data-testid="wrapper">
+            <input {...params.inputProps} data-testid="autocomplete-input" />
+          </div>
+        )}
+      />,
+    );
+
+    const wrapper = screen.getByTestId('wrapper');
+    const rect = { top: 100, bottom: 120, left: 10, right: 210, width: 200, height: 20, x: 10, y: 100, toJSON: () => ({}) };
+    wrapper.getBoundingClientRect = jest.fn(() => ({ ...rect }) as DOMRect);
+
+    fireEvent.change(screen.getByTestId('autocomplete-input'), { target: { value: 'ap' } });
+    await waitFor(() => {
+      expect((document.querySelector('ul[role="listbox"]') as HTMLElement).style.top).toBe('120px');
+    });
+
+    rect.left = 50;
+    await act(async () => {
+      fireEvent.resize(window);
+    });
+
+    await waitFor(() => {
+      expect((document.querySelector('ul[role="listbox"]') as HTMLElement).style.left).toBe('50px');
+    });
+  });
+});

--- a/src/diagram/tests/canvas-editing-name-done.test.ts
+++ b/src/diagram/tests/canvas-editing-name-done.test.ts
@@ -1,0 +1,162 @@
+/**
+ * @jest-environment node
+ *
+ * Copyright 2026 The Simlin Authors. All rights reserved.
+ * Use of this source code is governed by the Apache License,
+ * Version 2.0, that can be found in the LICENSE file.
+ */
+
+// Regression tests for the `flowStillBeingCreated` state machine in
+// Canvas.handleEditingNameDone. The flag is set when a flow-creation drag
+// finishes and the canvas enters name editing; cancelling that initial name
+// edit deletes the just-created flow. The flag must be cleared once name
+// editing ends (commit OR cancel) -- a stale `true` would make a later
+// Escape-cancel of an unrelated rename delete that variable.
+
+import { Canvas, CanvasProps } from '../drawing/Canvas';
+import { AuxViewElement, FlowViewElement, UID, ViewElement } from '@simlin/core/datamodel';
+import { plainDeserialize } from '../drawing/common';
+
+type CanvasInstance = InstanceType<typeof Canvas>;
+
+function makeAux(uid: number, name: string): AuxViewElement {
+  return {
+    type: 'aux',
+    uid,
+    var: undefined,
+    x: 100,
+    y: 100,
+    name,
+    ident: name.toLowerCase().replace(/ /g, '_'),
+    labelSide: 'right',
+    isZeroRadius: false,
+  };
+}
+
+function makeFlow(uid: number, name: string): FlowViewElement {
+  return {
+    type: 'flow',
+    uid,
+    var: undefined,
+    x: 100,
+    y: 100,
+    name,
+    ident: name.toLowerCase().replace(/ /g, '_'),
+    labelSide: 'bottom',
+    points: [
+      { x: 50, y: 100, attachedToUid: undefined },
+      { x: 150, y: 100, attachedToUid: undefined },
+    ],
+    isZeroRadius: false,
+  };
+}
+
+interface CanvasHarness {
+  canvas: CanvasInstance;
+  onDeleteSelection: jest.Mock;
+  onRenameVariable: jest.Mock;
+  setSelection: (uids: UID[]) => void;
+}
+
+function makeCanvas(elements: ViewElement[]): CanvasHarness {
+  const onDeleteSelection = jest.fn();
+  const onRenameVariable = jest.fn();
+  const props = {
+    embedded: false,
+    selection: new Set<UID>(),
+    selectedTool: undefined,
+    onDeleteSelection,
+    onRenameVariable,
+    onSetSelection: jest.fn(),
+    onCreateVariable: jest.fn(),
+    onSelection: jest.fn(),
+  } as unknown as CanvasProps;
+
+  const canvas = new Canvas(props);
+
+  // Shim React state management so we can drive the instance without the
+  // reconciler (same pattern as editor-selection-changed.test.ts).
+  Object.defineProperty(canvas, 'state', {
+    value: { ...canvas.state },
+    writable: true,
+    configurable: true,
+  });
+  canvas.setState = ((updater: unknown) => {
+    const next = typeof updater === 'function' ? (updater as (s: unknown) => unknown)(canvas.state) : updater;
+    Object.assign(canvas.state as object, next);
+  }) as CanvasInstance['setState'];
+
+  canvas.elements = new Map(elements.map((el) => [el.uid, el]));
+
+  const setSelection = (uids: UID[]) => {
+    Object.defineProperty(canvas, 'props', {
+      value: { ...props, selection: new Set(uids) },
+      writable: true,
+      configurable: true,
+    });
+  };
+
+  return { canvas, onDeleteSelection, onRenameVariable, setSelection };
+}
+
+describe('Canvas.handleEditingNameDone flowStillBeingCreated state machine', () => {
+  it('cancelling the initial name edit of a just-created flow deletes it', () => {
+    const flow = makeFlow(7, 'New Flow');
+    const { canvas, onDeleteSelection, setSelection } = makeCanvas([flow]);
+    setSelection([flow.uid]);
+
+    canvas.setState({
+      isEditingName: true,
+      editingName: plainDeserialize('label', 'New Flow'),
+      flowStillBeingCreated: true,
+    });
+
+    canvas.handleEditingNameDone(true);
+
+    expect(onDeleteSelection).toHaveBeenCalledTimes(1);
+    expect(canvas.state.flowStillBeingCreated).toBe(false);
+  });
+
+  it('committing the initial flow name clears the flag', () => {
+    const flow = makeFlow(7, 'New Flow');
+    const { canvas, onRenameVariable, setSelection } = makeCanvas([flow]);
+    setSelection([flow.uid]);
+
+    canvas.setState({
+      isEditingName: true,
+      editingName: plainDeserialize('label', 'inflow rate'),
+      flowStillBeingCreated: true,
+    });
+
+    canvas.handleEditingNameDone(false);
+
+    expect(onRenameVariable).toHaveBeenCalledTimes(1);
+    expect(canvas.state.flowStillBeingCreated).toBe(false);
+  });
+
+  it('cancelling a later rename of an unrelated variable does NOT delete it', () => {
+    const flow = makeFlow(7, 'New Flow');
+    const aux = makeAux(9, 'Existing Variable');
+    const { canvas, onDeleteSelection, setSelection } = makeCanvas([flow, aux]);
+
+    // 1. The user finishes creating a flow and commits its name.
+    setSelection([flow.uid]);
+    canvas.setState({
+      isEditingName: true,
+      editingName: plainDeserialize('label', 'inflow rate'),
+      flowStillBeingCreated: true,
+    });
+    canvas.handleEditingNameDone(false);
+
+    // 2. Later, the user double-clicks an existing variable to rename it,
+    //    then presses Escape to cancel. That cancel must not delete it.
+    setSelection([aux.uid]);
+    canvas.setState({
+      isEditingName: true,
+      editingName: plainDeserialize('label', 'Existing Variable'),
+    });
+    canvas.handleEditingNameDone(true);
+
+    expect(onDeleteSelection).not.toHaveBeenCalled();
+  });
+});

--- a/src/diagram/tests/connector-routing.test.ts
+++ b/src/diagram/tests/connector-routing.test.ts
@@ -758,3 +758,39 @@ describe('Connector routing', () => {
     });
   });
 });
+
+describe('intersectElementArc aux branch (tan asymptote hazard)', () => {
+  const aux = (x: number, y: number): AuxViewElement => ({
+    type: 'aux',
+    uid: 1,
+    name: 'a',
+    ident: 'a',
+    var: undefined,
+    x,
+    y,
+    labelSide: 'right',
+    isZeroRadius: false,
+  });
+
+  it('keeps the angular offset on the same side for tight arcs as for wide ones', () => {
+    // For a wide arc, offθ = atan-ish(AuxRadius / circ.r) is small and
+    // positive; with inv=false the intersection sits at a slightly negative
+    // angle (below the +x axis here). A tight arc (circ.r = 3, so
+    // AuxRadius/circ.r = 3 -- past tan's π/2 asymptote where tan(3) < 0)
+    // must stay on the same side rather than flipping above the axis.
+    const wide = intersectElementArc(aux(100, 0), { x: 0, y: 0, r: 100 }, false);
+    expect(wide.y).toBeLessThan(0);
+
+    const tight = intersectElementArc(aux(3, 0), { x: 0, y: 0, r: 3 }, false);
+    expect(tight.y).toBeLessThan(0);
+  });
+
+  it('bounds the angular offset below a quarter turn even at extreme ratios', () => {
+    // AuxRadius/circ.r = 9: tan(9 rad) is ~ -0.45 (wrapped); atan(9) ≈ 1.46.
+    // The intersection must stay within (-π/2, 0) of the element-center
+    // angle -- i.e. x must remain positive for an element on the +x axis.
+    const p = intersectElementArc(aux(1, 0), { x: 0, y: 0, r: 1 }, false);
+    expect(p.x).toBeGreaterThan(0);
+    expect(p.y).toBeLessThan(0);
+  });
+});

--- a/src/diagram/tests/dialog.test.tsx
+++ b/src/diagram/tests/dialog.test.tsx
@@ -3,7 +3,7 @@
 // Version 2.0, that can be found in the LICENSE file.
 
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { Dialog, DialogTitle, DialogContent, DialogContentText, DialogActions } from '../components/Dialog';
 
 describe('Dialog', () => {
@@ -33,6 +33,44 @@ describe('Dialog', () => {
     );
     const content = document.querySelector('.custom-dialog');
     expect(content).not.toBeNull();
+  });
+
+  // Radix's DismissableLayer registers its document-level pointerdown
+  // listener on a deferred timer (to ignore the pointerdown that opened the
+  // layer), so outside clicks must be fired a tick after render.
+  const nextTick = () => new Promise((resolve) => setTimeout(resolve, 0));
+
+  test('a pointer-down outside dismisses the dialog by default', async () => {
+    const onClose = jest.fn();
+    render(
+      <Dialog open={true} onClose={onClose}>
+        <div>Content</div>
+      </Dialog>,
+    );
+    await nextTick();
+
+    fireEvent.pointerDown(document.body);
+    fireEvent.pointerUp(document.body);
+
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  test('disableBackdropClick blocks outside-click dismissal', async () => {
+    // A dialog like NewUser's mandatory onboarding must be genuinely modal:
+    // blocking Escape but letting a backdrop click through routes onClose
+    // anyway (and in NewUser's case triggered an implicit submit).
+    const onClose = jest.fn();
+    render(
+      <Dialog open={true} onClose={onClose} disableEscapeKeyDown disableBackdropClick>
+        <div>Content</div>
+      </Dialog>,
+    );
+    await nextTick();
+
+    fireEvent.pointerDown(document.body);
+    fireEvent.pointerUp(document.body);
+
+    expect(onClose).not.toHaveBeenCalled();
   });
 });
 

--- a/src/diagram/tests/editor-details-remount.test.ts
+++ b/src/diagram/tests/editor-details-remount.test.ts
@@ -1,0 +1,159 @@
+/**
+ * @jest-environment node
+ *
+ * Copyright 2026 The Simlin Authors. All rights reserved.
+ * Use of this source code is governed by the Apache License,
+ * Version 2.0, that can be found in the LICENSE file.
+ */
+
+// Regression tests for when the variable/module details panels remount.
+//
+// The panels seed their Slate editors from props in their constructors, so
+// React remounts (key changes) are the mechanism that refreshes them after
+// the underlying variable changes. The key used to include projectVersion,
+// which bumps +0.001 on every pan/zoom frame and is reset to the server
+// version when an autosave completes -- each of those remounted an open
+// panel, discarding in-progress unsaved edits and refiring the async LaTeX
+// load. The key now uses `projectGeneration`, which must increment exactly
+// when project *content* changes (real edits, undo/redo) and stay put for
+// view-only updates and save-version bookkeeping.
+
+import { projectFromJson } from '@simlin/core/datamodel';
+import type { JsonProject } from '@simlin/engine';
+
+import { Editor } from '../Editor';
+
+type EditorInstance = InstanceType<typeof Editor>;
+
+const validProjectJson = JSON.stringify({
+  name: 'test',
+  simSpecs: { startTime: 0, endTime: 10, dt: '1' },
+  models: [{ name: 'main', stocks: [], flows: [], auxiliaries: [], views: [{ elements: [] }] }],
+});
+
+const snap = (n: number): Uint8Array => new Uint8Array([n]);
+
+function makeFakeEngine() {
+  return {
+    serializeProtobuf: jest.fn(async () => snap(9)),
+    serializeJson: jest.fn(async () => validProjectJson),
+    getErrors: jest.fn(async () => []),
+    applyPatch: jest.fn(async () => {}),
+    dispose: jest.fn(async () => {}),
+  };
+}
+
+function makeEditor(engine: ReturnType<typeof makeFakeEngine>): EditorInstance {
+  const editor = Object.create(Editor.prototype) as EditorInstance;
+
+  editor.engineProject = engine as unknown as EditorInstance['engineProject'];
+  editor.newEngineShouldPullView = false;
+  editor.newEngineQueuedView = undefined;
+  editor.inSave = false;
+  editor.saveQueued = false;
+
+  editor.state = {
+    modelErrors: [],
+    activeProject: projectFromJson(JSON.parse(validProjectJson) as JsonProject),
+    projectHistory: [snap(1)],
+    projectOffset: 0,
+    projectGeneration: 0,
+    modelName: 'main',
+    modelStack: [],
+    data: new Map(),
+    projectVersion: 1,
+    selection: new Set<number>(),
+    cachedErrors: {
+      varErrors: new Map(),
+      unitErrors: new Map(),
+      simError: undefined,
+      modelErrors: [],
+    },
+  } as unknown as EditorInstance['state'];
+
+  editor.props = {
+    inputFormat: 'json',
+    initialProjectJson: validProjectJson,
+    initialProjectVersion: 1,
+    name: 'test',
+    onSave: async () => 1,
+  } as unknown as EditorInstance['props'];
+
+  editor.setState = (updater: unknown) => {
+    const next = typeof updater === 'function' ? updater(editor.state) : updater;
+    Object.assign(editor.state as object, next);
+  };
+
+  editor.scheduleSave = jest.fn();
+  editor.scheduleSimRun = jest.fn();
+
+  return editor;
+}
+
+type GenerationState = { projectGeneration: number };
+
+describe('Editor.projectGeneration (details panel remount key)', () => {
+  it('increments on a real edit (history-recording updateProject)', async () => {
+    const editor = makeEditor(makeFakeEngine());
+    const before = (editor.state as unknown as GenerationState).projectGeneration;
+
+    await editor.updateProject(snap(2));
+
+    expect((editor.state as unknown as GenerationState).projectGeneration).toBe(before + 1);
+  });
+
+  it('does NOT increment on a view-only update (pan/zoom)', async () => {
+    const editor = makeEditor(makeFakeEngine());
+    const before = (editor.state as unknown as GenerationState).projectGeneration;
+
+    const view = editor.getView();
+    expect(view).toBeDefined();
+    await editor.queueViewUpdate({ ...view!, zoom: 2 });
+
+    expect((editor.state as unknown as GenerationState).projectGeneration).toBe(before);
+  });
+
+  it('does NOT change when an autosave completes and resets projectVersion', async () => {
+    const engine = makeFakeEngine();
+    const editor = makeEditor(engine);
+    const before = (editor.state as unknown as GenerationState).projectGeneration;
+
+    await editor.save(1);
+
+    expect((editor.state as unknown as GenerationState).projectGeneration).toBe(before);
+  });
+
+  it('increments on undo/redo so the panels pick up restored content', () => {
+    // handleUndoRedo is an arrow-function instance field, so this case uses
+    // `new Editor(props)` (constructor is side-effect free; the deferred
+    // engine reopen is held back by fake timers and a stub).
+    jest.useFakeTimers();
+    try {
+      const editor = new Editor({
+        inputFormat: 'json',
+        initialProjectJson: validProjectJson,
+        initialProjectVersion: 1,
+        name: 'test',
+        onSave: async () => 1,
+      });
+      Object.defineProperty(editor, 'state', {
+        value: { ...editor.state, projectHistory: [snap(2), snap(1)], projectOffset: 0 },
+        writable: true,
+        configurable: true,
+      });
+      editor.setState = ((updater: unknown) => {
+        const next = typeof updater === 'function' ? (updater as (s: unknown) => unknown)(editor.state) : updater;
+        Object.assign(editor.state as object, next);
+      }) as EditorInstance['setState'];
+      // The deferred engine reopen isn't under test here.
+      editor.openEngineProject = jest.fn(async () => undefined);
+      const before = (editor.state as unknown as GenerationState).projectGeneration;
+
+      editor.handleUndoRedo('undo');
+
+      expect((editor.state as unknown as GenerationState).projectGeneration).toBe(before + 1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/src/diagram/tests/editor-undo-history.test.ts
+++ b/src/diagram/tests/editor-undo-history.test.ts
@@ -1,0 +1,152 @@
+/**
+ * @jest-environment node
+ *
+ * Copyright 2026 The Simlin Authors. All rights reserved.
+ * Use of this source code is governed by the Apache License,
+ * Version 2.0, that can be found in the LICENSE file.
+ */
+
+// Regression tests for the Editor's undo history bookkeeping.
+//
+// Two invariants:
+//
+// 1. Editing after an undo discards the redo branch. projectHistory is
+//    newest-first and projectOffset points at the displayed snapshot;
+//    entries before the offset were created after the snapshot being
+//    edited, so a new edit must drop them or a later undo would jump to
+//    abandoned sibling states instead of the edit's true parent.
+//
+// 2. View-only updates (pan/zoom/momentum frames, panel resizes -- anything
+//    flowing through queueViewUpdate) must NOT record undo snapshots.
+//    viewBox/zoom are serialized into the protobuf, so each frame is a
+//    distinct snapshot; with MaxUndoSize = 5 a single momentum flick would
+//    otherwise evict every real edit from the undo buffer.
+//
+// Same Object.create(Editor.prototype) harness as editor-open-project.test.ts.
+
+import { projectFromJson } from '@simlin/core/datamodel';
+import type { JsonProject } from '@simlin/engine';
+
+import { Editor } from '../Editor';
+
+type EditorInstance = InstanceType<typeof Editor>;
+
+const validProjectJson = JSON.stringify({
+  name: 'test',
+  simSpecs: { startTime: 0, endTime: 10, dt: '1' },
+  models: [{ name: 'main', stocks: [], flows: [], auxiliaries: [], views: [{ elements: [] }] }],
+});
+
+const snap = (n: number): Uint8Array => new Uint8Array([n]);
+
+interface FakeEngine {
+  serializeProtobuf: jest.Mock;
+  serializeJson: jest.Mock;
+  getErrors: jest.Mock;
+  applyPatch: jest.Mock;
+  dispose: jest.Mock;
+}
+
+function makeFakeEngine(nextProtobuf: Uint8Array): FakeEngine {
+  return {
+    serializeProtobuf: jest.fn(async () => nextProtobuf),
+    serializeJson: jest.fn(async () => validProjectJson),
+    getErrors: jest.fn(async () => []),
+    applyPatch: jest.fn(async () => {}),
+    dispose: jest.fn(async () => {}),
+  };
+}
+
+function makeEditor(history: Uint8Array[], offset: number, engine: FakeEngine): EditorInstance {
+  const editor = Object.create(Editor.prototype) as EditorInstance;
+
+  editor.engineProject = engine as unknown as EditorInstance['engineProject'];
+  editor.newEngineShouldPullView = false;
+  editor.newEngineQueuedView = undefined;
+  editor.inSave = false;
+  editor.saveQueued = false;
+
+  editor.state = {
+    modelErrors: [],
+    activeProject: undefined,
+    projectHistory: history,
+    projectOffset: offset,
+    modelName: 'main',
+    modelStack: [],
+    data: new Map(),
+    projectVersion: 1,
+    cachedErrors: {
+      varErrors: new Map(),
+      unitErrors: new Map(),
+      simError: undefined,
+      modelErrors: [],
+    },
+  } as unknown as EditorInstance['state'];
+
+  editor.props = {
+    inputFormat: 'json',
+    initialProjectJson: validProjectJson,
+    initialProjectVersion: 1,
+    name: 'test',
+    onSave: async () => 1,
+  } as unknown as EditorInstance['props'];
+
+  editor.setState = (updater: unknown) => {
+    const next = typeof updater === 'function' ? updater(editor.state) : updater;
+    Object.assign(editor.state as object, next);
+  };
+
+  // The save path is exercised by editor-save-insave.test.ts; here we only
+  // care about history bookkeeping, so neuter the deferred save dispatch.
+  editor.scheduleSave = jest.fn();
+
+  return editor;
+}
+
+describe('Editor undo history bookkeeping', () => {
+  it('editing after an undo discards the redo branch', async () => {
+    // Viewing C (offset 2) of [E, D, C, B, A]; an edit producing F must
+    // yield [F, C, B, A] so undo from F lands on C, not E.
+    const engine = makeFakeEngine(snap(6));
+    const editor = makeEditor([snap(5), snap(4), snap(3), snap(2), snap(1)], 2, engine);
+
+    await editor.updateProject(snap(6));
+
+    expect(editor.state.projectHistory).toEqual([snap(6), snap(3), snap(2), snap(1)]);
+    expect(editor.state.projectOffset).toBe(0);
+    expect(editor.scheduleSave).toHaveBeenCalled();
+  });
+
+  it('an ordinary edit prepends and caps at MaxUndoSize', async () => {
+    const engine = makeFakeEngine(snap(6));
+    const editor = makeEditor([snap(5), snap(4), snap(3), snap(2), snap(1)], 0, engine);
+
+    await editor.updateProject(snap(6));
+
+    expect(editor.state.projectHistory).toEqual([snap(6), snap(5), snap(4), snap(3), snap(2)]);
+    expect(editor.state.projectOffset).toBe(0);
+  });
+
+  it('view-only updates do not record undo snapshots or move the offset', async () => {
+    const engine = makeFakeEngine(snap(9));
+    const editor = makeEditor([snap(2), snap(1)], 1, engine);
+
+    // Seed an active project so setView/getView work, then drive the
+    // view-only path (pan/zoom) the way Canvas's onViewBoxChange does.
+    const activeProject = projectFromJson(JSON.parse(validProjectJson) as JsonProject);
+    editor.setState({ activeProject });
+    const versionBefore = editor.state.projectVersion;
+
+    const view = editor.getView();
+    expect(view).toBeDefined();
+    await editor.queueViewUpdate({ ...view!, zoom: 2 });
+
+    // The view change reaches the engine and bumps the render version, but
+    // the undo history is untouched.
+    expect(engine.applyPatch).toHaveBeenCalled();
+    expect(editor.state.projectVersion).toBeGreaterThan(versionBefore);
+    expect(editor.state.projectHistory).toEqual([snap(2), snap(1)]);
+    expect(editor.state.projectOffset).toBe(1);
+    expect(editor.scheduleSave).not.toHaveBeenCalled();
+  });
+});

--- a/src/diagram/tests/equation-highlight.test.ts
+++ b/src/diagram/tests/equation-highlight.test.ts
@@ -1,0 +1,115 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import {
+  applyToAllPrefix,
+  byteOffsetToUtf16,
+  highlightSpansForLines,
+  slatePointForOffset,
+} from '../equation-highlight';
+
+describe('byteOffsetToUtf16', () => {
+  it('is the identity for ASCII', () => {
+    expect(byteOffsetToUtf16('a + b', 0)).toBe(0);
+    expect(byteOffsetToUtf16('a + b', 4)).toBe(4);
+    expect(byteOffsetToUtf16('a + b', 5)).toBe(5);
+  });
+
+  it('clamps negative and past-the-end offsets', () => {
+    expect(byteOffsetToUtf16('abc', -1)).toBe(0);
+    expect(byteOffsetToUtf16('abc', 99)).toBe(3);
+  });
+
+  it('accounts for 2-byte characters', () => {
+    // 'é' is 2 bytes in UTF-8 but 1 UTF-16 code unit.
+    const s = 'café + b';
+    expect(byteOffsetToUtf16(s, 5)).toBe(4); // after 'café'
+    expect(byteOffsetToUtf16(s, 7)).toBe(6); // before '+'
+  });
+
+  it('accounts for 3-byte characters', () => {
+    // '時' is 3 bytes in UTF-8, 1 UTF-16 code unit.
+    const s = '時間 + x';
+    expect(byteOffsetToUtf16(s, 6)).toBe(2); // after the two CJK characters
+  });
+
+  it('accounts for 4-byte (surrogate pair) characters', () => {
+    // '🌊' is 4 bytes in UTF-8, 2 UTF-16 code units.
+    const s = '🌊x';
+    expect(byteOffsetToUtf16(s, 4)).toBe(2);
+    expect(byteOffsetToUtf16(s, 5)).toBe(3);
+  });
+});
+
+describe('highlightSpansForLines', () => {
+  it('returns plain lines when there is no range', () => {
+    expect(highlightSpansForLines('a + b\nc', 0, undefined)).toEqual([[{ text: 'a + b' }], [{ text: 'c' }]]);
+  });
+
+  it('marks a range within a single line', () => {
+    const spans = highlightSpansForLines('a + bad_ref', 0, { startByte: 4, endByte: 11, kind: 'error' });
+    expect(spans).toEqual([[{ text: 'a + ' }, { text: 'bad_ref', error: true }]]);
+  });
+
+  it('marks a warning range', () => {
+    const spans = highlightSpansForLines('x * y', 0, { startByte: 0, endByte: 1, kind: 'warning' });
+    expect(spans).toEqual([[{ text: 'x', warning: true }, { text: ' * y' }]]);
+  });
+
+  it('marks a range on the second line of a multi-line equation', () => {
+    // Range covers 'bad' on line 1 (offsets are into the whole string).
+    const spans = highlightSpansForLines('a +\nbad + c', 0, { startByte: 4, endByte: 7, kind: 'error' });
+    expect(spans).toEqual([[{ text: 'a +' }], [{ text: 'bad', error: true }, { text: ' + c' }]]);
+  });
+
+  it('marks a range spanning a newline across two lines', () => {
+    const spans = highlightSpansForLines('ab\ncd', 0, { startByte: 1, endByte: 4, kind: 'error' });
+    expect(spans).toEqual([
+      [{ text: 'a' }, { text: 'b', error: true }],
+      [{ text: 'c', error: true }, { text: 'd' }],
+    ]);
+  });
+
+  it('shifts raw-equation offsets past the apply-to-all prefix', () => {
+    const displayed = applyToAllPrefix + 'rate * 2';
+    // Engine offsets are into the raw equation 'rate * 2'.
+    const spans = highlightSpansForLines(displayed, applyToAllPrefix.length, {
+      startByte: 0,
+      endByte: 4,
+      kind: 'error',
+    });
+    expect(spans).toEqual([[{ text: '{apply-to-all:}' }], [{ text: 'rate', error: true }, { text: ' * 2' }]]);
+  });
+
+  it('converts byte offsets in non-ASCII equations to UTF-16 indices', () => {
+    // 'é' is 2 UTF-8 bytes: byte range [7, 8] of 'café + b' is just 'b'
+    // (c=1,a=2,f=3,é=5,' '=6,+=7 ... offsets: after 'café + ' is byte 8).
+    const spans = highlightSpansForLines('café + b', 0, { startByte: 8, endByte: 9, kind: 'error' });
+    expect(spans).toEqual([[{ text: 'café + ' }, { text: 'b', error: true }]]);
+  });
+});
+
+describe('slatePointForOffset', () => {
+  it('maps an offset on the first line', () => {
+    expect(slatePointForOffset('abc\ndef', 2)).toEqual({ path: [0, 0], offset: 2 });
+  });
+
+  it('maps the end of the first line', () => {
+    expect(slatePointForOffset('abc\ndef', 3)).toEqual({ path: [0, 0], offset: 3 });
+  });
+
+  it('maps an offset on the second line', () => {
+    // offset 4 is the start of 'def' (the newline itself maps to line 1, col 0)
+    expect(slatePointForOffset('abc\ndef', 4)).toEqual({ path: [1, 0], offset: 0 });
+    expect(slatePointForOffset('abc\ndef', 6)).toEqual({ path: [1, 0], offset: 2 });
+  });
+
+  it('clamps past-the-end offsets to the document end', () => {
+    expect(slatePointForOffset('abc\ndef', 99)).toEqual({ path: [1, 0], offset: 3 });
+  });
+
+  it('clamps negative offsets to the document start', () => {
+    expect(slatePointForOffset('abc', -5)).toEqual({ path: [0, 0], offset: 0 });
+  });
+});

--- a/src/diagram/tests/flow-render-geometry.test.ts
+++ b/src/diagram/tests/flow-render-geometry.test.ts
@@ -1,0 +1,74 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+// Pure geometry helpers used by Flow.render():
+//
+//  - retractFinalPointIntoCloud pulls a cloud-terminated flow's endpoint
+//    back by CloudRadius so the arrowhead lands on the cloud's edge. The
+//    old inline version applied independent x and y shifts, so a diagonal
+//    final segment was double-shifted by sqrt(2)*CloudRadius.
+//  - finalSegmentAngle yields the direction of the last non-degenerate
+//    segment; atan2(0, 0) === 0 used to force a zero-length final segment's
+//    arrowhead to point right regardless of the flow's real orientation.
+
+import { finalSegmentAngle, retractFinalPointIntoCloud } from '../drawing/Flow';
+import { CloudRadius } from '../drawing/default';
+
+type Pt = { x: number; y: number; attachedToUid: number | undefined };
+const pt = (x: number, y: number): Pt => ({ x, y, attachedToUid: undefined });
+
+describe('retractFinalPointIntoCloud', () => {
+  it('retracts a horizontal final segment by exactly CloudRadius in x', () => {
+    const pts = retractFinalPointIntoCloud([pt(0, 0), pt(100, 0)], CloudRadius);
+    expect(pts[1].x).toBeCloseTo(100 - CloudRadius);
+    expect(pts[1].y).toBeCloseTo(0);
+  });
+
+  it('retracts a vertical final segment by exactly CloudRadius in y', () => {
+    const pts = retractFinalPointIntoCloud([pt(0, 0), pt(0, -100)], CloudRadius);
+    expect(pts[1].x).toBeCloseTo(0);
+    expect(pts[1].y).toBeCloseTo(-100 + CloudRadius);
+  });
+
+  it('retracts a diagonal final segment by CloudRadius along the segment, not per axis', () => {
+    const pts = retractFinalPointIntoCloud([pt(0, 0), pt(100, 100)], CloudRadius);
+    const dx = 100 - pts[1].x;
+    const dy = 100 - pts[1].y;
+    // The pullback distance must be CloudRadius, not sqrt(2)*CloudRadius.
+    expect(Math.sqrt(dx * dx + dy * dy)).toBeCloseTo(CloudRadius);
+    // ...and along the segment direction (45 degrees).
+    expect(dx).toBeCloseTo(dy);
+  });
+
+  it('leaves a zero-length final segment unchanged', () => {
+    const pts = retractFinalPointIntoCloud([pt(50, 50), pt(50, 50)], CloudRadius);
+    expect(pts[1]).toEqual(pt(50, 50));
+  });
+
+  it('only moves the final point', () => {
+    const original = [pt(0, 0), pt(50, 0), pt(100, 0)];
+    const pts = retractFinalPointIntoCloud(original, CloudRadius);
+    expect(pts[0]).toEqual(original[0]);
+    expect(pts[1]).toEqual(original[1]);
+  });
+});
+
+describe('finalSegmentAngle', () => {
+  it('returns the angle of the final segment in degrees [0, 360)', () => {
+    expect(finalSegmentAngle([pt(0, 0), pt(100, 0)])).toBeCloseTo(0);
+    expect(finalSegmentAngle([pt(0, 0), pt(0, 100)])).toBeCloseTo(90);
+    expect(finalSegmentAngle([pt(0, 0), pt(-100, 0)])).toBeCloseTo(180);
+    expect(finalSegmentAngle([pt(0, 0), pt(0, -100)])).toBeCloseTo(270);
+  });
+
+  it('walks back past coincident trailing points to find the real direction', () => {
+    // The final two points coincide; the direction comes from the last
+    // non-degenerate segment (pointing up: 270 in SVG coordinates).
+    expect(finalSegmentAngle([pt(0, 100), pt(0, 0), pt(0, 0)])).toBeCloseTo(270);
+  });
+
+  it('returns undefined when every point coincides', () => {
+    expect(finalSegmentAngle([pt(5, 5), pt(5, 5), pt(5, 5)])).toBeUndefined();
+  });
+});

--- a/src/diagram/tests/hosted-web-editor-load-errors.test.ts
+++ b/src/diagram/tests/hosted-web-editor-load-errors.test.ts
@@ -1,0 +1,103 @@
+/**
+ * @jest-environment node
+ *
+ * Copyright 2026 The Simlin Authors. All rights reserved.
+ * Use of this source code is governed by the Apache License,
+ * Version 2.0, that can be found in the LICENSE file.
+ */
+
+// Regression tests for HostedWebEditor.loadProject() error handling. The
+// deferred componentDidMount call is fire-and-forget, so loadProject must
+// never reject: a network error, a non-JSON body, or a response missing
+// pb/version used to escape as an unhandled rejection and leave the editor
+// permanently blank (render() returns an empty <div/> until projectBinary is
+// set, and serviceErrors stayed empty so no message ever appeared).
+
+import { fromUint8Array } from 'js-base64';
+
+import { HostedWebEditor } from '../HostedWebEditor';
+
+type HostedWebEditorInstance = InstanceType<typeof HostedWebEditor>;
+
+function makeEditor(): HostedWebEditorInstance {
+  const editor = new HostedWebEditor({
+    username: 'alice',
+    projectName: 'climate',
+    baseURL: 'http://test.invalid',
+    readOnlyMode: false,
+  } as HostedWebEditorInstance['props']);
+
+  Object.defineProperty(editor, 'state', {
+    value: { ...editor.state },
+    writable: true,
+    configurable: true,
+  });
+  editor.setState = ((updater: unknown) => {
+    const next = typeof updater === 'function' ? (updater as (s: unknown) => unknown)(editor.state) : updater;
+    Object.assign(editor.state as object, next);
+  }) as HostedWebEditorInstance['setState'];
+
+  return editor;
+}
+
+function mockFetch(impl: () => Promise<unknown>): jest.Mock {
+  const mock = jest.fn(impl);
+  (globalThis as { fetch?: unknown }).fetch = mock;
+  return mock;
+}
+
+describe('HostedWebEditor.loadProject() error handling', () => {
+  afterEach(() => {
+    delete (globalThis as { fetch?: unknown }).fetch;
+  });
+
+  it('surfaces a network-level fetch rejection as a service error', async () => {
+    mockFetch(() => Promise.reject(new Error('connection refused')));
+    const editor = makeEditor();
+
+    await expect(editor.loadProject()).resolves.toBeUndefined();
+
+    expect(editor.state.serviceErrors.length).toBeGreaterThan(0);
+    expect(editor.state.serviceErrors[0].message).toContain('unable to load');
+  });
+
+  it('surfaces a non-JSON response body as a service error', async () => {
+    mockFetch(async () => ({
+      status: 200,
+      json: () => Promise.reject(new SyntaxError('Unexpected token < in JSON')),
+    }));
+    const editor = makeEditor();
+
+    await expect(editor.loadProject()).resolves.toBeUndefined();
+
+    expect(editor.state.serviceErrors.length).toBeGreaterThan(0);
+  });
+
+  it('surfaces a response missing pb/version as a service error', async () => {
+    mockFetch(async () => ({
+      status: 200,
+      json: async () => ({}),
+    }));
+    const editor = makeEditor();
+
+    await expect(editor.loadProject()).resolves.toBeUndefined();
+
+    expect(editor.state.serviceErrors.length).toBeGreaterThan(0);
+    expect(editor.state.projectBinary).toBeUndefined();
+  });
+
+  it('still loads a well-formed response', async () => {
+    const pb = new Uint8Array([1, 2, 3]);
+    mockFetch(async () => ({
+      status: 200,
+      json: async () => ({ pb: fromUint8Array(pb), version: 4 }),
+    }));
+    const editor = makeEditor();
+
+    await editor.loadProject();
+
+    expect(editor.state.serviceErrors).toEqual([]);
+    expect(editor.state.projectBinary).toEqual(pb);
+    expect(editor.state.projectVersion).toBe(4);
+  });
+});

--- a/src/diagram/tests/lookup-editor-table.test.ts
+++ b/src/diagram/tests/lookup-editor-table.test.ts
@@ -1,0 +1,24 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import { xAtTableIndex } from '../LookupEditor';
+
+describe('xAtTableIndex', () => {
+  it('spans [xMin, xMax] inclusively for multi-point tables', () => {
+    expect(xAtTableIndex(0, 11, 0, 1)).toBeCloseTo(0);
+    expect(xAtTableIndex(5, 11, 0, 1)).toBeCloseTo(0.5);
+    expect(xAtTableIndex(10, 11, 0, 1)).toBeCloseTo(1);
+  });
+
+  it('maps a single-point table to xMin instead of NaN', () => {
+    // i / (size - 1) is 0/0 === NaN for a 1-point table; the NaN x poisons
+    // lookup()-based resampling and can be saved into the table.
+    expect(xAtTableIndex(0, 1, 2, 8)).toBe(2);
+    expect(Number.isNaN(xAtTableIndex(0, 1, 0, 1))).toBe(false);
+  });
+
+  it('handles offset scales', () => {
+    expect(xAtTableIndex(1, 3, 10, 20)).toBeCloseTo(15);
+  });
+});

--- a/src/diagram/tests/panel-css.test.ts
+++ b/src/diagram/tests/panel-css.test.ts
@@ -1,0 +1,78 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+// Layout contracts for the right-hand panels (search bar, details cards)
+// and the equation preview. jsdom can't do real layout, so these assert the
+// stylesheet text directly:
+//
+//  - The search bar and the details cards are width: var(--panel-width-*)
+//    boxes anchored at right: 8px; their left edges align only if every box
+//    that carries horizontal padding also computes as border-box. The global
+//    reset (reset.css) is not reliably present in every host bundle, so each
+//    panel rule must declare box-sizing: border-box itself.
+//
+//  - KaTeX renders equations into atomic inline-block .base spans with
+//    white-space: nowrap; overflow-wrap on an ancestor cannot break inside
+//    them, so a long equation needs both a .base override and a horizontal
+//    scroll fallback on .eqnPreview to stay within the card.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+function readCss(name: string): string {
+  return fs.readFileSync(path.join(__dirname, '..', name), 'utf-8');
+}
+
+/** The text of every top-level declaration block for `selector` (ignores
+ *  blocks inside media queries only insofar as they also match). */
+function blocksFor(css: string, selector: string): string[] {
+  const blocks: string[] = [];
+  const re = new RegExp(`${selector.replace('.', '\\.')}[^{]*\\{([^}]*)\\}`, 'g');
+  for (let m = re.exec(css); m !== null; m = re.exec(css)) {
+    blocks.push(m[1]);
+  }
+  return blocks;
+}
+
+describe('panel box-sizing contracts', () => {
+  it('the search bar declares border-box (it has horizontal padding)', () => {
+    const css = readCss('Editor.module.css');
+    const [main] = blocksFor(css, '.searchBar');
+    expect(main).toContain('box-sizing: border-box');
+  });
+
+  const cards: Array<[string, string]> = [
+    ['VariableDetails.module.css', '.card'],
+    ['ModuleDetails.module.css', '.card'],
+    ['ErrorDetails.module.css', '.card'],
+  ];
+
+  it.each(cards)('%s %s declares border-box to match the search bar', (file, selector) => {
+    const css = readCss(file);
+    const [main] = blocksFor(css, selector);
+    expect(main).toBeDefined();
+    expect(main).toContain('box-sizing: border-box');
+  });
+});
+
+describe('equation preview overflow contracts', () => {
+  const css = readCss('VariableDetails.module.css');
+
+  it('.eqnPreview can scroll horizontally as a fallback for unbreakable content', () => {
+    const [main] = blocksFor(css, '.eqnPreview');
+    expect(main).toContain('overflow-x: auto');
+  });
+
+  it('.eqnPreview flex children may shrink below content size', () => {
+    // A flex item defaults to min-width: auto and refuses to shrink below
+    // its content, pushing wide KaTeX output past the card edge.
+    const blocks = blocksFor(css, '.eqnPreview > \\*');
+    expect(blocks.length).toBeGreaterThan(0);
+    expect(blocks[0]).toContain('min-width: 0');
+  });
+
+  it("overrides KaTeX's nowrap .base spans so long equations can wrap", () => {
+    expect(css).toMatch(/\.eqnPreview\s+:global\(\.katex\s+\.base\)\s*\{[^}]*white-space:\s*normal/);
+  });
+});

--- a/src/diagram/tests/panel-width-sync.test.ts
+++ b/src/diagram/tests/panel-width-sync.test.ts
@@ -10,26 +10,33 @@ describe('Panel width constants sync', () => {
     const themeCss = fs.readFileSync(path.join(__dirname, '../theme.css'), 'utf-8');
 
     const smMatch = themeCss.match(/--panel-width-sm:\s*(\d+)px/);
+    const mdMatch = themeCss.match(/--panel-width-md:\s*(\d+)px/);
     const lgMatch = themeCss.match(/--panel-width-lg:\s*(\d+)px/);
 
     expect(smMatch).not.toBeNull();
+    expect(mdMatch).not.toBeNull();
     expect(lgMatch).not.toBeNull();
 
     const cssWidthSm = parseInt(smMatch![1], 10);
+    const cssWidthMd = parseInt(mdMatch![1], 10);
     const cssWidthLg = parseInt(lgMatch![1], 10);
 
     const editorTs = fs.readFileSync(path.join(__dirname, '../Editor.tsx'), 'utf-8');
 
     const tsSmMatch = editorTs.match(/SearchbarWidthSm\s*=\s*(\d+)/);
+    const tsMdMatch = editorTs.match(/SearchbarWidthMd\s*=\s*(\d+)/);
     const tsLgMatch = editorTs.match(/SearchbarWidthLg\s*=\s*(\d+)/);
 
     expect(tsSmMatch).not.toBeNull();
+    expect(tsMdMatch).not.toBeNull();
     expect(tsLgMatch).not.toBeNull();
 
     const tsWidthSm = parseInt(tsSmMatch![1], 10);
+    const tsWidthMd = parseInt(tsMdMatch![1], 10);
     const tsWidthLg = parseInt(tsLgMatch![1], 10);
 
     expect(tsWidthSm).toBe(cssWidthSm);
+    expect(tsWidthMd).toBe(cssWidthMd);
     expect(tsWidthLg).toBe(cssWidthLg);
   });
 });

--- a/src/diagram/tests/project-history.test.ts
+++ b/src/diagram/tests/project-history.test.ts
@@ -1,0 +1,44 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import { advanceProjectHistory } from '../project-history';
+
+const snap = (n: number): Uint8Array => new Uint8Array([n]);
+
+describe('advanceProjectHistory', () => {
+  it('prepends the new snapshot and resets the offset', () => {
+    const result = advanceProjectHistory({ projectHistory: [snap(2), snap(1)], projectOffset: 0 }, snap(3), 5);
+    expect(result.projectHistory).toEqual([snap(3), snap(2), snap(1)]);
+    expect(result.projectOffset).toBe(0);
+  });
+
+  it('caps the history at maxSize, dropping the oldest entries', () => {
+    const history = [snap(5), snap(4), snap(3), snap(2), snap(1)];
+    const result = advanceProjectHistory({ projectHistory: history, projectOffset: 0 }, snap(6), 5);
+    expect(result.projectHistory).toEqual([snap(6), snap(5), snap(4), snap(3), snap(2)]);
+  });
+
+  it('discards the redo branch when editing after an undo', () => {
+    // History (newest -> oldest): [E, D, C, B, A]; the user undid twice and
+    // is viewing C (offset 2), then edits C producing F. E and D are the
+    // abandoned redo branch: the new history must be F's linear ancestry
+    // [F, C, B, A], so that undoing F lands on C (its true parent), not E.
+    const history = [snap(5), snap(4), snap(3), snap(2), snap(1)];
+    const result = advanceProjectHistory({ projectHistory: history, projectOffset: 2 }, snap(6), 5);
+    expect(result.projectHistory).toEqual([snap(6), snap(3), snap(2), snap(1)]);
+    expect(result.projectOffset).toBe(0);
+  });
+
+  it('editing from the oldest snapshot keeps only that ancestry', () => {
+    const history = [snap(3), snap(2), snap(1)];
+    const result = advanceProjectHistory({ projectHistory: history, projectOffset: 2 }, snap(4), 5);
+    expect(result.projectHistory).toEqual([snap(4), snap(1)]);
+  });
+
+  it('works from an empty history', () => {
+    const result = advanceProjectHistory({ projectHistory: [], projectOffset: 0 }, snap(1), 5);
+    expect(result.projectHistory).toEqual([snap(1)]);
+    expect(result.projectOffset).toBe(0);
+  });
+});

--- a/src/diagram/tests/variable-details-preview.test.tsx
+++ b/src/diagram/tests/variable-details-preview.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Copyright 2026 The Simlin Authors. All rights reserved.
+ * Use of this source code is governed by the Apache License,
+ * Version 2.0, that can be found in the LICENSE file.
+ */
+
+// Regression tests for the equation preview in VariableDetails:
+//
+//  - Raw equation text must never be fed to katex.renderToString: while the
+//    engine LaTeX is loading (or when the engine can't produce LaTeX), the
+//    raw text is NOT LaTeX -- identifiers like revenue_per_unit would render
+//    with `_` as subscripts and `\`/`{}`/`^` as control sequences.
+//  - Non-fatal unit warnings must not force the panel out of the rendered
+//    preview into the raw editor (mirrors variableDetailsView, where only
+//    equation errors hide the chart).
+//  - Equation errors DO force the editor (so the highlight is visible).
+
+import { TextEncoder, TextDecoder } from 'util';
+Object.assign(globalThis, { TextEncoder, TextDecoder });
+
+import * as React from 'react';
+import { render, act } from '@testing-library/react';
+import { VariableDetails } from '../VariableDetails';
+import { Aux, AuxViewElement, EquationError, ErrorCode, UnitError } from '@simlin/core/datamodel';
+
+function makeAux(ident: string, equation: string, overrides: Partial<Aux> = {}): Aux {
+  return {
+    type: 'aux',
+    ident,
+    equation: { type: 'scalar', equation },
+    documentation: '',
+    units: '',
+    gf: undefined,
+    data: undefined,
+    errors: undefined,
+    unitErrors: undefined,
+    uid: undefined,
+    ...overrides,
+  };
+}
+
+function makeViewElement(ident: string): AuxViewElement {
+  return {
+    type: 'aux',
+    uid: 1,
+    name: ident,
+    ident,
+    var: undefined,
+    x: 0,
+    y: 0,
+    labelSide: 'right',
+    isZeroRadius: false,
+  };
+}
+
+const noop = () => {};
+
+function renderDetails(variable: Aux, getLatexEquation?: (ident: string) => Promise<string | undefined>) {
+  return render(
+    <VariableDetails
+      variable={variable}
+      viewElement={makeViewElement(variable.ident)}
+      getLatexEquation={getLatexEquation}
+      onDelete={noop}
+      onEquationChange={noop}
+      onTableChange={noop}
+      activeTab={0}
+      onActiveTabChange={noop}
+    />,
+  );
+}
+
+describe('VariableDetails equation preview', () => {
+  it('renders raw text as plain text (not KaTeX) while the engine LaTeX loads', async () => {
+    // A pending promise keeps latexEquation undefined.
+    const never = new Promise<string | undefined>(() => {});
+    const { container } = renderDetails(makeAux('rev', 'revenue_per_unit * sales'), () => never);
+
+    const preview = container.querySelector('.eqnPreview');
+    expect(preview).not.toBeNull();
+    // The raw text appears verbatim, and no KaTeX markup was generated
+    // (KaTeX would split revenue_per_unit into subscript spans).
+    expect(preview!.textContent).toContain('revenue_per_unit * sales');
+    expect(container.querySelector('.katex')).toBeNull();
+  });
+
+  it('renders engine-provided LaTeX through KaTeX once it arrives', async () => {
+    let resolve!: (v: string | undefined) => void;
+    const pending = new Promise<string | undefined>((res) => {
+      resolve = res;
+    });
+    const { container } = renderDetails(makeAux('rev', 'a + b'), () => pending);
+
+    await act(async () => {
+      resolve('a + b');
+    });
+
+    expect(container.querySelector('.katex')).not.toBeNull();
+  });
+
+  it('renders raw text as plain text when the engine cannot produce LaTeX', async () => {
+    const { container } = renderDetails(makeAux('rev', 'revenue_per_unit * 2'), async () => undefined);
+
+    await act(async () => {
+      // let the resolved-undefined promise settle
+    });
+
+    const preview = container.querySelector('.eqnPreview');
+    expect(preview).not.toBeNull();
+    expect(preview!.textContent).toContain('revenue_per_unit * 2');
+    expect(container.querySelector('.katex')).toBeNull();
+  });
+
+  it('keeps the preview for a variable with only non-fatal unit warnings', () => {
+    const unitErrors: UnitError[] = [
+      { start: 0, end: 0, code: 0 as unknown as ErrorCode, isConsistencyError: false, details: undefined },
+    ];
+    const { container } = renderDetails(makeAux('rev', 'a + b', { unitErrors }));
+
+    expect(container.querySelector('.eqnPreview')).not.toBeNull();
+  });
+
+  it('shows the editor (not the preview) for a variable with equation errors', () => {
+    const errors: EquationError[] = [{ start: 0, end: 1, code: 0 as unknown as ErrorCode }];
+    const { container } = renderDetails(makeAux('rev', 'a + b', { errors }));
+
+    expect(container.querySelector('.eqnPreview')).toBeNull();
+    expect(container.querySelector('.eqnEditor')).not.toBeNull();
+  });
+
+  it('highlights the errored range accounting for non-ASCII byte offsets', () => {
+    // 'é' is 2 UTF-8 bytes; engine byte range [8, 9) of 'café + bad' is 'b'…
+    // here we use [7, 10) which covers 'bad' (bytes: c1 a2 f3 é5 ␠6 +7 ␠8 b9 a10 d11)
+    // → byte range for 'bad' is [8, 11).
+    const errors: EquationError[] = [{ start: 8, end: 11, code: 0 as unknown as ErrorCode }];
+    const { container } = renderDetails(makeAux('x', 'café + bad', { errors }));
+
+    const marked = container.querySelector('.eqnError');
+    expect(marked).not.toBeNull();
+    expect(marked!.textContent).toBe('bad');
+  });
+
+  it('highlights an error on the second line of a multi-line equation', () => {
+    const equation = 'a +\nbad_ref';
+    // byte offsets into the raw equation: 'bad_ref' starts at 4 (after 'a +\n')
+    const errors: EquationError[] = [{ start: 4, end: 11, code: 0 as unknown as ErrorCode }];
+    const { container } = renderDetails(makeAux('x', equation, { errors }));
+
+    const marked = container.querySelector('.eqnError');
+    expect(marked).not.toBeNull();
+    expect(marked!.textContent).toBe('bad_ref');
+  });
+});

--- a/src/server/auth-helpers.ts
+++ b/src/server/auth-helpers.ts
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the Apache License,
 // Version 2.0, that can be found in the LICENSE file.
 
-import { Request } from 'express';
+import { Request, Response } from 'express';
 
 /**
  * Information about the authenticated user extracted from the session.
@@ -71,4 +71,21 @@ export function getAuthenticatedUser(req: Request): AuthenticatedUser | undefine
  */
 export function isResourceOwner(authUser: AuthenticatedUser | undefined, ownerId: string): boolean {
   return authUser !== undefined && authUser.userId === ownerId;
+}
+
+/**
+ * DELETE /session handler: terminates the passport login session.
+ *
+ * Sessions live in a seshcookie-encrypted cookie, so there is no server-side
+ * store to purge: passport's req.logout() removes req.session.passport and
+ * regenerates the session (the compat shim in app.ts resets req.session to a
+ * fresh object), and seshcookie's response hook rewrites the Set-Cookie with
+ * the now-unauthenticated session. The handler must always respond -- the
+ * previous TODO stub never wrote a response, so a client awaiting the fetch
+ * hung indefinitely.
+ */
+export function handleSessionDelete(req: Request, res: Response): void {
+  req.logout((err?: Error) => {
+    res.sendStatus(err ? 500 : 200);
+  });
 }

--- a/src/server/authn.ts
+++ b/src/server/authn.ts
@@ -11,6 +11,7 @@ import * as logger from 'winston';
 import * as admin from 'firebase-admin';
 
 import { Application } from './application';
+import { handleSessionDelete } from './auth-helpers';
 import { Table } from './models/table';
 import { User } from './schemas/user_pb';
 
@@ -235,7 +236,5 @@ export const authn = (app: Application, firebaseAuthn: admin.auth.Auth): void =>
     res.sendStatus(200);
   });
 
-  app.delete('/session', (_req: Request, _res: Response): void => {
-    console.log(`TODO: unset cookie`);
-  });
+  app.delete('/session', handleSessionDelete);
 };

--- a/src/server/tests/session-passport-compat.test.ts
+++ b/src/server/tests/session-passport-compat.test.ts
@@ -9,6 +9,8 @@ import { Strategy as BaseStrategy } from 'passport-strategy';
 import { seshcookie } from 'seshcookie';
 import http from 'http';
 
+import { handleSessionDelete } from '../auth-helpers';
+
 type SessionCallback = (err?: Error) => void;
 type SessionWithCompat = Record<string, unknown> & {
   regenerate?: (cb: SessionCallback) => void;
@@ -69,6 +71,8 @@ function createTestApp(options?: { addSessionCompat?: boolean }): express.Expres
   app.post('/login', passport.authenticate('test'), (_req, res) => {
     res.status(200).json({ ok: true });
   });
+
+  app.delete('/session', handleSessionDelete);
 
   app.get('/check', (req, res) => {
     if (req.session?.passport?.user) {
@@ -147,6 +151,35 @@ describe('seshcookie + passport session compatibility', () => {
       const checkRes = await request(server, 'GET', '/check', { cookie: cookieHeader });
       expect(checkRes.status).toBe(200);
       expect((checkRes.body as { user?: TestSessionUser }).user).toEqual({ id: 'test-user' });
+    } finally {
+      server.close();
+    }
+  });
+
+  it('DELETE /session logs the user out and clears the session cookie', async () => {
+    const app = createTestApp({ addSessionCompat: true });
+    const server = app.listen(0);
+    try {
+      const loginRes = await request(server, 'POST', '/login');
+      expect(loginRes.status).toBe(200);
+      const loginCookies = loginRes.headers['set-cookie'];
+      const loginCookie = Array.isArray(loginCookies) ? loginCookies.join('; ') : String(loginCookies);
+
+      // Sanity: the session authenticates before logout.
+      const before = await request(server, 'GET', '/check', { cookie: loginCookie });
+      expect(before.status).toBe(200);
+
+      // Logout must respond (the old handler hung: it never wrote a
+      // response) and must rewrite the seshcookie session cookie without
+      // the passport user.
+      const logoutRes = await request(server, 'DELETE', '/session', { cookie: loginCookie });
+      expect(logoutRes.status).toBe(200);
+      const logoutCookies = logoutRes.headers['set-cookie'];
+      expect(logoutCookies).toBeDefined();
+      const logoutCookie = Array.isArray(logoutCookies) ? logoutCookies.join('; ') : String(logoutCookies);
+
+      const after = await request(server, 'GET', '/check', { cookie: logoutCookie });
+      expect(after.status).toBe(401);
     } finally {
       server.close();
     }

--- a/src/simlin-engine/src/diagram/connector.rs
+++ b/src/simlin-engine/src/diagram/connector.rs
@@ -186,8 +186,12 @@ pub(crate) fn intersect_element_arc(
 
     match element_shape(element) {
         ElementShape::Circle { r } => {
-            // Matches TypeScript: Math.tan(r / circ.r), not atan
-            let off_theta = (r / circ.r).tan();
+            // atan (not tan), mirroring both the Rect branch below and the
+            // TypeScript renderer: a tight arc between nearby elements can
+            // push r/circ.r past tan's pi/2 asymptote, where tan goes huge or
+            // flips sign and swings the arrowhead to the wrong side. atan is
+            // bounded and monotonic for all ratios.
+            let off_theta = (r / circ.r).atan();
             let element_center_theta = (cy - circ.y).atan2(cx - circ.x);
             let theta = element_center_theta + if inv { 1.0 } else { -1.0 } * off_theta;
 
@@ -714,7 +718,7 @@ mod tests {
         let to = make_aux_ve(200.0, 200.0, "b", 2);
 
         let svg = render_connector(&link, &from, &to, &not_arrayed);
-        let expected = "<g><path d=\"M100,100A273.205081,273.205081 0 0,1 200,200\" class=\"simlin-connector-bg\"></path><path d=\"M100,100A273.205081,273.205081 0 0,1 200,200\" class=\"simlin-connector\"></path><g><path d=\"M199.870725,192.278529L188.620725,196.778529A27,27 0 0,1 188.620725,187.778529z\" class=\"simlin-arrowhead-bg\" transform=\"rotate(58.111863,195.370725,192.278529)\"></path><path d=\"M195.370725,192.278529L189.370725,195.278529A18,18 0 0,1 189.370725,189.278529z\" class=\"simlin-arrowhead-link\" transform=\"rotate(58.111863,195.370725,192.278529)\"></path></g></g>";
+        let expected = "<g><path d=\"M100,100A273.205081,273.205081 0 0,1 200,200\" class=\"simlin-connector-bg\"></path><path d=\"M100,100A273.205081,273.205081 0 0,1 200,200\" class=\"simlin-connector\"></path><g><path d=\"M199.874164,192.284057L188.624164,196.784057A27,27 0 0,1 188.624164,187.784057z\" class=\"simlin-arrowhead-bg\" transform=\"rotate(58.113228,195.374164,192.284057)\"></path><path d=\"M195.374164,192.284057L189.374164,195.284057A18,18 0 0,1 189.374164,189.284057z\" class=\"simlin-arrowhead-link\" transform=\"rotate(58.113228,195.374164,192.284057)\"></path></g></g>";
         assert_eq!(svg, expected);
         assert!(svg.starts_with("<g><path d=\"M100,100A"));
     }

--- a/src/simlin-engine/src/diagram/flow.rs
+++ b/src/simlin-engine/src/diagram/flow.rs
@@ -20,21 +20,22 @@ pub fn render_flow(element: &view_element::Flow, sink: &ViewElement, is_arrayed:
         return String::new();
     }
 
-    // If sink is a Cloud, adjust the last point inward by CloudRadius
+    // If sink is a Cloud, pull the last point back by CLOUD_RADIUS along the
+    // final segment's direction so the arrowhead lands on the cloud's edge.
+    // The retraction follows the segment's unit vector (matching the
+    // TypeScript renderer): independent per-axis shifts would over-retract a
+    // diagonal segment by sqrt(2)*CLOUD_RADIUS. A zero-length final segment
+    // is left unchanged.
     if let ViewElement::Cloud(_) = sink {
         let last_idx = pts.len() - 1;
         let (x, y) = pts[last_idx];
         let (prev_x, prev_y) = pts[last_idx - 1];
-
-        if prev_x < x {
-            pts[last_idx].0 = x - CLOUD_RADIUS;
-        } else if prev_x > x {
-            pts[last_idx].0 = x + CLOUD_RADIUS;
-        }
-        if prev_y < y {
-            pts[last_idx].1 = y - CLOUD_RADIUS;
-        } else if prev_y > y {
-            pts[last_idx].1 = y + CLOUD_RADIUS;
+        let dx = x - prev_x;
+        let dy = y - prev_y;
+        let len = (dx * dx + dy * dy).sqrt();
+        if len > 0.0 {
+            pts[last_idx].0 = x - (CLOUD_RADIUS * dx) / len;
+            pts[last_idx].1 = y - (CLOUD_RADIUS * dy) / len;
         }
     }
 
@@ -45,26 +46,40 @@ pub fn render_flow(element: &view_element::Flow, sink: &ViewElement, is_arrayed:
     for j in 0..pts.len() {
         let (mut x, mut y) = pts[j];
         if j == pts.len() - 1 {
-            let (prev_x, prev_y) = pts[j - 1];
-            let dx = x - prev_x;
-            let dy = y - prev_y;
-            let mut theta = dy.atan2(dx) * 180.0 / PI;
-            if theta < 0.0 {
-                theta += 360.0;
+            // Walk back past coincident points: a degenerate (zero-length)
+            // final segment must not read as "pointing right" via
+            // atan2(0, 0) == 0 (matches the TypeScript renderer).
+            let mut theta_opt: Option<f64> = None;
+            for i in (0..j).rev() {
+                let (px, py) = pts[i];
+                let dx = x - px;
+                let dy = y - py;
+                if dx != 0.0 || dy != 0.0 {
+                    let mut theta = dy.atan2(dx) * 180.0 / PI;
+                    if theta < 0.0 {
+                        theta += 360.0;
+                    }
+                    theta_opt = Some(theta);
+                    break;
+                }
             }
 
-            if !(45.0..315.0).contains(&theta) {
-                x -= final_adjust;
-                arrow_theta = 0.0;
-            } else if (45.0..135.0).contains(&theta) {
-                y -= final_adjust;
-                arrow_theta = 90.0;
-            } else if (135.0..225.0).contains(&theta) {
-                x += final_adjust;
-                arrow_theta = 180.0;
+            if let Some(theta) = theta_opt {
+                if !(45.0..315.0).contains(&theta) {
+                    x -= final_adjust;
+                    arrow_theta = 0.0;
+                } else if (45.0..135.0).contains(&theta) {
+                    y -= final_adjust;
+                    arrow_theta = 90.0;
+                } else if (135.0..225.0).contains(&theta) {
+                    x += final_adjust;
+                    arrow_theta = 180.0;
+                } else {
+                    y += final_adjust;
+                    arrow_theta = 270.0;
+                }
             } else {
-                y += final_adjust;
-                arrow_theta = 270.0;
+                arrow_theta = 0.0;
             }
         }
 


### PR DESCRIPTION
## What this is

A systematic bug audit of the frontend TypeScript/React/CSS code in `src/app` and `src/diagram`, followed by fixes for everything confirmed. Eight area/dimension review agents swept the code; every finding was adversarially verified by an independent agent before being accepted (51 raw findings -> 29 confirmed, 10 refuted). The full findings list with per-item status lives in [docs/dev/frontend-audit-2026-06.md](docs/dev/frontend-audit-2026-06.md), committed first on this branch so the fixes can be reviewed against it.

Every fix was done test-first where the behavior was testable (new pure helpers + component tests; 20+ new test files/cases), and each landed as its own commit through the full pre-commit suite.

## Highlights (the bugs behind the glitches you reported)

- **Equation preview glitches**: three compounding causes. (1) The details panels were keyed by `projectVersion`, which bumps on every pan frame and is reset by every autosave completion -- each bump remounted the open panel, discarding in-progress Slate edits and refiring the async LaTeX load. They are now keyed by a new `projectGeneration` that increments only on real content changes (edits, undo/redo). (2) While the engine LaTeX loaded (and whenever the engine couldn't produce LaTeX), the raw equation text was fed to `katex.renderToString`, rendering `revenue_per_unit` with `_` as subscripts; raw text now renders as plain monospace. (3) Error highlighting treated Rust byte offsets as UTF-16 indices and only ever touched line 0; a new `equation-highlight` module converts offsets, shifts past the `{apply-to-all:}` prefix, and highlights across lines (caret placement from preview clicks got the same fix).
- **Long equation running off the card**: KaTeX packs math into atomic inline-block `.base` spans with `white-space: nowrap`, which `overflow-wrap` on an ancestor can't break, and the flex container refused to shrink (`min-width: auto`). Fixed with a `.base` override (higher specificity than katex.css), `min-width: 0`, and `overflow-x: auto` as the unbreakable-content fallback.
- **Search bar / details card misalignment**: `reset.css` (the universal `box-sizing: border-box`) is tree-shaken out of the production CSS bundle even though it's a side-effect import -- so the padded search bar rendered 16px wider than the card. Fixed two ways: an explicit `import '@simlin/diagram/reset.css'` in the app entry (verified present in the rebuilt bundle) and explicit `box-sizing: border-box` on every panel rule so alignment never depends on a global reset. The unexplained tree-shaking is tracked as #708.

## Other high-severity fixes

- **Undo was broken two ways**: editing after an undo kept the abandoned redo branch (undo then jumped to sibling states instead of the edit's parent), and every pan/zoom/momentum frame pushed a snapshot into the 5-entry undo buffer, evicting real edits. View-only updates no longer touch history; real edits go through a pure, tested `advanceProjectHistory`.
- **Creating a flow armed a delete trap**: `flowStillBeingCreated` was never reset (the reset was a `true`-for-`false` typo), so a later Escape-cancel of any rename deleted that variable.
- **Logout did nothing** -- the menu item only closed the menu, and the server's `DELETE /session` was a TODO stub that never even wrote a response. Both halves implemented (Firebase signOut + session invalidation via passport `req.logout()` + seshcookie rewrite, with an end-to-end server test).
- **A failed project load left a permanently blank editor** (network error / non-JSON / missing fields all escaped as unhandled rejections); failures now render an error message.
- **NewUser onboarding could submit via backdrop click or Enter while bypassing the terms-agreement gate**; `Dialog` gained `disableBackdropClick` and the gate is enforced on every entry path.

Plus mediums/lows: Login error handling and stale-error clearing, Autocomplete dropdown detaching on scroll/resize, flow/connector rendering geometry edge cases (fixed identically in the TS *and* Rust renderers -- the SVG parity test compares them byte-for-byte), LookupEditor NaN on a 1-point table, missing React keys, PureComponent memoization defeated by per-render closures, unmount guards, breakpoint-aware panel-width math, Checkbox/TextField contract fixes.

## Decisions and tradeoffs

- **Remount-by-key kept, but on the right key.** Rather than teaching VariableDetails to resync Slate state from props (Slate ignores post-mount `initialValue` changes, so prop-resync wouldn't reach the DOM and would need editor-instance recreation), I kept the constructor-seeding + key-remount design and made the key change exactly when content changes. Lower risk, preserves all existing refresh semantics, and the difference is observable in tests.
- **Undo after a view change restores the camera of the snapshot.** Excluding pans from history means undo now jumps the viewport to where it was at edit time. I judged this standard editor behavior and better than view changes consuming undo slots.
- **Rust renderer changed in a "frontend" PR.** The TS and Rust SVG renderers are parity-tested byte-for-byte, so the geometry fixes had to land in both (the Rust code even carried a "Matches TypeScript: tan, not atan" comment). One hardcoded golden string was updated for atan's rounding on ordinary arcs (third-decimal differences).
- **Unit warnings no longer force the raw editor open.** This matches `variableDetailsView` (unit errors are non-fatal: they keep the chart) -- the warning list still renders under the chart, and clicking into the editor still shows the squiggle.
- **What I deliberately did not do**: no class-to-function component conversion (per your instruction); no debounce of the per-frame engine round-trips (#707 -- removing the undo pollution fixed the worst symptom, persistence batching is a bigger change); dark-mode for the component library (#709) and Menu anchor-tracking (#710) deferred and tracked.

## Verification

- All new and existing tests pass; every commit went through the full pre-commit suite (Rust fmt/clippy/tests, TS lint/build/tsc/tests, WASM build, Python tests).
- The CSS fixes are locked in by stylesheet-contract tests (`panel-css.test.ts`) and the rules were verified present in the rebuilt production bundle. I could not do a pixel-level browser check in this environment (headless Chromium lacks system libs here) -- worth a quick visual confirmation of the reliability model's details panel on your running app.
- 12 of 51 raw findings lost their verifier mid-run; I recovered them from the workflow journal and confirmed they all duplicated already-confirmed findings before proceeding.

Follow-ups filed: #707 (per-frame engine round-trips), #708 (reset.css tree-shaking), #709 (component-library dark mode), #710 (Menu anchor tracking).