### PR TITLE
diagram: convert drawing components to function components

### DIFF
--- a/docs/dev/typescript.md
+++ b/docs/dev/typescript.md
@@ -3,7 +3,7 @@
 ## Code Style
 
 - Use TypeScript with strict mode enabled.
-- Prefer class components by default. Hooks are allowed when wrapping/integrating with components that only support hook-based APIs; in all other cases, prefer classes.
+- Prefer function components with hooks. Wrap render-hot components (e.g. per-element diagram pieces) in `React.memo`, and `useCallback` any handler passed to a memo'd child so the memoization actually holds. Class components remain only where there is a concrete reason: `ErrorBoundary` (React has no hook equivalent), and large imperative shells like `Canvas`/`Editor` that are scheduled for incremental migration.
 - Use proper TypeScript types, avoid `any`.
 - NEVER manually copy files around to get builds or tests passing. Identify the root cause and fix the build scripts.
 

--- a/src/diagram/drawing/Alias.tsx
+++ b/src/diagram/drawing/Alias.tsx
@@ -57,89 +57,80 @@ export function aliasBounds(element: AliasViewElement, aliasOf: NamedViewElement
   return mergeBounds(bounds, labelBounds(labelProps));
 }
 
-export class Alias extends React.PureComponent<AliasProps> {
-  handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
+export const Alias = React.memo(function Alias(props: AliasProps): React.ReactElement {
+  const { element, isSelected, isValidTarget, series, aliasOf, onSelection, onLabelDrag } = props;
+
+  const handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
     e.preventDefault();
     e.stopPropagation();
-    this.props.onSelection(this.props.element, e);
+    onSelection(element, e);
   };
 
-  handleLabelSelection = (e: React.PointerEvent<SVGElement>): void => {
-    e.preventDefault();
-    e.stopPropagation();
-    this.props.onSelection(this.props.element, e, true);
-  };
+  // Memoized: passed to the memo'd Label below, so a stable identity (while
+  // element/onSelection are unchanged) lets Label skip re-rendering.
+  const handleLabelSelection = React.useCallback(
+    (e: React.PointerEvent<SVGElement>): void => {
+      e.preventDefault();
+      e.stopPropagation();
+      onSelection(element, e, true);
+    },
+    [onSelection, element],
+  );
 
-  radius(): number {
-    return AuxRadius;
-  }
+  const cx = element.x;
+  const cy = element.y;
+  const r = AuxRadius;
 
-  sparkline(series: Readonly<Array<Series>> | undefined) {
-    if (!series || series.length === 0) {
-      return undefined;
-    }
-    const { element } = this.props;
-    const isArrayed = false; // element.var?.isArrayed || false;
-    const arrayedOffset = isArrayed ? 3 : 0;
-    const cx = element.x - arrayedOffset;
-    const cy = element.y - arrayedOffset;
-    const r = this.radius();
+  const isArrayed = false; // element.var?.isArrayed || false;
+  const arrayedOffset = isArrayed ? 3 : 0;
 
-    return (
-      <g transform={`translate(${f(cx + 1 - r / 2)} ${f(cy + 1 - r / 2)})`}>
+  const side = element.labelSide;
+  const label = (
+    <Label
+      uid={element.uid}
+      cx={cx}
+      cy={cy}
+      side={side}
+      rw={r + arrayedOffset}
+      rh={r + arrayedOffset}
+      text={displayName(aliasOf?.name || 'unknown alias')}
+      onSelection={handleLabelSelection}
+      onLabelDrag={onLabelDrag}
+    />
+  );
+
+  let sparkline;
+  if (series && series.length > 0) {
+    const sx = cx - arrayedOffset;
+    const sy = cy - arrayedOffset;
+    sparkline = (
+      <g transform={`translate(${f(sx + 1 - r / 2)} ${f(sy + 1 - r / 2)})`}>
         <Sparkline series={series} width={r - 2} height={r - 2} />
       </g>
     );
   }
 
-  render() {
-    const { element, isSelected, isValidTarget, series, aliasOf } = this.props;
-    const cx = element.x;
-    const cy = element.y;
-    const r = this.radius();
+  const groupClassName = clsx(styles.alias, 'simlin-alias', {
+    [styles.selected]: isSelected && isValidTarget === undefined,
+    'simlin-selected': isSelected && isValidTarget === undefined,
+    [styles.targetGood]: isValidTarget === true,
+    [styles.targetBad]: isValidTarget === false,
+  });
 
-    const isArrayed = false; // element.var?.isArrayed || false;
-    const arrayedOffset = isArrayed ? 3 : 0;
-
-    const side = element.labelSide;
-    const label = (
-      <Label
-        uid={element.uid}
-        cx={cx}
-        cy={cy}
-        side={side}
-        rw={r + arrayedOffset}
-        rh={r + arrayedOffset}
-        text={displayName(aliasOf?.name || 'unknown alias')}
-        onSelection={this.handleLabelSelection}
-        onLabelDrag={this.props.onLabelDrag}
-      />
-    );
-
-    const sparkline = this.sparkline(series);
-
-    const groupClassName = clsx(styles.alias, 'simlin-alias', {
-      [styles.selected]: isSelected && isValidTarget === undefined,
-      'simlin-selected': isSelected && isValidTarget === undefined,
-      [styles.targetGood]: isValidTarget === true,
-      [styles.targetBad]: isValidTarget === false,
-    });
-
-    let circles = [<circle key="1" cx={cx} cy={cy} r={r} />];
-    if (isArrayed) {
-      circles = [
-        <circle key="0" cx={cx + arrayedOffset} cy={cy + arrayedOffset} r={r} />,
-        <circle key="1" cx={cx} cy={cy} r={r} />,
-        <circle key="2" cx={cx - arrayedOffset} cy={cy - arrayedOffset} r={r} />,
-      ];
-    }
-
-    return (
-      <g className={groupClassName} onPointerDown={this.handlePointerDown}>
-        {circles}
-        {sparkline}
-        {label}
-      </g>
-    );
+  let circles = [<circle key="1" cx={cx} cy={cy} r={r} />];
+  if (isArrayed) {
+    circles = [
+      <circle key="0" cx={cx + arrayedOffset} cy={cy + arrayedOffset} r={r} />,
+      <circle key="1" cx={cx} cy={cy} r={r} />,
+      <circle key="2" cx={cx - arrayedOffset} cy={cy - arrayedOffset} r={r} />,
+    ];
   }
-}
+
+  return (
+    <g className={groupClassName} onPointerDown={handlePointerDown}>
+      {circles}
+      {sparkline}
+      {label}
+    </g>
+  );
+});

--- a/src/diagram/drawing/Arrowhead.tsx
+++ b/src/diagram/drawing/Arrowhead.tsx
@@ -18,52 +18,51 @@ export interface ArrowheadProps {
   onSelection?: (e: React.PointerEvent<SVGElement>) => void;
 }
 
-export class Arrowhead extends React.PureComponent<ArrowheadProps> {
-  handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
-    if (this.props.onSelection) {
-      this.props.onSelection(e);
+export const Arrowhead = React.memo(function Arrowhead(props: ArrowheadProps): React.ReactElement {
+  const { type, isSelected, onSelection } = props;
+
+  const handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
+    if (onSelection) {
+      onSelection(e);
     }
   };
 
-  render() {
-    const { type, isSelected } = this.props;
-    const { x, y } = this.props.point;
-    let r = this.props.size;
-    // Quantize SVG path coordinates -- see `Connector.tsx::renderStraightLine`
-    // for the byte-identical Rust-vs-TS parity invariant the formatter enforces.
-    const path = `M${f(x)},${f(y)}L${f(x - r)},${f(y + r / 2)}A${f(r * 3)},${f(r * 3)} 0 0,1 ${f(x - r)},${f(y - r / 2)}z`;
-    r *= 1.5;
-    const bgPath = `M${f(x + 0.5 * r)},${f(y)}L${f(x - 0.75 * r)},${f(y + r / 2)}A${f(r * 3)},${f(r * 3)} 0 0,1 ${f(x - 0.75 * r)},${f(
-      y - r / 2,
-    )}z`;
+  const { x, y } = props.point;
+  let r = props.size;
+  // Quantize SVG path coordinates -- see `Connector.tsx::renderStraightLine`
+  // for the byte-identical Rust-vs-TS parity invariant the formatter enforces.
+  const path = `M${f(x)},${f(y)}L${f(x - r)},${f(y + r / 2)}A${f(r * 3)},${f(r * 3)} 0 0,1 ${f(x - r)},${f(y - r / 2)}z`;
+  r *= 1.5;
+  const bgPath = `M${f(x + 0.5 * r)},${f(y)}L${f(x - 0.75 * r)},${f(y + r / 2)}A${f(r * 3)},${f(r * 3)} 0 0,1 ${f(x - 0.75 * r)},${f(
+    y - r / 2,
+  )}z`;
 
-    let pathClassName: string;
-    let staticClass: string;
-    if (type === 'connector') {
-      pathClassName = isSelected ? styles.arrowheadConnectorSelected : styles.arrowheadConnector;
-      staticClass = isSelected ? 'simlin-arrowhead-link simlin-selected' : 'simlin-arrowhead-link';
-    } else {
-      pathClassName = isSelected ? styles.arrowheadFlowSelected : styles.arrowheadFlow;
-      staticClass = isSelected ? 'simlin-arrowhead-flow simlin-selected' : 'simlin-arrowhead-flow';
-    }
-
-    const transform = `rotate(${f(this.props.angle)},${f(x)},${f(y)})`;
-
-    return (
-      <g>
-        <path
-          d={bgPath}
-          className={`${styles.arrowheadBg} simlin-arrowhead-bg`}
-          transform={transform}
-          onPointerDown={this.handlePointerDown}
-        />
-        <path
-          d={path}
-          className={`${pathClassName} ${staticClass}`}
-          transform={transform}
-          onPointerDown={this.handlePointerDown}
-        />
-      </g>
-    );
+  let pathClassName: string;
+  let staticClass: string;
+  if (type === 'connector') {
+    pathClassName = isSelected ? styles.arrowheadConnectorSelected : styles.arrowheadConnector;
+    staticClass = isSelected ? 'simlin-arrowhead-link simlin-selected' : 'simlin-arrowhead-link';
+  } else {
+    pathClassName = isSelected ? styles.arrowheadFlowSelected : styles.arrowheadFlow;
+    staticClass = isSelected ? 'simlin-arrowhead-flow simlin-selected' : 'simlin-arrowhead-flow';
   }
-}
+
+  const transform = `rotate(${f(props.angle)},${f(x)},${f(y)})`;
+
+  return (
+    <g>
+      <path
+        d={bgPath}
+        className={`${styles.arrowheadBg} simlin-arrowhead-bg`}
+        transform={transform}
+        onPointerDown={handlePointerDown}
+      />
+      <path
+        d={path}
+        className={`${pathClassName} ${staticClass}`}
+        transform={transform}
+        onPointerDown={handlePointerDown}
+      />
+    </g>
+  );
+});

--- a/src/diagram/drawing/Auxiliary.tsx
+++ b/src/diagram/drawing/Auxiliary.tsx
@@ -58,106 +58,87 @@ export function auxBounds(element: AuxViewElement): Rect {
   return mergeBounds(bounds, labelBounds(labelProps));
 }
 
-export class Aux extends React.PureComponent<AuxProps> {
-  handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
+export const Aux = React.memo(function Aux(props: AuxProps): React.ReactElement {
+  const { element, isEditingName, isSelected, isValidTarget, hasWarning, series, onSelection, onLabelDrag } = props;
+
+  const handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
     e.preventDefault();
     e.stopPropagation();
-    this.props.onSelection(this.props.element, e);
+    onSelection(element, e);
   };
 
-  handleLabelSelection = (e: React.PointerEvent<SVGElement>): void => {
-    e.preventDefault();
-    e.stopPropagation();
-    this.props.onSelection(this.props.element, e, true);
-  };
+  // Memoized: passed to the memo'd Label below, so a stable identity (while
+  // element/onSelection are unchanged) lets Label skip re-rendering.
+  const handleLabelSelection = React.useCallback(
+    (e: React.PointerEvent<SVGElement>): void => {
+      e.preventDefault();
+      e.stopPropagation();
+      onSelection(element, e, true);
+    },
+    [onSelection, element],
+  );
 
-  radius(): number {
-    return AuxRadius;
-  }
+  const cx = element.x;
+  const cy = element.y;
+  const r = AuxRadius;
 
-  indicators() {
-    if (!this.props.hasWarning) {
-      return undefined;
-    }
+  const isArrayed = (element.var && variableIsArrayed(element.var)) || false;
+  const arrayedOffset = isArrayed ? 3 : 0;
 
-    const { element } = this.props;
-    const r = this.radius();
-    const θ = -Math.PI / 4; // 45 degrees
+  const side = element.labelSide;
+  const label = isEditingName ? undefined : (
+    <Label
+      uid={element.uid}
+      cx={cx}
+      cy={cy}
+      side={side}
+      rw={r + arrayedOffset}
+      rh={r + arrayedOffset}
+      text={displayName(defined(element.name))}
+      onSelection={handleLabelSelection}
+      onLabelDrag={onLabelDrag}
+    />
+  );
 
-    const cx = element.x + r * Math.cos(θ);
-    const cy = element.y + r * Math.sin(θ);
-
-    return <circle className={styles.errorIndicator} cx={cx} cy={cy} r={3} />;
-  }
-
-  sparkline(series: Readonly<Array<Series>> | undefined) {
-    if (!series || series.length === 0) {
-      return undefined;
-    }
-    const { element } = this.props;
-    const isArrayed = (element.var && variableIsArrayed(element.var)) || false;
-    const arrayedOffset = isArrayed ? 3 : 0;
-    const cx = element.x - arrayedOffset;
-    const cy = element.y - arrayedOffset;
-    const r = this.radius();
-
-    return (
-      <g transform={`translate(${f(cx + 1 - r / 2)} ${f(cy + 1 - r / 2)})`}>
+  let sparkline;
+  if (series && series.length > 0) {
+    const sx = cx - arrayedOffset;
+    const sy = cy - arrayedOffset;
+    sparkline = (
+      <g transform={`translate(${f(sx + 1 - r / 2)} ${f(sy + 1 - r / 2)})`}>
         <Sparkline series={series} width={r - 2} height={r - 2} />
       </g>
     );
   }
 
-  render() {
-    const { element, isEditingName, isSelected, isValidTarget, series } = this.props;
-    const cx = element.x;
-    const cy = element.y;
-    const r = this.radius();
-
-    const isArrayed = (element.var && variableIsArrayed(element.var)) || false;
-    const arrayedOffset = isArrayed ? 3 : 0;
-
-    const side = element.labelSide;
-    const label = isEditingName ? undefined : (
-      <Label
-        uid={element.uid}
-        cx={cx}
-        cy={cy}
-        side={side}
-        rw={r + arrayedOffset}
-        rh={r + arrayedOffset}
-        text={displayName(defined(element.name))}
-        onSelection={this.handleLabelSelection}
-        onLabelDrag={this.props.onLabelDrag}
-      />
-    );
-
-    const sparkline = this.sparkline(series);
-    const indicator = this.indicators();
-
-    const groupClassName = clsx(styles.aux, 'simlin-aux', {
-      [styles.selected]: isSelected && isValidTarget === undefined,
-      'simlin-selected': isSelected && isValidTarget === undefined,
-      [styles.targetGood]: isValidTarget === true,
-      [styles.targetBad]: isValidTarget === false,
-    });
-
-    let circles = [<circle key="1" cx={cx} cy={cy} r={r} />];
-    if (isArrayed) {
-      circles = [
-        <circle key="0" cx={cx + arrayedOffset} cy={cy + arrayedOffset} r={r} />,
-        <circle key="1" cx={cx} cy={cy} r={r} />,
-        <circle key="2" cx={cx - arrayedOffset} cy={cy - arrayedOffset} r={r} />,
-      ];
-    }
-
-    return (
-      <g className={groupClassName} onPointerDown={this.handlePointerDown}>
-        {circles}
-        {sparkline}
-        {indicator}
-        {label}
-      </g>
-    );
+  let indicator;
+  if (hasWarning) {
+    const θ = -Math.PI / 4; // 45 degrees
+    indicator = <circle className={styles.errorIndicator} cx={cx + r * Math.cos(θ)} cy={cy + r * Math.sin(θ)} r={3} />;
   }
-}
+
+  const groupClassName = clsx(styles.aux, 'simlin-aux', {
+    [styles.selected]: isSelected && isValidTarget === undefined,
+    'simlin-selected': isSelected && isValidTarget === undefined,
+    [styles.targetGood]: isValidTarget === true,
+    [styles.targetBad]: isValidTarget === false,
+  });
+
+  let circles = [<circle key="1" cx={cx} cy={cy} r={r} />];
+  if (isArrayed) {
+    circles = [
+      <circle key="0" cx={cx + arrayedOffset} cy={cy + arrayedOffset} r={r} />,
+      <circle key="1" cx={cx} cy={cy} r={r} />,
+      <circle key="2" cx={cx - arrayedOffset} cy={cy - arrayedOffset} r={r} />,
+    ];
+  }
+
+  return (
+    <g className={groupClassName} onPointerDown={handlePointerDown}>
+      {circles}
+      {sparkline}
+      {indicator}
+      {label}
+    </g>
+  );
+});

--- a/src/diagram/drawing/Cloud.tsx
+++ b/src/diagram/drawing/Cloud.tsx
@@ -54,35 +54,34 @@ export function cloudBounds(element: CloudViewElement): Rect {
   };
 }
 
-export class Cloud extends React.PureComponent<CloudProps> {
-  handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
+export const Cloud = React.memo(function Cloud(props: CloudProps): React.ReactElement {
+  const { element, isHidden, onSelection } = props;
+
+  const handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
     e.preventDefault();
     e.stopPropagation();
-    this.props.onSelection(this.props.element, e);
+    onSelection(element, e);
   };
 
-  render() {
-    const { element, isHidden } = this.props;
-    const x = defined(element.x);
-    const y = defined(element.y);
+  const x = defined(element.x);
+  const y = defined(element.y);
 
-    const radius = CloudRadius;
-    const diameter = radius * 2;
+  const radius = CloudRadius;
+  const diameter = radius * 2;
 
-    const scale = diameter / CloudWidth;
-    const t = `matrix(${f(scale)}, 0, 0, ${f(scale)}, ${f(x - radius)}, ${f(y - radius)})`;
+  const scale = diameter / CloudWidth;
+  const t = `matrix(${f(scale)}, 0, 0, ${f(scale)}, ${f(x - radius)}, ${f(y - radius)})`;
 
-    // Keep cloud in DOM (for pointer capture) but visually hidden when dragging
-    const style = isHidden ? { visibility: 'hidden' as const } : undefined;
+  // Keep cloud in DOM (for pointer capture) but visually hidden when dragging
+  const style = isHidden ? { visibility: 'hidden' as const } : undefined;
 
-    return (
-      <path
-        d={CloudPath}
-        className={`${styles.cloud} simlin-cloud`}
-        transform={t}
-        style={style}
-        onPointerDown={this.handlePointerDown}
-      />
-    );
-  }
-}
+  return (
+    <path
+      d={CloudPath}
+      className={`${styles.cloud} simlin-cloud`}
+      transform={t}
+      style={style}
+      onPointerDown={handlePointerDown}
+    />
+  );
+});

--- a/src/diagram/drawing/Connector.tsx
+++ b/src/diagram/drawing/Connector.tsx
@@ -4,16 +4,19 @@
 
 import * as React from 'react';
 
-import {
-  isNamedViewElement,
-  LinkViewElement,
-  variableIsArrayed,
-  ViewElement,
-} from '@simlin/core/datamodel';
+import { isNamedViewElement, LinkViewElement, variableIsArrayed, ViewElement } from '@simlin/core/datamodel';
 
 import { Arrowhead } from './Arrowhead';
 import { Circle, isInf, isZero, Point, Rect, square } from './common';
-import { ArrowheadRadius, AuxRadius, StockWidth, StockHeight, ModuleWidth, ModuleHeight, StraightLineMax } from './default';
+import {
+  ArrowheadRadius,
+  AuxRadius,
+  StockWidth,
+  StockHeight,
+  ModuleWidth,
+  ModuleHeight,
+  StraightLineMax,
+} from './default';
 import { degToRad, radToDeg } from '../arc-utils';
 import { jsFormatNumber as f } from '../render-common';
 import styles from './Connector.module.css';
@@ -47,7 +50,6 @@ const cos = Math.cos;
 const tan = Math.tan;
 const PI = Math.PI;
 const sqrt = Math.sqrt;
-
 
 export function rayRectIntersection(cx: number, cy: number, hw: number, hh: number, θ: number): Point {
   const cosT = cos(θ);
@@ -162,11 +164,7 @@ export function takeoffθ(props: Pick<ConnectorProps, 'element' | 'from' | 'to' 
  * line) when the cursor is collinear or within StraightLineMax of the direct
  * source-to-target line.
  */
-export function computeLinkCreationArc(
-  from: ViewElement,
-  to: ViewElement,
-  arcPoint: Point,
-): number | undefined {
+export function computeLinkCreationArc(from: ViewElement, to: ViewElement, arcPoint: Point): number | undefined {
   const fromVisual = getVisualCenter(from);
   const toVisual = getVisualCenter(to);
   const midθ = atan2(toVisual.cy - fromVisual.cy, toVisual.cx - fromVisual.cx);
@@ -274,63 +272,186 @@ export interface ConnectorProps {
   arcPoint?: Point;
 }
 
-export class Connector extends React.PureComponent<ConnectorProps> {
-  handlePointerDownArc = (e: React.PointerEvent<SVGElement>): void => {
-    e.preventDefault();
-    e.stopPropagation();
-    this.props.onSelection(this.props.element, e, false);
-  };
+export function intersectElementStraight(element: ViewElement, θ: number): Point {
+  const { cx, cy } = getVisualCenter(element);
 
-  handlePointerDownArrowhead = (e: React.PointerEvent<SVGElement>): void => {
-    e.preventDefault();
-    e.stopPropagation();
-    this.props.onSelection(this.props.element, e, true);
-  };
-
-  static intersectElementStraight(element: ViewElement, θ: number): Point {
-    const { cx, cy } = getVisualCenter(element);
-
-    if (element.type === 'stock') {
-      return rayRectIntersection(cx, cy, StockWidth / 2, StockHeight / 2, θ);
-    } else if (element.type === 'module') {
-      return rayRectIntersection(cx, cy, ModuleWidth / 2, ModuleHeight / 2, θ);
-    }
-
-    let r: number = AuxRadius;
-    if (element.isZeroRadius) {
-      r = 0;
-    }
-
-    return {
-      x: cx + r * cos(θ),
-      y: cy + r * sin(θ),
-    };
+  if (element.type === 'stock') {
+    return rayRectIntersection(cx, cy, StockWidth / 2, StockHeight / 2, θ);
+  } else if (element.type === 'module') {
+    return rayRectIntersection(cx, cy, ModuleWidth / 2, ModuleHeight / 2, θ);
   }
 
-  static isStraightLine(props: ConnectorProps): boolean {
-    const { element, arcPoint, from, to } = props;
-
-    // If there's no arc defined and no arcPoint, draw a straight line
-    if (element.arc === undefined && !arcPoint) {
-      return true;
-    }
-
-    const takeoffAngle = takeoffθ(props);
-    const fromVisual = getVisualCenter(from);
-    const toVisual = getVisualCenter(to);
-    const midθ = atan2(toVisual.cy - fromVisual.cy, toVisual.cx - fromVisual.cx);
-
-    return Math.abs(midθ - takeoffAngle) < degToRad(StraightLineMax);
+  let r: number = AuxRadius;
+  if (element.isZeroRadius) {
+    r = 0;
   }
 
-  renderStraightLine() {
-    const { from, to, isSelected, isDashed } = this.props;
+  return {
+    x: cx + r * cos(θ),
+    y: cy + r * sin(θ),
+  };
+}
 
+export function isStraightLine(props: ConnectorProps): boolean {
+  const { element, arcPoint, from, to } = props;
+
+  // If there's no arc defined and no arcPoint, draw a straight line
+  if (element.arc === undefined && !arcPoint) {
+    return true;
+  }
+
+  const takeoffAngle = takeoffθ(props);
+  const fromVisual = getVisualCenter(from);
+  const toVisual = getVisualCenter(to);
+  const midθ = atan2(toVisual.cy - fromVisual.cy, toVisual.cx - fromVisual.cx);
+
+  return Math.abs(midθ - takeoffAngle) < degToRad(StraightLineMax);
+}
+
+function arcCircle(props: ConnectorProps): Circle | undefined {
+  const { from, to, arcPoint } = props;
+
+  const fromVisual = getVisualCenter(from);
+  const toVisual = getVisualCenter(to);
+
+  if (arcPoint && !(toVisual.cx === arcPoint.x && toVisual.cy === arcPoint.y)) {
+    try {
+      return circleFromPoints({ x: fromVisual.cx, y: fromVisual.cy }, { x: toVisual.cx, y: toVisual.cy }, arcPoint);
+    } catch {
+      return undefined;
+    }
+  }
+
+  // Find cx, cy from 'takeoff angle', and center of
+  // 'from', and center of 'to'.  This means we have 2
+  // points on the edge of a cirlce, and the tangent at
+  // point 1.
+  //
+  //     eqn of a circle: (x - cx)^2 + (y - cy)^2 = r^2
+  //     line:            y = mx + b || 0 = mx - y + b
+
+  const slopeTakeoff = tan(takeoffθ(props));
+  // we need the slope of the line _perpendicular_ to
+  // the tangent in order to find out the x,y center of
+  // our circle
+  let slopePerpToTakeoff = -1 / slopeTakeoff;
+  if (isZero(slopePerpToTakeoff)) {
+    slopePerpToTakeoff = 0;
+  } else if (isInf(slopePerpToTakeoff)) {
+    // we are either on the left or right edge of the circle.
+    slopePerpToTakeoff = slopePerpToTakeoff > 0 ? Infinity : -Infinity;
+  }
+
+  // y = slope*x + b
+  // fy = slope*fx + b
+  // fy - slope*fx = b
+  // b = fy - slope*fx
+  const bFrom = fromVisual.cy - slopePerpToTakeoff * fromVisual.cx;
+  let cx: number;
+  let cy: number;
+
+  if (fromVisual.cy === toVisual.cy) {
+    cx = (fromVisual.cx + toVisual.cx) / 2;
+    cy = slopePerpToTakeoff * cx + bFrom;
+  } else {
+    // find the slope of the line between the 2 points
+    const slopeBisector = (fromVisual.cy - toVisual.cy) / (fromVisual.cx - toVisual.cx);
+    const slopePerpToBisector = -1 / slopeBisector;
+    const midx = (fromVisual.cx + toVisual.cx) / 2;
+    const midy = (fromVisual.cy + toVisual.cy) / 2;
+    // b = fy - slope*fx
+    const bPerp = midy - slopePerpToBisector * midx;
+
+    if (isInf(slopePerpToTakeoff)) {
+      cx = fromVisual.cx;
+      cy = slopePerpToBisector * cx + bPerp;
+    } else {
+      // y = perpSlopeTakeoff*x + bFrom
+      // y = perpSlopeBisector*x + bPerp
+      // perpSlopeTakeoff*x + bFrom = perpSlopeBisector*x + bPerp
+      // bFrom - bPerp = perpSlopeBisector*x - perpSlopeTakeoff*x
+      // bFrom - bPerp = (perpSlopeBisector- perpSlopeTakeoff)*x
+      // (bFrom - bPerp)/(perpSlopeBisector- perpSlopeTakeoff) = x
+      cx = (bFrom - bPerp) / (slopePerpToBisector - slopePerpToTakeoff);
+      cy = slopePerpToTakeoff * cx + bFrom;
+    }
+  }
+
+  const cr = sqrt(square(fromVisual.cx - cx) + square(fromVisual.cy - cy));
+
+  return { r: cr, x: cx, y: cy };
+}
+
+export function boundStraightLine(props: ConnectorProps): Rect {
+  const { to, from } = props;
+  const fromVisual = getVisualCenter(from);
+  const toVisual = getVisualCenter(to);
+  return {
+    top: Math.min(toVisual.cy, fromVisual.cy),
+    left: Math.min(toVisual.cx, fromVisual.cx),
+    right: Math.max(toVisual.cx, fromVisual.cx),
+    bottom: Math.max(toVisual.cy, fromVisual.cy),
+  };
+}
+
+export function boundArc(props: ConnectorProps): Rect | undefined {
+  const circ = arcCircle(props);
+  if (!circ) {
+    return undefined;
+  }
+
+  return {
+    top: circ.y - circ.r,
+    left: circ.x - circ.r,
+    right: circ.x + circ.r,
+    bottom: circ.y + circ.r,
+  };
+}
+
+export function connectorBounds(props: ConnectorProps): Rect | undefined {
+  if (isStraightLine(props)) {
+    return boundStraightLine(props);
+  } else {
+    return boundArc(props);
+  }
+}
+
+export const Connector = React.memo(function Connector(props: ConnectorProps): React.ReactElement {
+  const { element, from, to, isSelected, isDashed, onSelection } = props;
+
+  // Memoized: passed to the memo'd Arrowhead below, so a stable identity
+  // (while element/onSelection are unchanged) lets Arrowhead skip re-rendering.
+  const handlePointerDownArc = React.useCallback(
+    (e: React.PointerEvent<SVGElement>): void => {
+      e.preventDefault();
+      e.stopPropagation();
+      onSelection(element, e, false);
+    },
+    [onSelection, element],
+  );
+
+  const handlePointerDownArrowhead = React.useCallback(
+    (e: React.PointerEvent<SVGElement>): void => {
+      e.preventDefault();
+      e.stopPropagation();
+      onSelection(element, e, true);
+    },
+    [onSelection, element],
+  );
+
+  let connectorClass = isSelected
+    ? `${styles.connectorSelected} simlin-connector simlin-connector-selected`
+    : `${styles.connector} simlin-connector`;
+  if (isDashed && !isSelected) {
+    connectorClass = `${styles.connectorDashed} simlin-connector simlin-connector-dashed`;
+  }
+
+  if (isStraightLine(props)) {
     const fromVisual = getVisualCenter(from);
     const toVisual = getVisualCenter(to);
     const θ = atan2(toVisual.cy - fromVisual.cy, toVisual.cx - fromVisual.cx);
-    const start = Connector.intersectElementStraight(from, θ);
-    const end = Connector.intersectElementStraight(to, oppositeθ(θ));
+    const start = intersectElementStraight(from, θ);
+    const end = intersectElementStraight(to, oppositeθ(θ));
 
     const arrowθ = radToDeg(θ);
     // Quantize SVG coordinates so 1-ULP f64 differences between the Rust and
@@ -339,227 +460,83 @@ export class Connector extends React.PureComponent<ConnectorProps> {
     // identical). See `jsFormatNumber` in `render-common.tsx`.
     const path = `M${f(start.x)},${f(start.y)}L${f(end.x)},${f(end.y)}`;
 
-    let connectorClass = isSelected
-      ? `${styles.connectorSelected} simlin-connector simlin-connector-selected`
-      : `${styles.connector} simlin-connector`;
-    if (isDashed && !isSelected) {
-      connectorClass = `${styles.connectorDashed} simlin-connector simlin-connector-dashed`;
-    }
-
     return (
-      <g key={this.props.element.uid}>
-        <path
-          d={path}
-          className={`${styles.connectorBg} simlin-connector-bg`}
-          onPointerDown={this.handlePointerDownArc}
-        />
-        <path d={path} className={connectorClass} onPointerDown={this.handlePointerDownArc} />
+      <g key={element.uid}>
+        <path d={path} className={`${styles.connectorBg} simlin-connector-bg`} onPointerDown={handlePointerDownArc} />
+        <path d={path} className={connectorClass} onPointerDown={handlePointerDownArc} />
         <Arrowhead
           point={end}
           angle={arrowθ}
           isSelected={isSelected}
           size={ArrowheadRadius}
-          onSelection={this.handlePointerDownArrowhead}
+          onSelection={handlePointerDownArrowhead}
           type="connector"
         />
       </g>
     );
   }
 
-  private static arcCircle(props: ConnectorProps): Circle | undefined {
-    const { from, to, arcPoint } = props;
+  const fromVisual = getVisualCenter(from);
+  const toVisual = getVisualCenter(to);
 
-    const fromVisual = getVisualCenter(from);
-    const toVisual = getVisualCenter(to);
-
-    if (arcPoint && !(toVisual.cx === arcPoint.x && toVisual.cy === arcPoint.y)) {
-      try {
-        return circleFromPoints({ x: fromVisual.cx, y: fromVisual.cy }, { x: toVisual.cx, y: toVisual.cy }, arcPoint);
-      } catch {
-        return undefined;
-      }
-    }
-
-    // Find cx, cy from 'takeoff angle', and center of
-    // 'from', and center of 'to'.  This means we have 2
-    // points on the edge of a cirlce, and the tangent at
-    // point 1.
-    //
-    //     eqn of a circle: (x - cx)^2 + (y - cy)^2 = r^2
-    //     line:            y = mx + b || 0 = mx - y + b
-
-    const slopeTakeoff = tan(takeoffθ(props));
-    // we need the slope of the line _perpendicular_ to
-    // the tangent in order to find out the x,y center of
-    // our circle
-    let slopePerpToTakeoff = -1 / slopeTakeoff;
-    if (isZero(slopePerpToTakeoff)) {
-      slopePerpToTakeoff = 0;
-    } else if (isInf(slopePerpToTakeoff)) {
-      // we are either on the left or right edge of the circle.
-      slopePerpToTakeoff = slopePerpToTakeoff > 0 ? Infinity : -Infinity;
-    }
-
-    // y = slope*x + b
-    // fy = slope*fx + b
-    // fy - slope*fx = b
-    // b = fy - slope*fx
-    const bFrom = fromVisual.cy - slopePerpToTakeoff * fromVisual.cx;
-    let cx: number;
-    let cy: number;
-
-    if (fromVisual.cy === toVisual.cy) {
-      cx = (fromVisual.cx + toVisual.cx) / 2;
-      cy = slopePerpToTakeoff * cx + bFrom;
-    } else {
-      // find the slope of the line between the 2 points
-      const slopeBisector = (fromVisual.cy - toVisual.cy) / (fromVisual.cx - toVisual.cx);
-      const slopePerpToBisector = -1 / slopeBisector;
-      const midx = (fromVisual.cx + toVisual.cx) / 2;
-      const midy = (fromVisual.cy + toVisual.cy) / 2;
-      // b = fy - slope*fx
-      const bPerp = midy - slopePerpToBisector * midx;
-
-      if (isInf(slopePerpToTakeoff)) {
-        cx = fromVisual.cx;
-        cy = slopePerpToBisector * cx + bPerp;
-      } else {
-        // y = perpSlopeTakeoff*x + bFrom
-        // y = perpSlopeBisector*x + bPerp
-        // perpSlopeTakeoff*x + bFrom = perpSlopeBisector*x + bPerp
-        // bFrom - bPerp = perpSlopeBisector*x - perpSlopeTakeoff*x
-        // bFrom - bPerp = (perpSlopeBisector- perpSlopeTakeoff)*x
-        // (bFrom - bPerp)/(perpSlopeBisector- perpSlopeTakeoff) = x
-        cx = (bFrom - bPerp) / (slopePerpToBisector - slopePerpToTakeoff);
-        cy = slopePerpToTakeoff * cx + bFrom;
-      }
-    }
-
-    const cr = sqrt(square(fromVisual.cx - cx) + square(fromVisual.cy - cy));
-
-    return { r: cr, x: cx, y: cy };
+  const takeoffAngle = takeoffθ(props);
+  const circ = arcCircle(props);
+  if (circ === undefined) {
+    console.log('FIXME: arcCircle returned null');
+    return <g key={element.uid} />;
   }
 
-  renderArc() {
-    const { from, to, isSelected, isDashed } = this.props;
-
-    const fromVisual = getVisualCenter(from);
-    const toVisual = getVisualCenter(to);
-
-    const takeoffAngle = takeoffθ(this.props);
-    const circ = Connector.arcCircle(this.props);
-    if (circ === undefined) {
-      console.log('FIXME: arcCircle returned null');
-      return <g key={this.props.element.uid} />;
-    }
-
-    const fromθ = atan2(fromVisual.cy - circ.y, fromVisual.cx - circ.x);
-    const toθ = atan2(toVisual.cy - circ.y, toVisual.cx - circ.x);
-    let spanθ = toθ - fromθ;
-    if (spanθ > degToRad(180)) {
-      spanθ -= degToRad(360);
-    }
-
-    // if the sweep flag is set, we need to negate the
-    // inverse flag
-    let inv: boolean = spanθ > 0 || spanθ <= degToRad(-180);
-
-    const side1 =
-      (circ.x - fromVisual.cx) * (toVisual.cy - fromVisual.cy) -
-      (circ.y - fromVisual.cy) * (toVisual.cx - fromVisual.cx);
-    const startA = intersectElementArc(from, circ, inv);
-    const startR = sqrt(square(startA.x - fromVisual.cx) + square(startA.y - fromVisual.cy));
-    const takeoffPoint = {
-      x: fromVisual.cx + startR * cos(takeoffAngle),
-      y: fromVisual.cy + startR * sin(takeoffAngle),
-    };
-    const side2 =
-      (takeoffPoint.x - fromVisual.cx) * (toVisual.cy - fromVisual.cy) -
-      (takeoffPoint.y - fromVisual.cy) * (toVisual.cx - fromVisual.cx);
-
-    const sweep = side1 < 0 === side2 < 0;
-
-    if (sweep) {
-      inv = !inv;
-    }
-    const start = { x: fromVisual.cx, y: fromVisual.cy };
-    const arcEnd = { x: toVisual.cx, y: toVisual.cy };
-    const end = intersectElementArc(to, circ, !inv);
-
-    const path = `M${f(start.x)},${f(start.y)}A${f(circ.r)},${f(circ.r)} 0 ${+sweep},${+inv} ${f(arcEnd.x)},${f(arcEnd.y)}`;
-
-    let arrowθ = radToDeg(atan2(end.y - circ.y, end.x - circ.x)) - 90;
-    if (inv) {
-      arrowθ += 180;
-    }
-
-    let connectorClass = isSelected
-      ? `${styles.connectorSelected} simlin-connector simlin-connector-selected`
-      : `${styles.connector} simlin-connector`;
-    if (isDashed && !isSelected) {
-      connectorClass = `${styles.connectorDashed} simlin-connector simlin-connector-dashed`;
-    }
-
-    return (
-      <g key={this.props.element.uid}>
-        <path
-          d={path}
-          className={`${styles.connectorBg} simlin-connector-bg`}
-          onPointerDown={this.handlePointerDownArc}
-        />
-        <path d={path} className={connectorClass} onPointerDown={this.handlePointerDownArc} />
-        <Arrowhead
-          point={end}
-          angle={arrowθ}
-          isSelected={isSelected}
-          size={ArrowheadRadius}
-          type="connector"
-          onSelection={this.handlePointerDownArrowhead}
-        />
-      </g>
-    );
+  const fromθ = atan2(fromVisual.cy - circ.y, fromVisual.cx - circ.x);
+  const toθ = atan2(toVisual.cy - circ.y, toVisual.cx - circ.x);
+  let spanθ = toθ - fromθ;
+  if (spanθ > degToRad(180)) {
+    spanθ -= degToRad(360);
   }
 
-  static boundStraightLine(props: ConnectorProps): Rect {
-    const { to, from } = props;
-    const fromVisual = getVisualCenter(from);
-    const toVisual = getVisualCenter(to);
-    return {
-      top: Math.min(toVisual.cy, fromVisual.cy),
-      left: Math.min(toVisual.cx, fromVisual.cx),
-      right: Math.max(toVisual.cx, fromVisual.cx),
-      bottom: Math.max(toVisual.cy, fromVisual.cy),
-    };
+  // if the sweep flag is set, we need to negate the
+  // inverse flag
+  let inv: boolean = spanθ > 0 || spanθ <= degToRad(-180);
+
+  const side1 =
+    (circ.x - fromVisual.cx) * (toVisual.cy - fromVisual.cy) - (circ.y - fromVisual.cy) * (toVisual.cx - fromVisual.cx);
+  const startA = intersectElementArc(from, circ, inv);
+  const startR = sqrt(square(startA.x - fromVisual.cx) + square(startA.y - fromVisual.cy));
+  const takeoffPoint = {
+    x: fromVisual.cx + startR * cos(takeoffAngle),
+    y: fromVisual.cy + startR * sin(takeoffAngle),
+  };
+  const side2 =
+    (takeoffPoint.x - fromVisual.cx) * (toVisual.cy - fromVisual.cy) -
+    (takeoffPoint.y - fromVisual.cy) * (toVisual.cx - fromVisual.cx);
+
+  const sweep = side1 < 0 === side2 < 0;
+
+  if (sweep) {
+    inv = !inv;
+  }
+  const start = { x: fromVisual.cx, y: fromVisual.cy };
+  const arcEnd = { x: toVisual.cx, y: toVisual.cy };
+  const end = intersectElementArc(to, circ, !inv);
+
+  const path = `M${f(start.x)},${f(start.y)}A${f(circ.r)},${f(circ.r)} 0 ${+sweep},${+inv} ${f(arcEnd.x)},${f(arcEnd.y)}`;
+
+  let arrowθ = radToDeg(atan2(end.y - circ.y, end.x - circ.x)) - 90;
+  if (inv) {
+    arrowθ += 180;
   }
 
-  static boundArc(props: ConnectorProps): Rect | undefined {
-    const circ = Connector.arcCircle(props);
-    if (!circ) {
-      return undefined;
-    }
-
-    const bounds = {
-      top: circ.y - circ.r,
-      left: circ.x - circ.r,
-      right: circ.x + circ.r,
-      bottom: circ.y + circ.r,
-    };
-    return bounds;
-  }
-
-  static bounds(props: ConnectorProps): Rect | undefined {
-    if (Connector.isStraightLine(props)) {
-      return Connector.boundStraightLine(props);
-    } else {
-      return Connector.boundArc(props);
-    }
-  }
-
-  render() {
-    if (Connector.isStraightLine(this.props)) {
-      return this.renderStraightLine();
-    } else {
-      return this.renderArc();
-    }
-  }
-}
+  return (
+    <g key={element.uid}>
+      <path d={path} className={`${styles.connectorBg} simlin-connector-bg`} onPointerDown={handlePointerDownArc} />
+      <path d={path} className={connectorClass} onPointerDown={handlePointerDownArc} />
+      <Arrowhead
+        point={end}
+        angle={arrowθ}
+        isSelected={isSelected}
+        size={ArrowheadRadius}
+        type="connector"
+        onSelection={handlePointerDownArrowhead}
+      />
+    </g>
+  );
+});

--- a/src/diagram/drawing/EditableLabel.tsx
+++ b/src/diagram/drawing/EditableLabel.tsx
@@ -20,15 +20,13 @@ interface EditingLabelProps extends CommonLabelProps {
   zoom: number;
 }
 
-interface EditingLabelState {
-  editor: ReactEditor;
-}
+export const EditableLabel = React.memo(function EditableLabel(props: EditingLabelProps): React.ReactElement {
+  const { value, onChange, onDone } = props;
 
-export class EditableLabel extends React.PureComponent<EditingLabelProps, EditingLabelState> {
-  constructor(props: EditingLabelProps) {
-    super(props);
-
-    const { value } = props;
+  // The Slate editor is created exactly once per mount (Canvas remounts this
+  // component for each edit session), seeded from the initial value with the
+  // full text selected -- mirroring the class component's constructor.
+  const [editor] = React.useState<ReactEditor>(() => {
     const editor = withHistory(withReact(createEditor()));
     if (value.length > 0) {
       editor.children = value;
@@ -40,106 +38,99 @@ export class EditableLabel extends React.PureComponent<EditingLabelProps, Editin
         focus: Editor.end(editor, [value.length - 1]),
       });
     }
+    return editor;
+  });
 
-    this.state = {
-      editor,
-    };
-  }
-
-  handleChange = (value: Descendant[]): void => {
-    this.props.onChange(value);
+  const handleChange = (value: Descendant[]): void => {
+    onChange(value);
   };
 
-  handlePointerUpDown = (e: React.PointerEvent<HTMLDivElement>): void => {
+  const handlePointerUpDown = (e: React.PointerEvent<HTMLDivElement>): void => {
     e.stopPropagation();
   };
 
-  handleKeyPress = (e: React.KeyboardEvent<HTMLDivElement>): void => {
+  const handleKeyPress = (e: React.KeyboardEvent<HTMLDivElement>): void => {
     if (e.code === 'Enter' && (e.ctrlKey || e.shiftKey || e.altKey)) {
       e.stopPropagation();
-      this.props.onDone(false);
+      onDone(false);
     } else if (e.code === 'Escape') {
       e.stopPropagation();
-      this.props.onDone(true);
+      onDone(true);
     }
   };
 
-  render() {
-    const { cx, cy, side, zoom } = this.props;
-    const fontSize = 12 * zoom;
+  const { cx, cy, side, zoom } = props;
+  const fontSize = 12 * zoom;
 
-    const lines: string[] = this.props.value.map((n) => Node.string(n));
-    const linesCount = lines.length;
+  const lines: string[] = value.map((n) => Node.string(n));
+  const linesCount = lines.length;
 
-    const maxWidthChars = lines.reduce((prev, curr) => (curr.length > prev ? curr.length : prev), 0);
-    const editorWidth = (maxWidthChars * 6 + 10) * zoom;
+  const maxWidthChars = lines.reduce((prev, curr) => (curr.length > prev ? curr.length : prev), 0);
+  const editorWidth = (maxWidthChars * 6 + 10) * zoom;
 
-    const rw: number = this.props.rw || AuxRadius;
-    const rh: number = this.props.rh || AuxRadius;
-    let x = cx;
-    let y = cy;
-    const textX = Math.round(x);
-    let textY = y;
-    let left = 0;
-    let textAlign: 'center' | 'left' | 'right' = 'center';
-    const labelPadding = baseLabelPadding * zoom;
-    const lineSpacing = baseLineSpacing * zoom;
-    switch (side) {
-      case 'top':
-        y = cy - rh - labelPadding - lineSpacing * linesCount;
-        left = textX - editorWidth / 2;
-        textY = y;
-        break;
-      case 'bottom':
-        y = cy + rh + labelPadding;
-        left = textX - editorWidth / 2;
-        textY = y;
-        break;
-      case 'left':
-        x = cx - rw - labelPadding + 1;
-        textAlign = 'right';
-        left = x - editorWidth;
-        textY = y - (fontSize + (lines.length - 1) * 14 * zoom) / 2 - 3;
-        break;
-      case 'right':
-        x = cx + rw + labelPadding - 1;
-        textAlign = 'left';
-        left = x;
-        textY = y - (fontSize + (lines.length - 1) * 14 * zoom) / 2 - 3;
-        break;
-      default:
-        // FIXME
-        console.log('unknown label case ' + side);
-    }
-
-    textY = Math.round(textY);
-
-    const style: React.CSSProperties = {
-      position: 'relative',
-      left,
-      top: textY,
-      width: editorWidth,
-      textAlign,
-      lineHeight: `${14 * zoom}px`,
-      background: 'white',
-      borderRadius: '3px',
-      border: '1px solid #4444dd',
-      fontSize,
-    };
-
-    const { value } = this.props;
-
-    return (
-      <div
-        className={styles.editableLabel}
-        style={style}
-        onPointerDown={this.handlePointerUpDown}
-        onPointerUp={this.handlePointerUpDown}
-      >
-        <Slate editor={this.state.editor} initialValue={value} onChange={this.handleChange}>
-          <Editable autoFocus={true} onKeyUp={this.handleKeyPress} />
-        </Slate>
-      </div>
-    );
+  const rw: number = props.rw || AuxRadius;
+  const rh: number = props.rh || AuxRadius;
+  let x = cx;
+  let y = cy;
+  const textX = Math.round(x);
+  let textY = y;
+  let left = 0;
+  let textAlign: 'center' | 'left' | 'right' = 'center';
+  const labelPadding = baseLabelPadding * zoom;
+  const lineSpacing = baseLineSpacing * zoom;
+  switch (side) {
+    case 'top':
+      y = cy - rh - labelPadding - lineSpacing * linesCount;
+      left = textX - editorWidth / 2;
+      textY = y;
+      break;
+    case 'bottom':
+      y = cy + rh + labelPadding;
+      left = textX - editorWidth / 2;
+      textY = y;
+      break;
+    case 'left':
+      x = cx - rw - labelPadding + 1;
+      textAlign = 'right';
+      left = x - editorWidth;
+      textY = y - (fontSize + (lines.length - 1) * 14 * zoom) / 2 - 3;
+      break;
+    case 'right':
+      x = cx + rw + labelPadding - 1;
+      textAlign = 'left';
+      left = x;
+      textY = y - (fontSize + (lines.length - 1) * 14 * zoom) / 2 - 3;
+      break;
+    default:
+      // FIXME
+      console.log('unknown label case ' + side);
   }
-}
+
+  textY = Math.round(textY);
+
+  const style: React.CSSProperties = {
+    position: 'relative',
+    left,
+    top: textY,
+    width: editorWidth,
+    textAlign,
+    lineHeight: `${14 * zoom}px`,
+    background: 'white',
+    borderRadius: '3px',
+    border: '1px solid #4444dd',
+    fontSize,
+  };
+
+  return (
+    <div
+      className={styles.editableLabel}
+      style={style}
+      onPointerDown={handlePointerUpDown}
+      onPointerUp={handlePointerUpDown}
+    >
+      <Slate editor={editor} initialValue={value} onChange={handleChange}>
+        <Editable autoFocus={true} onKeyUp={handleKeyPress} />
+      </Slate>
+    </div>
+  );
+});

--- a/src/diagram/drawing/Flow.tsx
+++ b/src/diagram/drawing/Flow.tsx
@@ -6,7 +6,14 @@ import * as React from 'react';
 
 import clsx from 'clsx';
 
-import { Point, FlowViewElement, ViewElement, StockViewElement, CloudViewElement, variableIsArrayed } from '@simlin/core/datamodel';
+import {
+  Point,
+  FlowViewElement,
+  ViewElement,
+  StockViewElement,
+  CloudViewElement,
+  variableIsArrayed,
+} from '@simlin/core/datamodel';
 import { arrayWith, defined, Series } from '@simlin/core/common';
 import { at, first, last } from '@simlin/core/collections';
 
@@ -1633,13 +1640,16 @@ export interface FlowProps {
   sink: StockViewElement | CloudViewElement;
 }
 
-export class Flow extends React.PureComponent<FlowProps> {
-  handlePointerUp = (_e: React.PointerEvent<SVGElement>): void => {
+export const Flow = React.memo(function Flow(props: FlowProps): React.ReactElement {
+  const { element, isEditingName, isMovingArrow, isMovingSource, isSelected, isValidTarget, series, sink } = props;
+  const { hasWarning, embedded, onSelection, onLabelDrag } = props;
+
+  const handlePointerUp = (_e: React.PointerEvent<SVGElement>): void => {
     // e.preventDefault();
     // e.stopPropagation();
   };
 
-  handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
+  const handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
     e.preventDefault();
     e.stopPropagation();
 
@@ -1659,224 +1669,195 @@ export class Flow extends React.PureComponent<FlowProps> {
       const ctm = target.getScreenCTM();
       if (ctm) {
         const modelPt = pt.matrixTransform(ctm.inverse());
-        segmentIndex = findClickedSegment(
-          modelPt.x,
-          modelPt.y,
-          this.props.element.x,
-          this.props.element.y,
-          this.props.element.points,
-        );
+        segmentIndex = findClickedSegment(modelPt.x, modelPt.y, element.x, element.y, element.points);
       }
     }
 
-    this.props.onSelection(this.props.element, e, false, false, segmentIndex);
+    onSelection(element, e, false, false, segmentIndex);
   };
 
-  handleLabelSelection = (e: React.PointerEvent<SVGElement>): void => {
+  // Memoized: passed to the memo'd Label/Arrowhead below, so a stable identity
+  // (while element/onSelection are unchanged) lets them skip re-rendering.
+  const handleLabelSelection = React.useCallback(
+    (e: React.PointerEvent<SVGElement>): void => {
+      e.preventDefault();
+      e.stopPropagation();
+      onSelection(element, e, true);
+    },
+    [onSelection, element],
+  );
+
+  const handlePointerDownArrowhead = React.useCallback(
+    (e: React.PointerEvent<SVGElement>): void => {
+      e.preventDefault();
+      e.stopPropagation();
+      onSelection(element, e, false, true);
+    },
+    [onSelection, element],
+  );
+
+  const handlePointerDownSource = (e: React.PointerEvent<SVGElement>): void => {
     e.preventDefault();
     e.stopPropagation();
-    this.props.onSelection(this.props.element, e, true);
+    onSelection(element, e, false, false, undefined, true);
   };
 
-  handlePointerDownArrowhead = (e: React.PointerEvent<SVGElement>): void => {
-    e.preventDefault();
-    e.stopPropagation();
-    this.props.onSelection(this.props.element, e, false, true);
-  };
+  const isArrayed = element.var ? variableIsArrayed(element.var) : false;
+  const arrayedOffset = isArrayed ? 3 : 0;
 
-  handlePointerDownSource = (e: React.PointerEvent<SVGElement>): void => {
-    e.preventDefault();
-    e.stopPropagation();
-    this.props.onSelection(this.props.element, e, false, false, undefined, true);
-  };
-
-  radius(): number {
-    return AuxRadius;
+  let pts = element.points;
+  if (pts.length < 2) {
+    throw new Error('expected at least two points on a flow');
   }
 
-  indicators() {
-    if (!this.props.hasWarning) {
-      return undefined;
-    }
-
-    const { element } = this.props;
-    const r = this.radius();
-    const theta = -Math.PI / 4; // 45 degrees
-
-    const cx = element.x + r * Math.cos(theta);
-    const cy = element.y + r * Math.sin(theta);
-
-    return <circle className={styles.errorIndicator} cx={cx} cy={cy} r={3} />;
+  if (sink.type === 'cloud' && !isMovingArrow) {
+    pts = retractFinalPointIntoCloud(pts, CloudRadius);
   }
 
-  sparkline(series: Readonly<Array<Series>> | undefined) {
-    if (!series || series.length === 0) {
-      return undefined;
+  const finalAdjust = 7.5;
+  let spath = '';
+  let arrowTheta = 0;
+  for (let j = 0; j < pts.length; j++) {
+    let x = at(pts, j).x;
+    let y = at(pts, j).y;
+    if (j === pts.length - 1) {
+      // Walk back past coincident points: a degenerate (zero-length) final
+      // segment must not read as "pointing right" via atan2(0, 0) === 0.
+      const theta = finalSegmentAngle(pts);
+      if (theta === undefined) {
+        arrowTheta = 0;
+      } else if (theta >= 315 || theta < 45) {
+        x -= finalAdjust;
+        arrowTheta = 0;
+      } else if (theta >= 45 && theta < 135) {
+        y -= finalAdjust;
+        arrowTheta = 90;
+      } else if (theta >= 135 && theta < 225) {
+        x += finalAdjust;
+        arrowTheta = 180;
+      } else {
+        y += finalAdjust;
+        arrowTheta = 270;
+      }
     }
-    const { element } = this.props;
-    const isArrayed = element.var ? variableIsArrayed(element.var) : false;
-    const arrayedOffset = isArrayed ? 3 : 0;
-    const cx = element.x - arrayedOffset;
-    const cy = element.y - arrayedOffset;
-    const r = this.radius();
+    const prefix = j === 0 ? 'M' : 'L';
+    // Quantize flow path coordinates -- see `jsFormatNumber` in
+    // `render-common.tsx` for the cross-toolchain SVG parity invariant.
+    spath += `${prefix}${ff(x)},${ff(y)}`;
+  }
 
-    return (
-      <g transform={`translate(${ff(cx + 1 - r / 2)} ${ff(cy + 1 - r / 2)})`}>
+  const cx = element.x;
+  const cy = element.y;
+  const r = AuxRadius;
+
+  const lastPt = at(pts, pts.length - 1);
+  const side = element.labelSide;
+  const label = isEditingName ? undefined : (
+    <Label
+      uid={element.uid}
+      cx={cx}
+      cy={cy}
+      side={side}
+      rw={r + arrayedOffset}
+      rh={r + arrayedOffset}
+      text={displayName(defined(element.name))}
+      onSelection={handleLabelSelection}
+      onLabelDrag={onLabelDrag}
+    />
+  );
+
+  let sparkline;
+  if (series && series.length > 0) {
+    const sx = cx - arrayedOffset;
+    const sy = cy - arrayedOffset;
+    sparkline = (
+      <g transform={`translate(${ff(sx + 1 - r / 2)} ${ff(sy + 1 - r / 2)})`}>
         <Sparkline series={series} width={r - 2} height={r - 2} />
       </g>
     );
   }
 
-  render() {
-    const { element, isEditingName, isMovingArrow, isMovingSource, isSelected, isValidTarget, series, sink } =
-      this.props;
-
-    const isArrayed = element.var ? variableIsArrayed(element.var) : false;
-    const arrayedOffset = isArrayed ? 3 : 0;
-
-    let pts = this.props.element.points;
-    if (pts.length < 2) {
-      throw new Error('expected at least two points on a flow');
-    }
-
-    if (sink.type === 'cloud' && !isMovingArrow) {
-      pts = retractFinalPointIntoCloud(pts, CloudRadius);
-    }
-
-    const finalAdjust = 7.5;
-    let spath = '';
-    let arrowTheta = 0;
-    for (let j = 0; j < pts.length; j++) {
-      let x = at(pts, j).x;
-      let y = at(pts, j).y;
-      if (j === pts.length - 1) {
-        // Walk back past coincident points: a degenerate (zero-length) final
-        // segment must not read as "pointing right" via atan2(0, 0) === 0.
-        const theta = finalSegmentAngle(pts);
-        if (theta === undefined) {
-          arrowTheta = 0;
-        } else if (theta >= 315 || theta < 45) {
-          x -= finalAdjust;
-          arrowTheta = 0;
-        } else if (theta >= 45 && theta < 135) {
-          y -= finalAdjust;
-          arrowTheta = 90;
-        } else if (theta >= 135 && theta < 225) {
-          x += finalAdjust;
-          arrowTheta = 180;
-        } else {
-          y += finalAdjust;
-          arrowTheta = 270;
-        }
-      }
-      const prefix = j === 0 ? 'M' : 'L';
-      // Quantize flow path coordinates -- see `jsFormatNumber` in
-      // `render-common.tsx` for the cross-toolchain SVG parity invariant.
-      spath += `${prefix}${ff(x)},${ff(y)}`;
-    }
-
-    const cx = element.x;
-    const cy = element.y;
-    const r = this.radius();
-
-    const lastPt = at(pts, pts.length - 1);
-    const side = element.labelSide;
-    const label = isEditingName ? undefined : (
-      <Label
-        uid={element.uid}
-        cx={cx}
-        cy={cy}
-        side={side}
-        rw={r + arrayedOffset}
-        rh={r + arrayedOffset}
-        text={displayName(defined(element.name))}
-        onSelection={this.handleLabelSelection}
-        onLabelDrag={this.props.onLabelDrag}
-      />
-    );
-
-    const sparkline = this.sparkline(series);
-    const indicator = this.indicators();
-
-    const groupClassName = clsx(styles.flow, 'simlin-flow', {
-      [styles.selected]: isSelected && isValidTarget === undefined,
-      'simlin-selected': isSelected && isValidTarget === undefined,
-      [styles.targetGood]: isValidTarget === true,
-      [styles.targetBad]: isValidTarget === false,
-    });
-
-    let circles = [<circle key="1" cx={cx} cy={cy} r={r} />];
-    if (isArrayed) {
-      circles = [
-        <circle key="0" cx={cx + arrayedOffset} cy={cy + arrayedOffset} r={r} />,
-        <circle key="1" cx={cx} cy={cy} r={r} />,
-        <circle key="2" cx={cx - arrayedOffset} cy={cy - arrayedOffset} r={r} />,
-      ];
-    }
-
-    const outerClassName = isSelected
-      ? clsx(styles.outerSelected, 'simlin-outer-selected')
-      : clsx(styles.outer, 'simlin-outer');
-
-    // Invisible hit area at the source end for grabbing the source
-    // Position it slightly into the first segment from the source point
-    const firstPt = at(pts, 0);
-    const secondPt = at(pts, 1);
-    const sourceHitSize = 20;
-
-    // Calculate position along the first segment, offset from the source
-    let sourceHitX = firstPt.x;
-    let sourceHitY = firstPt.y;
-
-    // Move hit area slightly into the segment for better UX
-    const segDx = secondPt.x - firstPt.x;
-    const segDy = secondPt.y - firstPt.y;
-    const segLen = Math.hypot(segDx, segDy);
-    if (segLen > sourceHitSize) {
-      const offsetRatio = sourceHitSize / 2 / segLen;
-      sourceHitX = firstPt.x + segDx * offsetRatio;
-      sourceHitY = firstPt.y + segDy * offsetRatio;
-    }
-
-    // Only show the source hit area when not in embedded/export mode and not already moving the source
-    const sourceHitArea =
-      !this.props.embedded && !isMovingSource ? (
-        <rect
-          x={sourceHitX - sourceHitSize / 2}
-          y={sourceHitY - sourceHitSize / 2}
-          width={sourceHitSize}
-          height={sourceHitSize}
-          fill="transparent"
-          style={{ cursor: 'grab' }}
-          onPointerDown={this.handlePointerDownSource}
-        />
-      ) : null;
-
-    return (
-      <g className={groupClassName}>
-        <path
-          d={spath}
-          className={outerClassName}
-          onPointerDown={this.handlePointerDown}
-          onPointerUp={this.handlePointerUp}
-        />
-        {sourceHitArea}
-        <Arrowhead
-          point={lastPt}
-          angle={arrowTheta}
-          size={FlowArrowheadRadius}
-          type="flow"
-          isSelected={this.props.isSelected}
-          onSelection={this.handlePointerDownArrowhead}
-        />
-        <path d={spath} className={clsx(styles.inner, 'simlin-inner')} />
-        <g onPointerDown={this.handlePointerDown} onPointerUp={this.handlePointerUp}>
-          {circles}
-          {sparkline}
-        </g>
-        {indicator}
-        {label}
-      </g>
+  let indicator;
+  if (hasWarning) {
+    const theta = -Math.PI / 4; // 45 degrees
+    indicator = (
+      <circle className={styles.errorIndicator} cx={cx + r * Math.cos(theta)} cy={cy + r * Math.sin(theta)} r={3} />
     );
   }
-}
+
+  const groupClassName = clsx(styles.flow, 'simlin-flow', {
+    [styles.selected]: isSelected && isValidTarget === undefined,
+    'simlin-selected': isSelected && isValidTarget === undefined,
+    [styles.targetGood]: isValidTarget === true,
+    [styles.targetBad]: isValidTarget === false,
+  });
+
+  let circles = [<circle key="1" cx={cx} cy={cy} r={r} />];
+  if (isArrayed) {
+    circles = [
+      <circle key="0" cx={cx + arrayedOffset} cy={cy + arrayedOffset} r={r} />,
+      <circle key="1" cx={cx} cy={cy} r={r} />,
+      <circle key="2" cx={cx - arrayedOffset} cy={cy - arrayedOffset} r={r} />,
+    ];
+  }
+
+  const outerClassName = isSelected
+    ? clsx(styles.outerSelected, 'simlin-outer-selected')
+    : clsx(styles.outer, 'simlin-outer');
+
+  // Invisible hit area at the source end for grabbing the source
+  // Position it slightly into the first segment from the source point
+  const firstPt = at(pts, 0);
+  const secondPt = at(pts, 1);
+  const sourceHitSize = 20;
+
+  // Calculate position along the first segment, offset from the source
+  let sourceHitX = firstPt.x;
+  let sourceHitY = firstPt.y;
+
+  // Move hit area slightly into the segment for better UX
+  const segDx = secondPt.x - firstPt.x;
+  const segDy = secondPt.y - firstPt.y;
+  const segLen = Math.hypot(segDx, segDy);
+  if (segLen > sourceHitSize) {
+    const offsetRatio = sourceHitSize / 2 / segLen;
+    sourceHitX = firstPt.x + segDx * offsetRatio;
+    sourceHitY = firstPt.y + segDy * offsetRatio;
+  }
+
+  // Only show the source hit area when not in embedded/export mode and not already moving the source
+  const sourceHitArea =
+    !embedded && !isMovingSource ? (
+      <rect
+        x={sourceHitX - sourceHitSize / 2}
+        y={sourceHitY - sourceHitSize / 2}
+        width={sourceHitSize}
+        height={sourceHitSize}
+        fill="transparent"
+        style={{ cursor: 'grab' }}
+        onPointerDown={handlePointerDownSource}
+      />
+    ) : null;
+
+  return (
+    <g className={groupClassName}>
+      <path d={spath} className={outerClassName} onPointerDown={handlePointerDown} onPointerUp={handlePointerUp} />
+      {sourceHitArea}
+      <Arrowhead
+        point={lastPt}
+        angle={arrowTheta}
+        size={FlowArrowheadRadius}
+        type="flow"
+        isSelected={isSelected}
+        onSelection={handlePointerDownArrowhead}
+      />
+      <path d={spath} className={clsx(styles.inner, 'simlin-inner')} />
+      <g onPointerDown={handlePointerDown} onPointerUp={handlePointerUp}>
+        {circles}
+        {sparkline}
+      </g>
+      {indicator}
+      {label}
+    </g>
+  );
+});

--- a/src/diagram/drawing/Group.tsx
+++ b/src/diagram/drawing/Group.tsx
@@ -34,24 +34,22 @@ export function groupBounds(element: GroupViewElement): Rect {
   };
 }
 
-export class Group extends React.PureComponent<GroupProps> {
-  render() {
-    const { element, isSelected } = this.props;
-    const { x, y, width, height, name } = element;
+export const Group = React.memo(function Group(props: GroupProps): React.ReactElement {
+  const { element, isSelected } = props;
+  const { x, y, width, height, name } = element;
 
-    // x/y is the center, compute top-left for SVG rect
-    const left = x - width / 2;
-    const top = y - height / 2;
+  // x/y is the center, compute top-left for SVG rect
+  const left = x - width / 2;
+  const top = y - height / 2;
 
-    const className = isSelected ? `${styles.group} ${styles.selected}` : styles.group;
+  const className = isSelected ? `${styles.group} ${styles.selected}` : styles.group;
 
-    return (
-      <g className={`${className} simlin-group`}>
-        <rect x={left} y={top} width={width} height={height} rx={GroupRadius} ry={GroupRadius} />
-        <text x={left + LabelPadding} y={top + LabelPadding} dominantBaseline="hanging" className={styles.label}>
-          {displayName(name)}
-        </text>
-      </g>
-    );
-  }
-}
+  return (
+    <g className={`${className} simlin-group`}>
+      <rect x={left} y={top} width={width} height={height} rx={GroupRadius} ry={GroupRadius} />
+      <text x={left + LabelPadding} y={top + LabelPadding} dominantBaseline="hanging" className={styles.label}>
+        {displayName(name)}
+      </text>
+    </g>
+  );
+});

--- a/src/diagram/drawing/Label.tsx
+++ b/src/diagram/drawing/Label.tsx
@@ -143,83 +143,79 @@ interface LabelPropsFull extends CommonLabelProps {
 
 export type LabelProps = Pick<LabelPropsFull, 'text' | 'onSelection' | 'cx' | 'cy' | 'side' | 'rw' | 'rh'>;
 
-export class Label extends React.PureComponent<LabelPropsFull> {
-  pointerId: number | undefined;
-  inMove = false;
+export const Label = React.memo(function Label(props: LabelPropsFull): React.ReactElement {
+  const { uid, onSelection, onLabelDrag } = props;
 
-  constructor(props: LabelPropsFull) {
-    super(props);
+  // Transient pointer-gesture tracking: deliberately refs, not state -- a
+  // drag-in-progress must not trigger re-renders of the label itself.
+  const pointerId = React.useRef<number | undefined>(undefined);
+  const inMove = React.useRef(false);
 
-    this.state = {};
-  }
-
-  handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
+  const handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
     if (!e.isPrimary) {
       return;
     }
     e.preventDefault();
     e.stopPropagation();
 
-    this.pointerId = e.pointerId;
+    pointerId.current = e.pointerId;
   };
 
-  handlePointerMove = (e: React.PointerEvent<SVGElement>): void => {
-    if (this.pointerId !== e.pointerId) {
+  const handlePointerMove = (e: React.PointerEvent<SVGElement>): void => {
+    if (pointerId.current !== e.pointerId) {
       return;
     }
-    this.inMove = true;
+    inMove.current = true;
 
     (e.target as Element).setPointerCapture(e.pointerId);
-    this.props.onLabelDrag?.(this.props.uid, e);
+    onLabelDrag?.(uid, e);
   };
 
-  handlePointerUp = (e: React.PointerEvent<SVGElement>): void => {
-    if (this.pointerId !== e.pointerId) {
+  const handlePointerUp = (e: React.PointerEvent<SVGElement>): void => {
+    if (pointerId.current !== e.pointerId) {
       return;
     }
-    this.pointerId = undefined;
-    this.inMove = false;
+    pointerId.current = undefined;
+    inMove.current = false;
   };
 
-  handleDoubleClick = (e: React.MouseEvent<SVGElement>): void => {
-    if (!this.inMove) {
-      this.props.onSelection?.(e as unknown as React.PointerEvent<SVGElement>);
+  const handleDoubleClick = (e: React.MouseEvent<SVGElement>): void => {
+    if (!inMove.current) {
+      onSelection?.(e as unknown as React.PointerEvent<SVGElement>);
     }
   };
 
-  render() {
-    const { textX, textY, x, lines, reverseBaseline, align } = labelLayout(this.props);
-    const linesCount = lines.length;
+  const { textX, textY, x, lines, reverseBaseline, align } = labelLayout(props);
+  const linesCount = lines.length;
 
-    return (
-      <g>
-        <text
-          x={textX}
-          y={textY}
-          style={{ ...textStyle, textAnchor: align, filter: 'url(#labelBackground)' }}
-          onPointerDown={this.handlePointerDown}
-          onPointerMove={this.handlePointerMove}
-          onPointerUp={this.handlePointerUp}
-          onDoubleClick={this.handleDoubleClick}
-          textRendering="optimizeLegibility"
-        >
-          {lines.map((l, i) => {
-            let dy: string = i === 0 ? '1em' : `${lineSpacing}px`;
-            if (reverseBaseline && i === 0) {
-              dy = `${-(lineSpacing * (linesCount - 1))}px`;
-            }
-            return (
-              // Keyed by index, not line text: repeated lines (e.g. a label
-              // edited to "x\nx") would otherwise produce duplicate keys.
-              // Index keys are safe here -- a flat, fully-rebuilt list with
-              // no per-line state.
-              <tspan key={i} x={x} dy={dy}>
-                {l}
-              </tspan>
-            );
-          })}
-        </text>
-      </g>
-    );
-  }
-}
+  return (
+    <g>
+      <text
+        x={textX}
+        y={textY}
+        style={{ ...textStyle, textAnchor: align, filter: 'url(#labelBackground)' }}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onDoubleClick={handleDoubleClick}
+        textRendering="optimizeLegibility"
+      >
+        {lines.map((l, i) => {
+          let dy: string = i === 0 ? '1em' : `${lineSpacing}px`;
+          if (reverseBaseline && i === 0) {
+            dy = `${-(lineSpacing * (linesCount - 1))}px`;
+          }
+          return (
+            // Keyed by index, not line text: repeated lines (e.g. a label
+            // edited to "x\nx") would otherwise produce duplicate keys.
+            // Index keys are safe here -- a flat, fully-rebuilt list with
+            // no per-line state.
+            <tspan key={i} x={x} dy={dy}>
+              {l}
+            </tspan>
+          );
+        })}
+      </text>
+    </g>
+  );
+});

--- a/src/diagram/drawing/Module.tsx
+++ b/src/diagram/drawing/Module.tsx
@@ -60,86 +60,80 @@ export function moduleBounds(element: ModuleViewElement): Rect {
   return mergeBounds(bounds, labelBounds(labelProps));
 }
 
-export class Module extends React.PureComponent<ModuleProps> {
-  handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
+export const Module = React.memo(function Module(props: ModuleProps): React.ReactElement {
+  const { element, isEditingName, isSelected, isValidTarget, hasWarning, onSelection, onLabelDrag, onDoubleClick } =
+    props;
+
+  const handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
     e.preventDefault();
     e.stopPropagation();
-    this.props.onSelection(this.props.element, e);
+    onSelection(element, e);
   };
 
-  handleLabelSelection = (e: React.PointerEvent<SVGElement>): void => {
-    e.preventDefault();
-    e.stopPropagation();
-    this.props.onSelection(this.props.element, e, true);
-  };
+  // Memoized: passed to the memo'd Label below, so a stable identity (while
+  // element/onSelection are unchanged) lets Label skip re-rendering.
+  const handleLabelSelection = React.useCallback(
+    (e: React.PointerEvent<SVGElement>): void => {
+      e.preventDefault();
+      e.stopPropagation();
+      onSelection(element, e, true);
+    },
+    [onSelection, element],
+  );
 
-  handleDoubleClick = (e: React.MouseEvent<SVGElement>): void => {
+  const handleDoubleClick = (e: React.MouseEvent<SVGElement>): void => {
     e.preventDefault();
     e.stopPropagation();
-    if (this.props.onDoubleClick) {
-      this.props.onDoubleClick(this.props.element);
+    if (onDoubleClick) {
+      onDoubleClick(element);
     }
   };
 
-  indicators() {
-    if (!this.props.hasWarning) {
-      return undefined;
-    }
+  const w = ModuleWidth;
+  const h = ModuleHeight;
+  const cx = element.x;
+  const cy = element.y;
+  const side = element.labelSide;
 
-    const { element } = this.props;
-    const w = ModuleWidth;
-    const h = ModuleHeight;
-    const cx = element.x + w / 2 - 1;
-    const cy = element.y - h / 2 + 1;
+  const label = isEditingName ? undefined : (
+    <Label
+      uid={element.uid}
+      cx={cx}
+      cy={cy}
+      side={side}
+      text={displayName(defined(element.name))}
+      rw={w / 2}
+      rh={h / 2}
+      onSelection={handleLabelSelection}
+      onLabelDrag={onLabelDrag}
+    />
+  );
 
-    return <circle className={styles.errorIndicator} cx={cx} cy={cy} r={3} />;
+  let indicator;
+  if (hasWarning) {
+    indicator = <circle className={styles.errorIndicator} cx={cx + w / 2 - 1} cy={cy - h / 2 + 1} r={3} />;
   }
 
-  render() {
-    const { element, isEditingName, isSelected, isValidTarget } = this.props;
-    const w = ModuleWidth;
-    const h = ModuleHeight;
-    const cx = element.x;
-    const cy = element.y;
-    const side = element.labelSide;
+  const groupClassName = clsx(styles.module, 'simlin-module', {
+    [styles.selected]: isSelected && isValidTarget === undefined,
+    'simlin-selected': isSelected && isValidTarget === undefined,
+    [styles.targetGood]: isValidTarget === true,
+    [styles.targetBad]: isValidTarget === false,
+  });
 
-    const label = isEditingName ? undefined : (
-      <Label
-        uid={element.uid}
-        cx={cx}
-        cy={cy}
-        side={side}
-        text={displayName(defined(element.name))}
-        rw={w / 2}
-        rh={h / 2}
-        onSelection={this.handleLabelSelection}
-        onLabelDrag={this.props.onLabelDrag}
+  return (
+    <g className={groupClassName} onPointerDown={handlePointerDown}>
+      <rect
+        x={Math.ceil(cx - w / 2)}
+        y={Math.ceil(cy - h / 2)}
+        width={w}
+        height={h}
+        rx={ModuleRadius}
+        ry={ModuleRadius}
+        onDoubleClick={handleDoubleClick}
       />
-    );
-
-    const indicator = this.indicators();
-
-    const groupClassName = clsx(styles.module, 'simlin-module', {
-      [styles.selected]: isSelected && isValidTarget === undefined,
-      'simlin-selected': isSelected && isValidTarget === undefined,
-      [styles.targetGood]: isValidTarget === true,
-      [styles.targetBad]: isValidTarget === false,
-    });
-
-    return (
-      <g className={groupClassName} onPointerDown={this.handlePointerDown}>
-        <rect
-          x={Math.ceil(cx - w / 2)}
-          y={Math.ceil(cy - h / 2)}
-          width={w}
-          height={h}
-          rx={ModuleRadius}
-          ry={ModuleRadius}
-          onDoubleClick={this.handleDoubleClick}
-        />
-        {indicator}
-        {label}
-      </g>
-    );
-  }
-}
+      {indicator}
+      {label}
+    </g>
+  );
+});

--- a/src/diagram/drawing/Sparkline.tsx
+++ b/src/diagram/drawing/Sparkline.tsx
@@ -50,18 +50,19 @@ export interface SparklineProps {
   height: number;
 }
 
-export class Sparkline extends React.PureComponent<SparklineProps> {
-  // these should all be 'private', but Typescript can't enforce that with the `styled` above
-  pAxis = '';
-  sparklines: Array<React.ReactNode> = [];
-  cachedSeries: Readonly<Array<Series>> | unknown;
+export const Sparkline = React.memo(function Sparkline(props: SparklineProps): React.ReactElement {
+  const { series, width, height } = props;
 
-  recache() {
-    const time = defined(this.props.series[0]).time;
+  // Path construction walks every data point of every series, so memoize it;
+  // this replaces the hand-rolled `recache()`/`cachedSeries` instance-field
+  // cache the class component used (which only keyed off series identity --
+  // keying off width/height too is strictly more correct).
+  const { pAxis, sparklines } = React.useMemo(() => {
+    const time = defined(series[0]).time;
     const x = 0;
     const y = 0;
-    const w = this.props.width;
-    const h = this.props.height;
+    const w = width;
+    const h = height;
 
     const xMin = time[0];
     const xMax = last(time);
@@ -70,7 +71,7 @@ export class Sparkline extends React.PureComponent<SparklineProps> {
     let yMin = 0;
     let yMax = -Infinity;
     // first build up the min + max across all datasets
-    for (const dataset of this.props.series) {
+    for (const dataset of series) {
       const values = dataset.values;
       yMin = Math.min(yMin, min(values)); // 0 or below 0
       yMax = Math.max(yMax, max(values));
@@ -78,45 +79,36 @@ export class Sparkline extends React.PureComponent<SparklineProps> {
     const ySpan = yMax - yMin || 1;
 
     const colors = Dark2;
-    const sparklines = [];
+    const lines = [];
     let i = 0;
-    for (const dataset of this.props.series) {
+    for (const dataset of series) {
       const values = dataset.values;
       let p = '';
-      for (let i = 0; i < values.length; i++) {
-        if (isNaN(values[i])) {
-          // console.log(`NaN at ${time[i]}`);
+      for (let j = 0; j < values.length; j++) {
+        if (isNaN(values[j])) {
+          // console.log(`NaN at ${time[j]}`);
           continue;
         }
-        const prefix = i === 0 ? 'M' : 'L';
+        const prefix = j === 0 ? 'M' : 'L';
         // Quantize sparkline path coordinates for cross-toolchain SVG parity;
         // see `jsFormatNumber` in `render-common.tsx`.
-        p += `${prefix}${f(x + (w * (time[i] - xMin)) / xSpan)},${f(y + h - (h * (values[i] - yMin)) / ySpan)}`;
+        p += `${prefix}${f(x + (w * (time[j] - xMin)) / xSpan)},${f(y + h - (h * (values[j] - yMin)) / ySpan)}`;
       }
-      const style = this.props.series.length === 1 ? undefined : { stroke: colors[i % colors.length] };
-      sparklines.push(
+      const style = series.length === 1 ? undefined : { stroke: colors[i % colors.length] };
+      lines.push(
         <path key={dataset.name} d={p} className={`${styles.sparkline} simlin-sparkline-line`} style={style} />,
       );
       i++;
     }
 
-    this.pAxis = `M${f(x)},${f(y + h - (h * (0 - yMin)) / ySpan)}L${f(x + w)},${f(y + h - (h * (0 - yMin)) / ySpan)}`;
-    this.sparklines = sparklines;
-    this.cachedSeries = this.props.series;
-  }
+    const axis = `M${f(x)},${f(y + h - (h * (0 - yMin)) / ySpan)}L${f(x + w)},${f(y + h - (h * (0 - yMin)) / ySpan)}`;
+    return { pAxis: axis, sparklines: lines };
+  }, [series, width, height]);
 
-  render() {
-    if (this.props.series !== this.cachedSeries) {
-      this.recache();
-    }
-
-    return (
-      <g>
-        <>
-          <path key="$axis" d={this.pAxis} className={`${styles.axis} simlin-sparkline-axis`} />
-          {this.sparklines}
-        </>
-      </g>
-    );
-  }
-}
+  return (
+    <g>
+      <path key="$axis" d={pAxis} className={`${styles.axis} simlin-sparkline-axis`} />
+      {sparklines}
+    </g>
+  );
+});

--- a/src/diagram/drawing/Stock.tsx
+++ b/src/diagram/drawing/Stock.tsx
@@ -66,114 +66,95 @@ export function stockBounds(element: StockViewElement): Rect {
   return mergeBounds(bounds, labelBounds(labelProps));
 }
 
-export class Stock extends React.PureComponent<StockProps> {
-  handlePointerUp = (_e: React.PointerEvent<SVGElement>): void => {
+export const Stock = React.memo(function Stock(props: StockProps): React.ReactElement {
+  const { element, isEditingName, isSelected, isValidTarget, hasWarning, series, onSelection, onLabelDrag } = props;
+
+  const handlePointerUp = (_e: React.PointerEvent<SVGElement>): void => {
     // e.preventDefault();
     // e.stopPropagation();
   };
 
-  handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
+  const handlePointerDown = (e: React.PointerEvent<SVGElement>): void => {
     e.preventDefault();
     e.stopPropagation();
-    this.props.onSelection(this.props.element, e);
+    onSelection(element, e);
   };
 
-  handleLabelSelection = (e: React.PointerEvent<SVGElement>): void => {
-    e.preventDefault();
-    e.stopPropagation();
-    this.props.onSelection(this.props.element, e, true);
-  };
+  // Memoized: passed to the memo'd Label below, so a stable identity (while
+  // element/onSelection are unchanged) lets Label skip re-rendering.
+  const handleLabelSelection = React.useCallback(
+    (e: React.PointerEvent<SVGElement>): void => {
+      e.preventDefault();
+      e.stopPropagation();
+      onSelection(element, e, true);
+    },
+    [onSelection, element],
+  );
 
-  indicators() {
-    if (!this.props.hasWarning) {
-      return undefined;
-    }
+  const w = StockWidth;
+  const h = StockHeight;
+  const cx = element.x;
+  const cy = element.y;
 
-    const { element } = this.props;
-    const w = StockWidth;
-    const h = StockHeight;
+  const isArrayed = (element.var && variableIsArrayed(element.var)) || false;
+  const arrayedOffset = isArrayed ? 3 : 0;
 
-    const cx = element.x + w / 2 - 1;
-    const cy = element.y - h / 2 + 1;
+  const side = element.labelSide;
+  const label = isEditingName ? undefined : (
+    <Label
+      uid={element.uid}
+      cx={cx}
+      cy={cy}
+      side={side}
+      rw={w / 2 + arrayedOffset}
+      rh={h / 2 + arrayedOffset}
+      text={displayName(defined(element.name))}
+      onSelection={handleLabelSelection}
+      onLabelDrag={onLabelDrag}
+    />
+  );
 
-    return <circle className={styles.errorIndicator} cx={cx} cy={cy} r={3} />;
-  }
-
-  sparkline(series: Readonly<Array<Series>> | undefined) {
-    if (!series || series.length === 0) {
-      return undefined;
-    }
-    const { element } = this.props;
-    const isArrayed = (element.var && variableIsArrayed(element.var)) || false;
-    const arrayedOffset = isArrayed ? 3 : 0;
-    const cx = element.x - arrayedOffset;
-    const cy = element.y - arrayedOffset;
-    const w = StockWidth;
-    const h = StockHeight;
-
-    return (
-      <g transform={`translate(${f(cx + 1 - w / 2)} ${f(cy + 1 - h / 2)})`}>
+  let sparkline;
+  if (series && series.length > 0) {
+    const sx = cx - arrayedOffset;
+    const sy = cy - arrayedOffset;
+    sparkline = (
+      <g transform={`translate(${f(sx + 1 - w / 2)} ${f(sy + 1 - h / 2)})`}>
         <Sparkline series={series} width={w - 2} height={h - 2} />
       </g>
     );
   }
 
-  render() {
-    const { element, isEditingName, isSelected, isValidTarget } = this.props;
-    const w = StockWidth;
-    const h = StockHeight;
-    const cx = element.x;
-    const cy = element.y;
-
-    const series = this.props.series;
-
-    const isArrayed = (element.var && variableIsArrayed(element.var)) || false;
-    const arrayedOffset = isArrayed ? 3 : 0;
-
-    const side = element.labelSide;
-    const label = isEditingName ? undefined : (
-      <Label
-        uid={element.uid}
-        cx={cx}
-        cy={cy}
-        side={side}
-        rw={w / 2 + arrayedOffset}
-        rh={h / 2 + arrayedOffset}
-        text={displayName(defined(element.name))}
-        onSelection={this.handleLabelSelection}
-        onLabelDrag={this.props.onLabelDrag}
-      />
-    );
-
-    const sparkline = this.sparkline(series);
-    const indicator = this.indicators();
-
-    const groupClassName = clsx(styles.stock, 'simlin-stock', {
-      [styles.selected]: isSelected && isValidTarget === undefined,
-      'simlin-selected': isSelected && isValidTarget === undefined,
-      [styles.targetGood]: isValidTarget === true,
-      [styles.targetBad]: isValidTarget === false,
-    });
-
-    const x = cx - w / 2;
-    const y = cy - h / 2;
-
-    let rects = [<rect key="1" x={x} y={y} width={w} height={h} />];
-    if (isArrayed) {
-      rects = [
-        <rect key="0" x={x + arrayedOffset} y={y + arrayedOffset} width={w} height={h} />,
-        <rect key="1" x={x} y={y} width={w} height={h} />,
-        <rect key="2" x={x - arrayedOffset} y={y - arrayedOffset} width={w} height={h} />,
-      ];
-    }
-
-    return (
-      <g className={groupClassName} onPointerDown={this.handlePointerDown} onPointerUp={this.handlePointerUp}>
-        {rects}
-        {sparkline}
-        {indicator}
-        {label}
-      </g>
-    );
+  let indicator;
+  if (hasWarning) {
+    indicator = <circle className={styles.errorIndicator} cx={cx + w / 2 - 1} cy={cy - h / 2 + 1} r={3} />;
   }
-}
+
+  const groupClassName = clsx(styles.stock, 'simlin-stock', {
+    [styles.selected]: isSelected && isValidTarget === undefined,
+    'simlin-selected': isSelected && isValidTarget === undefined,
+    [styles.targetGood]: isValidTarget === true,
+    [styles.targetBad]: isValidTarget === false,
+  });
+
+  const x = cx - w / 2;
+  const y = cy - h / 2;
+
+  let rects = [<rect key="1" x={x} y={y} width={w} height={h} />];
+  if (isArrayed) {
+    rects = [
+      <rect key="0" x={x + arrayedOffset} y={y + arrayedOffset} width={w} height={h} />,
+      <rect key="1" x={x} y={y} width={w} height={h} />,
+      <rect key="2" x={x - arrayedOffset} y={y - arrayedOffset} width={w} height={h} />,
+    ];
+  }
+
+  return (
+    <g className={groupClassName} onPointerDown={handlePointerDown} onPointerUp={handlePointerUp}>
+      {rects}
+      {sparkline}
+      {indicator}
+      {label}
+    </g>
+  );
+});

--- a/src/diagram/tests/connector-routing.test.ts
+++ b/src/diagram/tests/connector-routing.test.ts
@@ -13,17 +13,18 @@ import {
 } from '@simlin/core/datamodel';
 
 import {
-  Connector,
   circleFromPoints,
   getVisualCenter,
   intersectElementArc,
+  intersectElementStraight,
+  isStraightLine,
   rayRectIntersection,
   circleRectIntersections,
   ArrayedOffset,
   takeoffθ,
   computeLinkCreationArc,
 } from '../drawing/Connector';
-import { AuxRadius, StockWidth, StockHeight, StraightLineMax } from '../drawing/default';
+import { AuxRadius, StockWidth, StockHeight } from '../drawing/default';
 import { square, Circle, Point } from '../drawing/common';
 
 function makeAux(uid: number, x: number, y: number, isArrayed: boolean = false): AuxViewElement {
@@ -210,7 +211,7 @@ describe('Connector routing', () => {
         };
 
         // Verify isStraightLine is true for straight links
-        expect(Connector.isStraightLine(props)).toBe(true);
+        expect(isStraightLine(props)).toBe(true);
 
         // The intersection point for aux should be at (100 + AuxRadius, 100)
         // since we're going right (theta = 0)
@@ -270,7 +271,7 @@ describe('Connector routing', () => {
           onSelection: () => {},
         };
 
-        expect(Connector.isStraightLine(props)).toBe(true);
+        expect(isStraightLine(props)).toBe(true);
       });
 
       it('should adjust center for arrayed stock', () => {
@@ -550,7 +551,7 @@ describe('Connector routing', () => {
     it('should hit left edge when approaching from the left', () => {
       const stock = makeStock(2, 200, 100);
       const theta = Math.PI; // approaching from left means connector angle is PI
-      const p = Connector.intersectElementStraight(stock, theta);
+      const p = intersectElementStraight(stock, theta);
       expect(p.x).toBeCloseTo(200 - StockWidth / 2);
       expect(p.y).toBeCloseTo(100);
     });
@@ -558,7 +559,7 @@ describe('Connector routing', () => {
     it('should hit top edge when approaching from above', () => {
       const stock = makeStock(2, 200, 200);
       const theta = Math.PI / 2; // approaching from above
-      const p = Connector.intersectElementStraight(stock, theta);
+      const p = intersectElementStraight(stock, theta);
       expect(p.x).toBeCloseTo(200);
       expect(p.y).toBeCloseTo(200 + StockHeight / 2);
     });
@@ -566,7 +567,7 @@ describe('Connector routing', () => {
     it('should not change behavior for auxiliaries', () => {
       const aux = makeAux(1, 200, 100);
       const theta = 0;
-      const p = Connector.intersectElementStraight(aux, theta);
+      const p = intersectElementStraight(aux, theta);
       expect(p.x).toBeCloseTo(200 + AuxRadius);
       expect(p.y).toBeCloseTo(100);
     });
@@ -681,7 +682,7 @@ describe('Connector routing', () => {
         to,
         onSelection: () => {},
       };
-      expect(Connector.isStraightLine(props)).toBe(true);
+      expect(isStraightLine(props)).toBe(true);
     });
 
     it('should return true when arcPoint is collinear with from and to', () => {
@@ -696,7 +697,7 @@ describe('Connector routing', () => {
         onSelection: () => {},
         arcPoint: { x: 200, y: 100 },
       };
-      expect(Connector.isStraightLine(props)).toBe(true);
+      expect(isStraightLine(props)).toBe(true);
     });
 
     it('should return false when arcPoint is far from the line', () => {
@@ -711,7 +712,7 @@ describe('Connector routing', () => {
         onSelection: () => {},
         arcPoint: { x: 200, y: 0 },
       };
-      expect(Connector.isStraightLine(props)).toBe(false);
+      expect(isStraightLine(props)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Summary

Converts the twelve `React.PureComponent` classes under `src/diagram/drawing/` (everything except Canvas) to memo'd function components, continuing the front-end cleanup after #721. The intent is zero behavior change; the byte-identical Rust-vs-TS SVG parity test (`tests/svg-rendering.test.ts`) plus the existing geometry suites are the regression net.

Highlights:

- **Trivial leaves** (Arrowhead, Group, Cloud, Alias, Aux, Stock, Module, Flow, Connector): mechanical conversion. Handlers passed to memo'd children (Label, Arrowhead) are wrapped in `useCallback` so `React.memo` actually holds during drags; handlers attached only to DOM elements stay plain closures.
- **Sparkline**: the hand-rolled `recache()`/`cachedSeries` instance-field cache becomes a `useMemo` (now correctly keyed on width/height too, fixing a latent staleness bug).
- **Label**: transient pointer-gesture fields (`pointerId`/`inMove`) become refs — deliberately not state, so a drag never re-renders the label.
- **EditableLabel**: the constructor-created Slate editor becomes a `useState` lazy initializer; Canvas mounts it per edit session, so init-once-per-mount semantics are preserved.
- **Connector**: static methods move to module-level functions (`isStraightLine`, `intersectElementStraight`, `connectorBounds`), matching how the rest of the file's geometry already lives; tests import them directly.
- **docs/dev/typescript.md**: now prefers function components, replacing the stale class-components-by-default guidance.

**Canvas stays a class on purpose**: its hooks migration is sequenced after the `canvas-interaction.ts` state migration (gated on e2e gesture tests, tech-debt #65) to avoid migrating it twice.

## Test plan

- Full pre-commit suite (Rust fmt/clippy/tests, TS lint/build/tsc/tests, WASM build, pysimlin) passes.
- `@simlin/diagram`: 72 suites / 1023 tests green, including the five-model byte-identical SVG parity test that exercises every converted component through `renderToString`.
- Two independent adversarial review passes (hunk-by-hunk diff audit, handler-identity/pointer-capture analysis, StrictMode double-invoke check) found no material issues.