### PR TITLE
build: switch CI coverage from tarpaulin ptrace to cargo-llvm-cov

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -122,32 +122,46 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
             target/
-          key: cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          key: cargo-llvm-cov-${{ hashFiles('**/Cargo.lock') }}
           restore-keys: |
-            cargo-coverage-
+            cargo-llvm-cov-
 
-      - name: Install cargo-tarpaulin
+      - name: Install cargo-llvm-cov
         uses: taiki-e/install-action@v2
         with:
-          tool: cargo-tarpaulin
+          tool: cargo-llvm-cov
 
-      # 90-minute outer cap on tarpaulin. Baseline pre-simlin-serve was
-      # ~23 min; the simlin-serve test suite (filesystem watcher with
-      # real debounce waits, MCP duplex pairs, end-to-end save/HTTP
-      # round-trips) tipped the wall-clock past the original 45-minute
-      # cap, so the whole job timed out without producing coverage XML.
-      # Tarpaulin still self-polices per-test at 60s, so this outer cap
-      # is a backstop against a runaway test rather than the primary
-      # budget. If runtime keeps growing, the next move is `--engine
-      # llvm` for source-based coverage at native test speed.
-      - name: Run cargo-tarpaulin
-        timeout-minutes: 90
-        run: cargo tarpaulin --out Xml
+      # cargo-llvm-cov needs the llvm-tools component for the pinned
+      # toolchain. It is deliberately NOT in rust-toolchain.toml: every
+      # other job (and every developer `rustup show`) would pay the
+      # download for a component only this job uses.
+      - name: Install llvm-tools
+        run: rustup component add llvm-tools
+
+      # Source-based LLVM coverage replaced cargo-tarpaulin's default
+      # ptrace engine (GH #622, #726): ptrace instrumentation ran the
+      # suite 5-50x slower than native, first blowing a 90-minute cap
+      # and later violating timing assumptions in libsimlin's
+      # concurrency tests. llvm-cov instrumentation runs tests at
+      # near-native speed (native `cargo test --workspace` is ~60s
+      # post-compile), so this cap is a generous backstop dominated by
+      # the instrumented build: a warm-cache run fits comfortably in
+      # 30 minutes, and the headroom above that absorbs the cold-cache
+      # case (first run after a Cargo.lock change or cache eviction
+      # rebuilds the whole instrumented workspace from scratch). Note
+      # that unlike tarpaulin, llvm-cov has no per-test 60s
+      # self-policing -- a runaway test eats the whole cap, and the
+      # Build job's 3-minute test cap is the primary guard against
+      # that.
+      - name: Run cargo-llvm-cov
+        timeout-minutes: 45
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
 
       - name: Upload Coverage
         uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          files: lcov.info
 
   frontend:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -63,7 +63,7 @@ yarn-error.log*
 
 /test/*.js
 
-/tarpaulin*
+/lcov.info
 
 /website/.docusaurus
 /website/.cache-loader

--- a/src/libsimlin/src/patch.rs
+++ b/src/libsimlin/src/patch.rs
@@ -38,6 +38,19 @@ static PATCH_TEST_HOOK_LOCK: std::sync::LazyLock<std::sync::Mutex<()>> =
 static PATCH_TEST_HOOK: std::sync::LazyLock<std::sync::Mutex<Option<PatchTestHook>>> =
     std::sync::LazyLock::new(|| std::sync::Mutex::new(None));
 
+/// Lock one of the hook mutexes, recovering from poisoning. A test that
+/// panics while holding `PatchTestHookGuard` poisons these mutexes; the
+/// guard's `Drop` always resets the hook to `None`, so the protected state
+/// is consistent even after a panic and recovery is sound. Without this,
+/// one genuine test failure cascades into spurious `PoisonError` panics in
+/// every other hook-based test (GH #726).
+#[cfg(test)]
+fn lock_unpoisoned<T>(mutex: &std::sync::Mutex<T>) -> std::sync::MutexGuard<'_, T> {
+    mutex
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
 #[cfg(test)]
 pub(crate) struct PatchTestHookGuard {
     _lock: std::sync::MutexGuard<'static, ()>,
@@ -46,20 +59,20 @@ pub(crate) struct PatchTestHookGuard {
 #[cfg(test)]
 impl Drop for PatchTestHookGuard {
     fn drop(&mut self) {
-        *PATCH_TEST_HOOK.lock().unwrap() = None;
+        *lock_unpoisoned(&PATCH_TEST_HOOK) = None;
     }
 }
 
 #[cfg(test)]
 pub(crate) fn install_patch_test_hook(hook: PatchTestHook) -> PatchTestHookGuard {
-    let lock = PATCH_TEST_HOOK_LOCK.lock().unwrap();
-    *PATCH_TEST_HOOK.lock().unwrap() = Some(hook);
+    let lock = lock_unpoisoned(&PATCH_TEST_HOOK_LOCK);
+    *lock_unpoisoned(&PATCH_TEST_HOOK) = Some(hook);
     PatchTestHookGuard { _lock: lock }
 }
 
 #[cfg(test)]
 fn invoke_patch_test_hook(point: PatchHookPoint, project_ref: &SimlinProject) {
-    let hook = PATCH_TEST_HOOK.lock().unwrap().clone();
+    let hook = lock_unpoisoned(&PATCH_TEST_HOOK).clone();
     if let Some(hook) = hook {
         hook(point, project_ref);
     }

--- a/src/libsimlin/src/tests_concurrency.rs
+++ b/src/libsimlin/src/tests_concurrency.rs
@@ -3,6 +3,16 @@
 // Version 2.0, that can be found in the LICENSE file.
 
 // ── concurrency regression tests ────────────────────────────────────────
+//
+// Timeout policy: positive waits ("the other thread SHOULD get here") use
+// POSITIVE_WAIT, generous because `recv_timeout` returns as soon as the
+// message arrives -- the budget is only consumed on genuine failure, and a
+// tight budget false-fails under coverage instrumentation or CI load
+// (GH #726). Negative waits ("the other thread should NOT have completed
+// yet") stay short: slowness can only make them pass, never fail, and they
+// are paid in full on every run.
+
+const POSITIVE_WAIT: std::time::Duration = std::time::Duration::from_secs(30);
 
 /// Regression test for issue #303: concurrent add_model + sim_new should never
 /// produce a spurious NotSimulatable error caused by sync_state being temporarily
@@ -98,6 +108,28 @@ fn test_concurrent_add_model_and_sim_new_no_spurious_not_simulatable() {
     }
 }
 
+/// A test that panics while holding the patch-test-hook guard (e.g. a timing
+/// assertion blown by coverage instrumentation slowdown, GH #726) poisons the
+/// hook mutexes. Subsequent hook installs must recover instead of cascading
+/// that one failure into spurious panics in every other hook-based test.
+#[test]
+fn test_patch_hook_survives_poisoning_panic() {
+    use crate::patch::install_patch_test_hook;
+    use std::sync::Arc;
+    use std::thread;
+
+    let result = thread::spawn(|| {
+        let _guard = install_patch_test_hook(Arc::new(|_, _| {}));
+        panic!("intentional panic while holding the patch test hook guard");
+    })
+    .join();
+    assert!(result.is_err(), "spawned thread should have panicked");
+
+    // Without poison recovery this second install panics on the poisoned
+    // lock; with it, hook-based tests keep working after an earlier failure.
+    let _guard = install_patch_test_hook(Arc::new(|_, _| {}));
+}
+
 /// Regression test for issue #296: warning baseline and datamodel snapshot
 /// must be captured under one project lock scope so competing patches cannot
 /// interleave between those reads.
@@ -186,7 +218,7 @@ fn test_issue_296_snapshot_lock_blocks_competing_patch() {
     });
 
     hook_enter_rx
-        .recv_timeout(Duration::from_secs(2))
+        .recv_timeout(POSITIVE_WAIT)
         .expect("issue #296 hook should have been reached");
 
     let (writer_b_done_tx, writer_b_done_rx) = mpsc::channel::<()>();
@@ -224,7 +256,7 @@ fn test_issue_296_snapshot_lock_blocks_competing_patch() {
     release.store(true, Ordering::Release);
 
     writer_b_done_rx
-        .recv_timeout(Duration::from_secs(2))
+        .recv_timeout(POSITIVE_WAIT)
         .expect("writer B should complete after writer A releases the snapshot lock");
     writer_a.join().expect("writer A should not panic");
     writer_b.join().expect("writer B should not panic");
@@ -326,7 +358,7 @@ fn test_issue_297_patch_staging_keeps_sync_state_present() {
     });
 
     hook_enter_rx
-        .recv_timeout(Duration::from_secs(2))
+        .recv_timeout(POSITIVE_WAIT)
         .expect("issue #297 hook should have been reached during staging");
 
     // Reader races the staging patch: it must block on the db lock until the
@@ -353,7 +385,7 @@ fn test_issue_297_patch_staging_keeps_sync_state_present() {
     release.store(true, Ordering::Release);
 
     let observed_some = reader_done_rx
-        .recv_timeout(Duration::from_secs(2))
+        .recv_timeout(POSITIVE_WAIT)
         .expect("reader should complete after the patch decision releases the lock");
     assert!(
         observed_some,
@@ -442,7 +474,7 @@ fn test_issue_298_sim_new_blocks_until_patch_decision() {
     });
 
     hook_enter_rx
-        .recv_timeout(Duration::from_secs(2))
+        .recv_timeout(POSITIVE_WAIT)
         .expect("issue #298 hook should have been reached");
 
     let (reader_result_tx, reader_result_rx) = mpsc::channel::<f64>();
@@ -483,7 +515,7 @@ fn test_issue_298_sim_new_blocks_until_patch_decision() {
     release.store(true, Ordering::Release);
 
     let alpha_value = reader_result_rx
-        .recv_timeout(Duration::from_secs(2))
+        .recv_timeout(POSITIVE_WAIT)
         .expect("reader should complete after patch decision");
     assert!(
         (alpha_value - 100.0).abs() < 1e-10,
@@ -580,7 +612,7 @@ fn test_concurrent_patches_no_lost_update() {
 
     // Wait for Thread A to enter validation (holding db lock).
     hook_enter_rx
-        .recv_timeout(Duration::from_secs(5))
+        .recv_timeout(POSITIVE_WAIT)
         .expect("Thread A should reach the hook");
 
     // Thread B: patch b → 20. With the fix, this blocks on the
@@ -633,7 +665,7 @@ fn test_concurrent_patches_no_lost_update() {
     // Both threads should complete.
     thread_a.join().expect("Thread A should not panic");
     b_done_rx
-        .recv_timeout(Duration::from_secs(5))
+        .recv_timeout(POSITIVE_WAIT)
         .expect("Thread B should complete after Thread A releases");
     thread_b.join().expect("Thread B should not panic");
 


### PR DESCRIPTION
## Problem

The Code Coverage CI job has been dead on `main` through two failure modes, both rooted in cargo-tarpaulin's ptrace engine running tests 5-50x slower than native:

- #622: the instrumented suite blew the job's 90-minute cap, producing no coverage XML.
- #726: more recently, the ptrace slowdown violated the 2-second `recv_timeout` budgets in libsimlin's concurrency tests. `test_issue_297_patch_staging_keeps_sync_state_present` panicked at the timing assertion while holding `PATCH_TEST_HOOK_LOCK`, poisoning it -- the other three concurrency tests then cascade-failed at `patch.rs:55` on `.lock().unwrap()` of the poisoned mutex. Three of the four CI failures were pure collateral.

## Fix

**Switch the coverage engine to cargo-llvm-cov** (source-based LLVM coverage):

- Tests run at near-native speed: the full workspace coverage run takes ~51s locally (engine suite: 3.5s instrumented vs 158s under tarpaulin's ptrace in the last CI run). This resolves both the timeout and the timing-budget violations at the root.
- Region-based source coverage is also more accurate than ptrace breakpoints.
- This aligns CI with `docs/dev/commands.md`, which already documents `cargo llvm-cov` as the project's local coverage command -- CI on tarpaulin was the outlier.
- `llvm-tools` is installed as a coverage-job step rather than in `rust-toolchain.toml`, so the other ~10 CI jobs and developer machines don't pay for a component only this job uses.
- Cache key renamed (`cargo-coverage-*` -> `cargo-llvm-cov-*`) since the instrumented artifacts are disjoint; `target/llvm-cov-target` lives under the cached `target/` path.
- Step cap reduced 90 -> 45 minutes: warm-cache runs fit comfortably in 30, the headroom absorbs the cold-cache full instrumented rebuild.

**Harden the tests so instrumentation slowdown can't manufacture failures again:**

- Recover the patch-test-hook mutexes from poisoning (`PoisonError::into_inner`). This is sound because `PatchTestHookGuard`'s `Drop` always resets the hook to `None` before releasing the serialization lock, so the protected state is consistent after any panic. Covered by a new regression test that deliberately panics while holding the guard (written first; it reproduces the exact `patch.rs:55:44` CI panic without the fix).
- Positive `recv_timeout` budgets ("the other thread SHOULD get here") raised from 2s/5s to a shared 30s `POSITIVE_WAIT` -- these return as soon as the message arrives, so the budget is only consumed on genuine failure. The 200ms negative assertions ("should NOT have completed yet") are untouched: slowness can only make them pass, never fail.

## Validation

- Full `cargo llvm-cov --workspace --lcov` run locally: all 15 test binaries pass (4358 engine tests included), valid 5.2MB lcov.info produced, 50.6s wall-clock.
- Adversarially reviewed by a fresh-context reviewer (poison-recovery interleavings, lock ordering, coverage parity, CI config) over two rounds until no material findings remained.
- Coverage parity: both old (`cargo tarpaulin`) and new (`cargo llvm-cov --workspace`) run default features only; doctests run under neither (they still execute in the Build job).

## Notes for after merge

- Codecov has had no uploads since the job died, so there is no base report; the first upload simply re-baselines. Absolute numbers will shift with the engine change (region-based vs ptrace) -- that level shift is expected, not a coverage regression. Recent PRs confirm codecov posts no status contexts with the base missing, so nothing turns red in the interim.
- During triage, consider closing #622 in favor of #726 (or both, if the first `main` run of this job is green) -- both symptoms trace to the ptrace engine removed here.

Addresses #622 and #726.