### PR TITLE
build: fix invalid YAML that disabled all CI runs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -375,6 +375,8 @@ jobs:
 
       # The smoke test lives in the consolidated `integration` harness;
       # `smoke::` filters to just its tests (all `#[ignore]`d, hence
-      # `--ignored`).
+      # `--ignored`). The run command is quoted because a plain YAML scalar
+      # ending in `:` parses as a mapping key, which made the whole workflow
+      # file invalid (every CI run since failed at startup with zero jobs).
       - name: Run smoke test
-        run: cargo test -p simlin-serve --release --test integration -- --ignored --nocapture smoke::
+        run: 'cargo test -p simlin-serve --release --test integration -- --ignored --nocapture smoke::'


### PR DESCRIPTION
The smoke-test consolidation in b842996d left the run command ending in `smoke::` -- a plain YAML scalar ending in a colon parses as a mapping key, making the whole workflow file invalid. Every `ci.yaml` run since (push and pull_request, on every branch) failed at startup with zero jobs, which is why recent PRs (e.g. #713) show almost no checks.

Fix: quote the command. All workflow files validated with a YAML parser locally.

Separately: even before the file broke, `ci.yaml` was failing on every run -- the Code Coverage (cargo-tarpaulin) job hits its 90-minute timeout mid-suite. That predates this breakage and is being tracked as its own issue; this PR only restores the workflow so jobs run at all.

Once this merges, re-running checks on open PRs will pick up the fixed workflow from the merge ref.