### PR TITLE
frontend: burn down four diagram/server TypeScript issues

### DIFF
--- a/src/diagram/Editor.tsx
+++ b/src/diagram/Editor.tsx
@@ -2212,9 +2212,9 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
           // revoke any previous snapshot URL via setSnapshotUrl.
           setSnapshotUrl(URL.createObjectURL(snapshotBlob));
         } else {
-          setState({
-            modelErrors: [...latest.current.state.modelErrors, new Error('snapshot creation failed (1).')],
-          });
+          setState((prev) => ({
+            modelErrors: [...prev.modelErrors, new Error('snapshot creation failed (1).')],
+          }));
         }
       });
     };
@@ -2223,9 +2223,9 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
       if (isUnmounted()) {
         return;
       }
-      setState({
-        modelErrors: [...latest.current.state.modelErrors, new Error('snapshot creation failed (2).')],
-      });
+      setState((prev) => ({
+        modelErrors: [...prev.modelErrors, new Error('snapshot creation failed (2).')],
+      }));
     };
 
     image.src = svgUrl;

--- a/src/diagram/components/Menu.tsx
+++ b/src/diagram/components/Menu.tsx
@@ -20,13 +20,65 @@ export interface MenuProps {
   children?: React.ReactNode;
 }
 
+/**
+ * Track an anchor element's viewport rect live while a menu is open.
+ *
+ * The rect must follow the anchor if it moves while the menu is open (window
+ * resize, scroll of a non-fixed scroll container, layout reflow). Memoizing on
+ * `anchorEl` identity alone captures a stale snapshot that never re-measures, so
+ * the menu detaches from its trigger (issue #710). Re-measure on scroll
+ * (capture phase, so nested scroll containers count, not just window) and
+ * resize, and observe the anchor's own size changes. `useLayoutEffect`
+ * re-measures synchronously before paint, so the first open positions correctly
+ * without a visible jump.
+ */
+function useAnchorRect(anchorEl: HTMLElement | null, open: boolean): DOMRect | undefined {
+  const [rect, setRect] = React.useState<DOMRect | undefined>(undefined);
+
+  React.useLayoutEffect(() => {
+    if (!open || !anchorEl) {
+      return;
+    }
+    // Re-measure, but bail out (return the previous reference) when nothing
+    // changed so a stream of scroll/resize ticks over a stationary anchor does
+    // not force a re-render on every event -- this fires hottest exactly in the
+    // scrollable-region case the issue is about.
+    const update = (): void => {
+      const next = anchorEl.getBoundingClientRect();
+      setRect((prev) =>
+        prev &&
+        prev.top === next.top &&
+        prev.left === next.left &&
+        prev.width === next.width &&
+        prev.height === next.height
+          ? prev
+          : next,
+      );
+    };
+    update();
+
+    window.addEventListener('scroll', update, true);
+    window.addEventListener('resize', update);
+    const observer = typeof ResizeObserver !== 'undefined' ? new ResizeObserver(update) : undefined;
+    observer?.observe(anchorEl);
+
+    return () => {
+      window.removeEventListener('scroll', update, true);
+      window.removeEventListener('resize', update);
+      observer?.disconnect();
+    };
+  }, [anchorEl, open]);
+
+  return rect;
+}
+
 export function Menu(props: MenuProps): React.ReactElement {
   const { anchorEl, open, onClose, anchorOrigin, id, className, style, children } = props;
 
   const side = anchorOrigin?.vertical === 'top' ? 'top' : 'bottom';
   const align = anchorOrigin?.horizontal === 'right' ? 'end' : 'start';
 
-  const anchorRect = React.useMemo(() => anchorEl?.getBoundingClientRect(), [anchorEl]);
+  const anchorRect = useAnchorRect(anchorEl, open);
 
   return (
     <DropdownMenu.Root open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>

--- a/src/diagram/drawing/Flow.tsx
+++ b/src/diagram/drawing/Flow.tsx
@@ -558,7 +558,14 @@ function adjustFlows(
       return point;
     });
 
-    otherEnd = defined(otherEnd);
+    // Degenerate self-loop: both endpoints attach to the same stock, so no
+    // endpoint was recorded as the "other end" to anchor the valve fraction
+    // against. Such a flow can't be created in the editor but can arrive via an
+    // imported model or a programmatic patch (issue #720). Leave it unchanged
+    // rather than throwing on the canvas render/interaction path.
+    if (otherEnd === undefined) {
+      return flow;
+    }
 
     // For multi-segment flows (3+ points), use segment-based valve positioning.
     // When moving an endpoint (like the arrowhead), the valve should only be

--- a/src/diagram/tests/flow-routing.test.ts
+++ b/src/diagram/tests/flow-routing.test.ts
@@ -2660,4 +2660,37 @@ describe('Flow routing', () => {
       expect(firstPt.y).toBe(stockY - moveDelta.y);
     });
   });
+
+  describe('degenerate self-loop flow (both endpoints on the same stock)', () => {
+    // A flow whose first and last points are both attached to the same stock
+    // (issue #720). It cannot be produced through normal editor interactions,
+    // but can arrive via imported models or programmatic patches. adjustFlows
+    // (reached here through UpdateCloudAndFlow's straight-flow axis-constrain
+    // path) used to call defined(otherEnd) and throw because no endpoint was
+    // attached to a *different* element -- crashing the canvas render/interaction
+    // path. It must degrade gracefully instead.
+    it('does not throw and leaves the flow unchanged when dragged', () => {
+      const stockX = 100;
+      const stockY = 100;
+      // 2-point horizontal flow with BOTH endpoints attached to the stock.
+      const flow = makeFlow(flowUid, 150, stockY, [
+        { x: stockX, y: stockY, attachedToUid: stockUid },
+        { x: 200, y: stockY, attachedToUid: stockUid },
+      ]);
+      const stock = makeStock(stockUid, stockX, stockY);
+
+      // A small drag so we stay on the straight-flow axis-constrain path
+      // (below PERP_THRESHOLD) that reaches adjustFlows.
+      const moveDelta = { x: 2, y: 1 };
+
+      let result: ReturnType<typeof UpdateCloudAndFlow> | undefined;
+      expect(() => {
+        result = UpdateCloudAndFlow(stock, flow, moveDelta);
+      }).not.toThrow();
+
+      const [, newFlow] = result!;
+      // Graceful degradation: the degenerate flow's points are returned intact.
+      expect(newFlow.points).toEqual(flow.points);
+    });
+  });
 });

--- a/src/diagram/tests/menu.test.tsx
+++ b/src/diagram/tests/menu.test.tsx
@@ -1,0 +1,151 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, act } from '@testing-library/react';
+
+import { Menu, MenuItem } from '../components/Menu';
+
+// Install a controllable getBoundingClientRect on an element so we can simulate
+// the anchor moving while the menu is open (issue #710). Returns a setter.
+function mockRect(el: HTMLElement, initial: { top: number; left: number; width: number; height: number }) {
+  let current = initial;
+  el.getBoundingClientRect = () =>
+    ({
+      top: current.top,
+      left: current.left,
+      width: current.width,
+      height: current.height,
+      bottom: current.top + current.height,
+      right: current.left + current.width,
+      x: current.left,
+      y: current.top,
+      toJSON() {
+        return current;
+      },
+    }) as DOMRect;
+  return (next: { top: number; left: number; width: number; height: number }) => {
+    current = next;
+  };
+}
+
+// The proxy span Radix anchors to is the (asChild) trigger; it carries
+// aria-haspopup="menu" and is the only position:fixed element we render.
+function getProxySpan(): HTMLElement {
+  const el = document.querySelector<HTMLElement>('[aria-haspopup="menu"]');
+  if (!el) {
+    throw new Error('proxy trigger span not found');
+  }
+  return el;
+}
+
+describe('Menu anchor positioning (issue #710)', () => {
+  it('positions the proxy at the anchor rect on open', () => {
+    const anchor = document.createElement('button');
+    document.body.appendChild(anchor);
+    mockRect(anchor, { top: 10, left: 20, width: 40, height: 8 });
+
+    render(
+      <Menu anchorEl={anchor} open onClose={() => {}}>
+        <MenuItem>One</MenuItem>
+      </Menu>,
+    );
+
+    const span = getProxySpan();
+    // top is anchored to the rect's bottom (top + height), left to its left.
+    expect(span.style.top).toBe('18px');
+    expect(span.style.left).toBe('20px');
+    expect(span.style.width).toBe('40px');
+
+    anchor.remove();
+  });
+
+  it('re-measures and follows the anchor when it moves on scroll while open', () => {
+    const anchor = document.createElement('button');
+    document.body.appendChild(anchor);
+    const setRect = mockRect(anchor, { top: 10, left: 20, width: 40, height: 8 });
+
+    render(
+      <Menu anchorEl={anchor} open onClose={() => {}}>
+        <MenuItem>One</MenuItem>
+      </Menu>,
+    );
+
+    expect(getProxySpan().style.top).toBe('18px');
+
+    // The anchor moves (e.g. a scroll container shifts it up) and a scroll event
+    // fires. The stale-snapshot bug would leave the proxy at the old position.
+    setRect({ top: 100, left: 200, width: 40, height: 8 });
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    const span = getProxySpan();
+    expect(span.style.top).toBe('108px');
+    expect(span.style.left).toBe('200px');
+
+    anchor.remove();
+  });
+
+  it('re-measures on window resize while open', () => {
+    const anchor = document.createElement('button');
+    document.body.appendChild(anchor);
+    const setRect = mockRect(anchor, { top: 10, left: 20, width: 40, height: 8 });
+
+    render(
+      <Menu anchorEl={anchor} open onClose={() => {}}>
+        <MenuItem>One</MenuItem>
+      </Menu>,
+    );
+
+    setRect({ top: 10, left: 300, width: 40, height: 8 });
+    act(() => {
+      window.dispatchEvent(new Event('resize'));
+    });
+
+    expect(getProxySpan().style.left).toBe('300px');
+
+    anchor.remove();
+  });
+
+  it('detaches its scroll/resize listeners when closed', () => {
+    const anchor = document.createElement('button');
+    document.body.appendChild(anchor);
+    const setRect = mockRect(anchor, { top: 10, left: 20, width: 40, height: 8 });
+
+    const { rerender } = render(
+      <Menu anchorEl={anchor} open onClose={() => {}}>
+        <MenuItem>One</MenuItem>
+      </Menu>,
+    );
+
+    const spanWhileOpen = getProxySpan();
+    expect(spanWhileOpen.style.top).toBe('18px');
+
+    // Close the menu, then move the anchor and fire scroll. With listeners
+    // detached, no stale work runs; reopening re-measures from scratch.
+    rerender(
+      <Menu anchorEl={anchor} open={false} onClose={() => {}}>
+        <MenuItem>One</MenuItem>
+      </Menu>,
+    );
+
+    setRect({ top: 500, left: 600, width: 40, height: 8 });
+    act(() => {
+      window.dispatchEvent(new Event('scroll'));
+    });
+
+    // Reopen: the layout effect re-measures synchronously to the current rect.
+    rerender(
+      <Menu anchorEl={anchor} open onClose={() => {}}>
+        <MenuItem>One</MenuItem>
+      </Menu>,
+    );
+
+    expect(getProxySpan().style.top).toBe('508px');
+    expect(getProxySpan().style.left).toBe('600px');
+
+    anchor.remove();
+  });
+});

--- a/src/server/api-validation.ts
+++ b/src/server/api-validation.ts
@@ -1,0 +1,36 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+// pattern: Functional Core
+// Pure request-body validators with no I/O and no heavy dependencies (no
+// express, DB, protobuf, or engine WASM), so they can be unit-tested in
+// isolation without pulling the server's render/DB surface into the test graph.
+
+// body-parser 2 (paired with Express 5) leaves `req.body` undefined for
+// empty-body or non-matching-Content-Type requests, where body-parser 1 left
+// `{}`. These validators guard that case so a malformed request gets the
+// intended 400 instead of throwing a TypeError that Express 5 surfaces as a
+// generic 500 (issue #691). Each returns the client-facing error message, or
+// undefined when the body is acceptable.
+
+export function validateCreateProjectBody(body: unknown): string | undefined {
+  if (typeof body !== 'object' || body === null || !(body as Record<string, unknown>).projectName) {
+    return 'projectName is required';
+  }
+  return undefined;
+}
+
+export function validateUserPatchBody(body: unknown): string | undefined {
+  // A user PATCH may only carry two fields. This validator enforces "exactly two
+  // keys, one of which is a truthy `username`"; the handler separately requires
+  // the second key to be `agreeToTermsAndPrivacyPolicy`.
+  if (typeof body !== 'object' || body === null) {
+    return 'only username can be patched';
+  }
+  const fields = body as Record<string, unknown>;
+  if (Object.keys(fields).length !== 2 || !fields.username) {
+    return 'only username can be patched';
+  }
+  return undefined;
+}

--- a/src/server/api.ts
+++ b/src/server/api.ts
@@ -6,6 +6,7 @@ import { Request, Response, Router } from 'express';
 import { Timestamp } from 'google-protobuf/google/protobuf/timestamp_pb';
 import * as logger from './logger';
 
+import { validateCreateProjectBody, validateUserPatchBody } from './api-validation';
 import { Application } from './application';
 import { Database } from './models/db-interfaces';
 import { populateExamples } from './new-user';
@@ -99,8 +100,9 @@ export const apiRouter = (app: Application): Router => {
   api.post('/projects', async (req: Request, res: Response): Promise<void> => {
     const user = getUser(req, res);
 
-    if (!req.body.projectName) {
-      res.status(400).json({ error: 'projectName is required' });
+    const createBodyError = validateCreateProjectBody(req.body);
+    if (createBodyError) {
+      res.status(400).json({ error: createBodyError });
       return;
     }
 
@@ -312,8 +314,9 @@ export const apiRouter = (app: Application): Router => {
   api.patch('/user', async (req: Request, res: Response): Promise<void> => {
     const userModel = getUser(req, res);
 
-    if (Object.keys(req.body).length !== 2 || !req.body.username) {
-      res.status(400).json({ error: 'only username can be patched' });
+    const patchBodyError = validateUserPatchBody(req.body);
+    if (patchBodyError) {
+      res.status(400).json({ error: patchBodyError });
       return;
     }
 

--- a/src/server/tests/api-body-validation.test.ts
+++ b/src/server/tests/api-body-validation.test.ts
@@ -1,0 +1,73 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import { validateCreateProjectBody, validateUserPatchBody } from '../api-validation';
+
+// Regression coverage for issue #691: after the body-parser 1 -> 2 upgrade,
+// `req.body` is `undefined` (not `{}`) for empty-body or wrong-Content-Type
+// requests. These pure validators must treat that case as a 400-worthy bad
+// request rather than letting a TypeError escape into a generic 500.
+
+describe('validateCreateProjectBody', () => {
+  it('rejects an undefined body (empty / wrong Content-Type request)', () => {
+    expect(validateCreateProjectBody(undefined)).toBe('projectName is required');
+  });
+
+  it('rejects a null body', () => {
+    expect(validateCreateProjectBody(null)).toBe('projectName is required');
+  });
+
+  it('rejects an empty object', () => {
+    expect(validateCreateProjectBody({})).toBe('projectName is required');
+  });
+
+  it('rejects a body with a falsy projectName', () => {
+    expect(validateCreateProjectBody({ projectName: '' })).toBe('projectName is required');
+  });
+
+  it('rejects a non-object body', () => {
+    expect(validateCreateProjectBody('projectName=foo')).toBe('projectName is required');
+  });
+
+  it('accepts a body with a projectName', () => {
+    expect(validateCreateProjectBody({ projectName: 'My Model' })).toBeUndefined();
+  });
+
+  it('accepts a body with projectName plus extra optional fields', () => {
+    expect(
+      validateCreateProjectBody({ projectName: 'My Model', description: 'd', isPublic: true, projectPB: 'AA==' }),
+    ).toBeUndefined();
+  });
+});
+
+describe('validateUserPatchBody', () => {
+  it('rejects an undefined body (empty / wrong Content-Type request)', () => {
+    expect(validateUserPatchBody(undefined)).toBe('only username can be patched');
+  });
+
+  it('rejects a null body', () => {
+    expect(validateUserPatchBody(null)).toBe('only username can be patched');
+  });
+
+  it('rejects an empty object', () => {
+    expect(validateUserPatchBody({})).toBe('only username can be patched');
+  });
+
+  it('rejects a body with the wrong number of keys', () => {
+    expect(validateUserPatchBody({ username: 'alice' })).toBe('only username can be patched');
+    expect(validateUserPatchBody({ username: 'alice', agreeToTermsAndPrivacyPolicy: true, extra: 1 })).toBe(
+      'only username can be patched',
+    );
+  });
+
+  it('rejects two keys when username is falsy', () => {
+    expect(validateUserPatchBody({ username: '', agreeToTermsAndPrivacyPolicy: true })).toBe(
+      'only username can be patched',
+    );
+  });
+
+  it('accepts exactly { username, agreeToTermsAndPrivacyPolicy }', () => {
+    expect(validateUserPatchBody({ username: 'alice', agreeToTermsAndPrivacyPolicy: true })).toBeUndefined();
+  });
+});


### PR DESCRIPTION
Fixes #720, fixes #710, fixes #728, fixes #691

Closes a batch of frontend/TypeScript issues surfaced during the recent React component audit and the deploy-risk audit. Each fix is test-driven; the changes were run through an adversarial sub-agent review and iterated until no material findings remained.

## Fixes

### #720 — `adjustFlows` crashes on a degenerate self-loop flow
`adjustFlows` (`src/diagram/drawing/Flow.tsx`) called `defined(otherEnd)` and threw when handed a flow whose first and last points are both attached to the same stock. Such a flow can't be drawn in the editor but can arrive via imported models (XMILE/Vensim) or programmatic patches (MCP/API), crashing the canvas render/interaction path. It now early-returns the flow unchanged when there is no "other end" to anchor the valve fraction against (defense at the render boundary).
- Test: `flow-routing.test.ts` — "degenerate self-loop flow" (reproduces the crash, verifies graceful no-op).

### #710 — Menu anchors Radix to a stale `getBoundingClientRect` snapshot
`Menu.tsx` positioned the dropdown via a `position:fixed` proxy span placed at a rect memoized on `anchorEl` identity, so it never re-measured when the anchor moved (scroll/resize/reflow) and the menu detached from its trigger. A new `useAnchorRect(anchorEl, open)` hook re-measures (via `useLayoutEffect`) on capture-phase `scroll`, `resize`, and `ResizeObserver` while open, and bails out (returns the prior reference) when the rect is unchanged so a stationary anchor doesn't force a re-render on every scroll tick.
- Test: `menu.test.tsx` — initial measure, scroll-follow, resize-follow, listener-detach-on-close + reopen re-measure.

### #728 — Snapshotter `modelErrors` appends use non-functional `setState`
The two snapshot-image error handlers in `Editor.tsx` appended to `modelErrors` with a read-then-write `setState({ ... latest.current.state.modelErrors ... })`, which is clobber-prone under concurrent appends. Converted both to the functional updater form, matching the file's other concurrent-safe append sites. (The Snapshotter UI is currently commented out, so this is dead code today; the fix prevents it being re-enabled in a broken state — no test is reachable.)

### #691 — Empty-body requests return 500 instead of 400
After the body-parser 1→2 / Express 4→5 upgrades, `req.body` is `undefined` (not `{}`) for empty-body or wrong-`Content-Type` requests. `POST /api/projects` and `PATCH /api/user` dereferenced `req.body` without guarding, so malformed/probe traffic threw a `TypeError` that Express 5 surfaced as a generic **500** (with stack noise that masks real 500s) instead of the intended **400**. The body validation is extracted into pure, dependency-free validators (`src/server/api-validation.ts`) wired into both handlers.
- Test: `api-body-validation.test.ts` — undefined/null/empty/wrong-type/falsy/extra-key cases for both validators (kept out of `api.ts` so the unit tests don't pull the DB/protobuf/engine-WASM graph).

## Verification
- Full pre-commit hook (Rust fmt/clippy/test, WASM build, TS lint/typecheck/test, pysimlin) passes on both commits.
- Diagram suite: 1111 tests pass. Server suite: 111 tests pass.
- Adversarial sub-agent review found no Critical/Important issues; its two Minor findings (Menu re-render guard, FCIS validator decoupling) and a Nit were addressed.

## Deliberately deferred (not in this PR)
These related frontend/TS issues were evaluated and intentionally left for focused follow-ups:
- **#624** (unify the two `canonicalize` implementations): the issue's suggested approach (promote into `@simlin/core`, have `@simlin/engine` consume it) is backwards relative to the actual dependency direction (`@simlin/core` → `@simlin/engine`; engine has no `@simlin` deps by design). True unification requires a core→engine runtime import plus a new cross-package subpath that must resolve consistently across four jest configs and the rsbuild production bundle — an architecture/bundler change too risky to bundle with hygiene fixes.
- **#707** (debounce per-frame view persistence): touches the heavily-invariant optimistic-view / save-queue / preserve-live-view path in `ProjectController`; needs dedicated design.
- **#709** (component-library dark-mode tokens): a 16-file visual CSS sweep where light-mode fidelity can't be unit-verified; warrants careful review against the design system.
- **#708** (reset.css tree-shaking): an open-ended bundler root-cause investigation, not a clean code change.
- **#718** (react-hooks lint enablement): `exhaustive-deps` would surface a large backlog against the freshly-migrated `latest`-ref / empty-deps-effect code; a deliberate enable-and-triage effort of its own.