### PR TITLE
app: drop fetchSignInMethodsForEmail from login flow

### DIFF
--- a/src/app/Login.tsx
+++ b/src/app/Login.tsx
@@ -9,7 +9,6 @@ import {
   GoogleAuthProvider,
   OAuthProvider,
   Auth as FirebaseAuth,
-  fetchSignInMethodsForEmail,
   createUserWithEmailAndPassword,
   updateProfile,
   sendPasswordResetEmail,
@@ -32,7 +31,19 @@ import typography from './typography.module.css';
 
 import styles from './Login.module.css';
 
-type EmailLoginStates = 'showEmail' | 'showPassword' | 'showSignup' | 'showProviderRedirect' | 'showRecover';
+// The email flow is a single combined sign-in card rather than a method-prefetch
+// router. We deliberately do NOT call Firebase's deprecated
+// fetchSignInMethodsForEmail: it enables email enumeration, and when a project
+// turns on Email Enumeration Protection it returns [] for every address, which
+// the old flow misread as "no account" and used to route every existing
+// password user to the signup card -- a silent, total lockout (issue #692).
+// Removing the prefetch makes the flow correct whether that protection is on or
+// off, at the cost of no longer being able to tell a returning OAuth-only user
+// which provider they used: a wrong password and an OAuth-only account both
+// surface as auth/invalid-credential under protection, so we show one generic
+// message and point such users back to the provider buttons on the landing
+// screen.
+type EmailLoginStates = 'signin' | 'signup' | 'recover' | 'recoverSent';
 
 export interface LoginProps {
   disabled: boolean;
@@ -47,7 +58,10 @@ interface LoginState {
   passwordError: string | undefined;
   fullName: string;
   fullNameError: string | undefined;
-  provider: 'google.com' | 'apple.com' | undefined;
+  // Card-level credential failure on the combined sign-in card (kept separate
+  // from the per-field emailError/passwordError so it can be announced via
+  // role=alert and cleared when the user edits either field).
+  signinError: string | undefined;
 }
 
 function appleProvider(): OAuthProvider {
@@ -55,6 +69,22 @@ function appleProvider(): OAuthProvider {
   provider.addScope('email');
   provider.addScope('name');
   return provider;
+}
+
+/**
+ * Firebase Auth errors carry a string `code` (e.g. 'auth/invalid-credential')
+ * on top of the Error shape. Read it defensively: a non-Firebase throw (a bare
+ * network TypeError, say) has no `code` and must fall through to the generic
+ * branch rather than crash the handler.
+ */
+function firebaseErrorCode(err: unknown): string | undefined {
+  if (typeof err === 'object' && err !== null) {
+    const code = (err as { code?: unknown }).code;
+    if (typeof code === 'string') {
+      return code;
+    }
+  }
+  return undefined;
 }
 
 export const GoogleIcon: React.FunctionComponent = (props) => {
@@ -73,13 +103,13 @@ const initialState: LoginState = {
   passwordError: undefined,
   fullName: '',
   fullNameError: undefined,
-  provider: undefined,
+  signinError: undefined,
 };
 
 export function Login(props: LoginProps): React.JSX.Element {
   // One useState object with a class-parity merging `setState` helper preserves
-  // the class's behavior for handlers that issue several setState calls in one
-  // turn (each merges a partial patch onto the previous state).
+  // the behavior for handlers that issue several setState calls in one turn
+  // (each merges a partial patch onto the previous state).
   const [state, setStateRaw] = React.useState<LoginState>(() => ({ ...initialState }));
 
   const setState = React.useCallback((patch: Partial<LoginState>): void => {
@@ -89,17 +119,14 @@ export function Login(props: LoginProps): React.JSX.Element {
   // The async auth handlers escape the render that created them (they await
   // firebase calls), so they read the freshest props/state through this ref:
   // a prop change (auth) or an interleaved state edit between handler creation
-  // and the await's resolution is observed correctly, matching the class's
-  // this.props / this.state reads.
+  // and the await's resolution is observed correctly.
   const latest = React.useRef<{ props: LoginProps; state: LoginState }>(
     undefined as unknown as { props: LoginProps; state: LoginState },
   );
   latest.current = { props, state };
 
   // Surface OAuth redirect failures (provider misconfig, popup blocked,
-  // network errors, expired auth domain) into emailError so the user sees
-  // them. The previous setTimeout-around-async pattern silently swallowed
-  // rejections because nothing awaited or .catch'd the inner promise.
+  // network errors, expired auth domain) into emailError so the user sees them.
   const appleLoginClick = async () => {
     const provider = appleProvider();
     try {
@@ -121,59 +148,90 @@ export function Login(props: LoginProps): React.JSX.Element {
       });
     }
   };
+  // Entering the email flow lands directly on the combined sign-in card. Clear
+  // any stale OAuth error from the landing screen so it doesn't reappear under
+  // the email field.
   const emailLoginClick = () => {
-    setState({ emailLoginFlow: 'showEmail' });
+    setState({ emailLoginFlow: 'signin', emailError: undefined, passwordError: undefined, signinError: undefined });
   };
-  // Editing a field clears its stale error: once the user starts correcting
-  // the value, keeping the old red message would be misleading (it described
-  // the previous submission, not the text on screen).
+  // Editing a field clears its stale error: once the user starts correcting the
+  // value, keeping the old red message would be misleading. The combined
+  // credential error (signinError) is about "email OR password", so editing
+  // either field clears it.
   const onFullNameChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
     setState({ fullName: event.target.value, fullNameError: undefined });
   };
   const onPasswordChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setState({ password: event.target.value, passwordError: undefined });
+    setState({ password: event.target.value, passwordError: undefined, signinError: undefined });
   };
   const onEmailChanged = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setState({ email: event.target.value, emailError: undefined });
+    setState({ email: event.target.value, emailError: undefined, signinError: undefined });
   };
-  const onEmailCancel = () => {
-    setState({ emailLoginFlow: undefined });
+  const onCancel = () => {
+    setState({
+      emailLoginFlow: undefined,
+      emailError: undefined,
+      passwordError: undefined,
+      fullNameError: undefined,
+      signinError: undefined,
+    });
   };
-  const onSubmitEmail = async () => {
+  const onTroubleSigningIn = () => {
+    setState({ emailLoginFlow: 'recover', emailError: undefined, passwordError: undefined, signinError: undefined });
+  };
+  const onCreateAccount = () => {
+    setState({
+      emailLoginFlow: 'signup',
+      emailError: undefined,
+      passwordError: undefined,
+      fullNameError: undefined,
+      signinError: undefined,
+    });
+  };
+  const onSignInInstead = () => {
+    setState({
+      emailLoginFlow: 'signin',
+      emailError: undefined,
+      passwordError: undefined,
+      fullNameError: undefined,
+      signinError: undefined,
+    });
+  };
+  // Combined sign-in: attempt the password sign-in directly and branch on the
+  // Firebase error code. On success App's onAuthStateChanged observer takes
+  // over (exchanges the id token for a session), so there's nothing to do here.
+  const onSignIn = async () => {
     const email = latest.current.state.email.trim();
     if (!email) {
       setState({ emailError: 'Enter your email address to continue' });
       return;
     }
-
-    // fetchSignInMethodsForEmail rejects on network errors, rate limiting,
-    // and Firebase's email-enumeration protection; the sibling auth handlers
-    // all surface failures, so this one must too (it used to escape as an
-    // unhandled rejection and the form just sat there).
-    let methods: string[];
-    try {
-      methods = await fetchSignInMethodsForEmail(latest.current.props.auth, email);
-    } catch (err) {
-      setState({
-        emailError: err instanceof Error ? err.message : 'unable to look up that email address; try again',
-      });
+    const password = latest.current.state.password.trim();
+    if (!password) {
+      setState({ passwordError: 'Enter your password to continue' });
       return;
     }
-    if (methods.includes('password')) {
-      setState({ emailLoginFlow: 'showPassword' });
-    } else if (methods.length === 0) {
-      setState({ emailLoginFlow: 'showSignup' });
-    } else {
-      // we only allow 1 method
-      const method = methods[0];
-      if (method === 'google.com' || method === 'apple.com') {
-        setState({
-          emailLoginFlow: 'showProviderRedirect',
-          provider: methods[0] as 'google.com' | 'apple.com',
-        });
+
+    try {
+      await signInWithEmailAndPassword(latest.current.props.auth, email, password);
+    } catch (err) {
+      const code = firebaseErrorCode(err);
+      if (code === 'auth/invalid-email') {
+        setState({ signinError: "That doesn't look like a valid email address." });
+      } else if (code === 'auth/network-request-failed' || code === 'auth/too-many-requests') {
+        // Transient, account-agnostic failures: Firebase returns these whether
+        // or not the account exists, so reporting them honestly leaks nothing --
+        // and it avoids telling a user with correct credentials that their
+        // password is wrong during a network outage or rate-limit.
+        setState({ signinError: "We couldn't sign you in right now. Please try again in a moment." });
       } else {
+        // auth/invalid-credential (the unified wrong-password / no-such-user /
+        // OAuth-only error under Email Enumeration Protection),
+        // auth/wrong-password, auth/user-not-found, and any non-Firebase throw
+        // all collapse to one enumeration-safe message.
         setState({
-          emailError: 'an unknown error occurred; try a different email address',
+          signinError:
+            'Incorrect email or password. If you used Google or Apple to sign up, go back and use those buttons.',
         });
       }
     }
@@ -188,18 +246,27 @@ export function Login(props: LoginProps): React.JSX.Element {
     try {
       await sendPasswordResetEmail(latest.current.props.auth, email);
     } catch (err) {
-      // Stay on the recovery card with a visible error rather than advancing
-      // as if the reset email had been sent.
+      // Stay on the recovery card with a visible error rather than advancing as
+      // if the reset email had been sent.
       setState({
         emailError: err instanceof Error ? err.message : 'sending the recovery email failed; try again',
       });
       return;
     }
 
+    // Neutral confirmation only: sendPasswordResetEmail succeeds even for
+    // addresses with no account when Email Enumeration Protection is on, so we
+    // must not assert an email was actually sent to a real account.
+    setState({ emailLoginFlow: 'recoverSent' });
+  };
+  const onRecoverDone = () => {
     setState({
-      emailLoginFlow: 'showPassword',
+      emailLoginFlow: 'signin',
       password: '',
       passwordError: undefined,
+      emailError: undefined,
+      fullNameError: undefined,
+      signinError: undefined,
     });
   };
   const onSubmitNewUser = async () => {
@@ -225,11 +292,15 @@ export function Login(props: LoginProps): React.JSX.Element {
       const userCred = await createUserWithEmailAndPassword(latest.current.props.auth, email, password);
       await updateProfile(userCred.user, { displayName: fullName });
     } catch (err) {
-      console.log(err);
-      if (err instanceof Error) {
-        setState({ passwordError: err.message });
+      const code = firebaseErrorCode(err);
+      if (code === 'auth/email-already-in-use') {
+        setState({ emailError: 'An account with this email already exists.' });
+      } else if (code === 'auth/weak-password') {
+        setState({ passwordError: 'Choose a password with at least 6 characters.' });
+      } else if (code === 'auth/invalid-email') {
+        setState({ emailError: "That doesn't look like a valid email address." });
       } else {
-        setState({ passwordError: 'something unknown went wrong' });
+        setState({ passwordError: err instanceof Error ? err.message : 'something unknown went wrong' });
       }
     }
   };
@@ -237,43 +308,18 @@ export function Login(props: LoginProps): React.JSX.Element {
     event.preventDefault();
     return false;
   };
-  const onEmailHelp = () => {
-    setState({ emailLoginFlow: 'showRecover' });
-  };
-  const onEmailLogin = async () => {
-    const email = latest.current.state.email.trim();
-    if (!email) {
-      setState({ emailError: 'Enter your email address to continue' });
-      return;
-    }
-
-    const password = latest.current.state.password.trim();
-    if (!password) {
-      setState({ passwordError: 'Enter your email address to continue' });
-      return;
-    }
-
-    try {
-      await signInWithEmailAndPassword(latest.current.props.auth, email, password);
-    } catch (err) {
-      console.log(err);
-      if (err instanceof Error) {
-        setState({ passwordError: err.message });
-      }
-    }
-  };
 
   const disabledClass = props.disabled ? styles.disabled : styles.innerInner;
 
   let loginUI: React.JSX.Element | undefined = undefined;
   if (!props.disabled) {
     switch (state.emailLoginFlow) {
-      case 'showEmail':
+      case 'signin':
         loginUI = (
           <Card variant="outlined" className={styles.emailForm}>
             <form onSubmit={onNullSubmit}>
               <CardContent>
-                <h6 className={typography.heading6}>Sign in with email</h6>
+                <h6 className={typography.heading6}>Sign in to Simlin</h6>
                 <TextField
                   label="Email"
                   value={state.email}
@@ -284,37 +330,9 @@ export function Login(props: LoginProps): React.JSX.Element {
                   error={state.emailError !== undefined}
                   helperText={state.emailError}
                   fullWidth
-                  autoFocus
-                />
-              </CardContent>
-              <CardActions>
-                <Button style={{ marginLeft: 'auto' }} onClick={onEmailCancel}>
-                  Cancel
-                </Button>
-                <Button type="submit" variant="contained" onClick={onSubmitEmail}>
-                  Next
-                </Button>
-              </CardActions>
-            </form>
-          </Card>
-        );
-        break;
-      case 'showPassword':
-        loginUI = (
-          <Card variant="outlined" className={styles.emailForm}>
-            <form onSubmit={onNullSubmit}>
-              <CardContent>
-                <h6 className={typography.heading6}>Sign in</h6>
-                <TextField
-                  label="Email"
-                  value={state.email}
-                  onChange={onEmailChanged}
-                  type="email"
-                  margin="normal"
-                  variant="standard"
-                  error={state.emailError !== undefined}
-                  helperText={state.emailError}
-                  fullWidth
+                  // Focus the empty field: email on first entry, password when
+                  // an email was carried in from another card.
+                  autoFocus={state.email === ''}
                 />
                 <TextField
                   label="Password"
@@ -327,16 +345,28 @@ export function Login(props: LoginProps): React.JSX.Element {
                   error={state.passwordError !== undefined}
                   helperText={state.passwordError}
                   fullWidth
-                  autoFocus
+                  autoFocus={state.email !== ''}
                 />
-              </CardContent>
-              <CardActions>
-                <span className={typography.body2} style={{ marginRight: 'auto' }}>
-                  <TextLink style={{ cursor: 'help' }} underline="hover" onClick={onEmailHelp}>
+                {state.signinError !== undefined && (
+                  <p role="alert" className={typography.body2}>
+                    {state.signinError}
+                  </p>
+                )}
+                <p className={typography.body2}>
+                  <TextLink underline="hover" onClick={onTroubleSigningIn}>
                     Trouble signing in?
                   </TextLink>
-                </span>
-                <Button type="submit" variant="contained" onClick={onEmailLogin}>
+                  {' '}
+                  <TextLink underline="hover" onClick={onCreateAccount}>
+                    Create account
+                  </TextLink>
+                </p>
+              </CardContent>
+              <CardActions>
+                <Button style={{ marginLeft: 'auto' }} onClick={onCancel}>
+                  Cancel
+                </Button>
+                <Button type="submit" variant="contained" onClick={onSignIn}>
                   Sign in
                 </Button>
               </CardActions>
@@ -344,12 +374,12 @@ export function Login(props: LoginProps): React.JSX.Element {
           </Card>
         );
         break;
-      case 'showSignup':
+      case 'signup':
         loginUI = (
           <Card variant="outlined" className={styles.emailForm}>
             <form onSubmit={onNullSubmit}>
               <CardContent>
-                <h6 className={typography.heading6}>Create account</h6>
+                <h6 className={typography.heading6}>Create your account</h6>
                 <TextField
                   label="Email"
                   value={state.email}
@@ -377,16 +407,21 @@ export function Login(props: LoginProps): React.JSX.Element {
                   value={state.password}
                   onChange={onPasswordChanged}
                   type="password"
-                  autoComplete="current-password"
+                  autoComplete="new-password"
                   margin="normal"
                   variant="standard"
                   error={state.passwordError !== undefined}
                   helperText={state.passwordError}
                   fullWidth
                 />
+                <p className={typography.body2}>
+                  <TextLink underline="hover" onClick={onSignInInstead}>
+                    Already have an account? Sign in instead
+                  </TextLink>
+                </p>
               </CardContent>
               <CardActions>
-                <Button style={{ marginLeft: 'auto' }} onClick={onEmailCancel}>
+                <Button style={{ marginLeft: 'auto' }} onClick={onCancel}>
                   Cancel
                 </Button>
                 <Button type="submit" variant="contained" onClick={onSubmitNewUser}>
@@ -397,43 +432,7 @@ export function Login(props: LoginProps): React.JSX.Element {
           </Card>
         );
         break;
-      case 'showProviderRedirect': {
-        const provider = state.provider === 'google.com' ? 'Google' : 'Apple';
-        loginUI = (
-          <Card variant="outlined" className={styles.emailForm}>
-            <form onSubmit={onNullSubmit}>
-              <CardContent>
-                <h6 className={typography.heading6}>Sign in - you already have an account</h6>
-                <p className={styles.recoverInstructions}>
-                  You've already used {provider} to sign up with <b>{state.email}</b>. Sign in with {provider} to
-                  continue.
-                </p>
-                {/* The "Sign in with {provider}" button calls googleLoginClick /
-                 * appleLoginClick, whose signInWithRedirect rejection is surfaced
-                 * via emailError -- render it here so the failure is visible (this
-                 * card has no helperText-bearing TextField like the other flows). */}
-                {state.emailError !== undefined && (
-                  <p role="alert" className={typography.body2}>
-                    {state.emailError}
-                  </p>
-                )}
-              </CardContent>
-              <CardActions>
-                <Button
-                  style={{ marginLeft: 'auto' }}
-                  type="submit"
-                  variant="contained"
-                  onClick={state.provider === 'google.com' ? googleLoginClick : appleLoginClick}
-                >
-                  Sign in with {provider}
-                </Button>
-              </CardActions>
-            </form>
-          </Card>
-        );
-        break;
-      }
-      case 'showRecover':
+      case 'recover':
         loginUI = (
           <Card variant="outlined" className={styles.emailForm}>
             <form onSubmit={onNullSubmit}>
@@ -456,7 +455,7 @@ export function Login(props: LoginProps): React.JSX.Element {
                 />
               </CardContent>
               <CardActions>
-                <Button style={{ marginLeft: 'auto' }} onClick={onEmailCancel}>
+                <Button style={{ marginLeft: 'auto' }} onClick={onCancel}>
                   Cancel
                 </Button>
                 <Button type="submit" variant="contained" onClick={onSubmitRecovery}>
@@ -464,6 +463,24 @@ export function Login(props: LoginProps): React.JSX.Element {
                 </Button>
               </CardActions>
             </form>
+          </Card>
+        );
+        break;
+      case 'recoverSent':
+        loginUI = (
+          <Card variant="outlined" className={styles.emailForm}>
+            <CardContent>
+              <h6 className={typography.heading6}>Check your email</h6>
+              <p className={styles.recoverInstructions}>
+                If an account exists for <b>{state.email}</b>, we&apos;ve sent password-reset instructions. Follow the
+                link in that email to choose a new password.
+              </p>
+            </CardContent>
+            <CardActions>
+              <Button style={{ marginLeft: 'auto' }} variant="contained" onClick={onRecoverDone}>
+                Done
+              </Button>
+            </CardActions>
           </Card>
         );
         break;
@@ -491,8 +508,8 @@ export function Login(props: LoginProps): React.JSX.Element {
             </Button>
             {/* Visible error sink for OAuth click handlers. Without this, a
              * rejected signInWithRedirect (popup blocked, provider misconfig,
-             * network failure) would set emailError but stay invisible until
-             * the user enters the email-flow path. */}
+             * network failure) would set emailError but stay invisible because
+             * no email-flow card is mounted to render it. */}
             {state.emailError !== undefined && (
               <p role="alert" className={typography.body2}>
                 {state.emailError}

--- a/src/app/tests/login.test.tsx
+++ b/src/app/tests/login.test.tsx
@@ -2,10 +2,14 @@
 // Use of this source code is governed by the Apache License,
 // Version 2.0, that can be found in the LICENSE file.
 
-// Mock @firebase/auth so we can drive signInWithRedirect to either resolve
-// or reject without involving the real Firebase SDK. The mock factory must
-// not reference outer-scope variables (jest hoists it), so we wire up
-// per-test behavior via jest.requireMock below.
+// Mock @firebase/auth so we can drive the auth calls to resolve or reject
+// without involving the real Firebase SDK. The mock factory must not reference
+// outer-scope variables (jest hoists it), so we wire up per-test behavior via
+// jest.requireMock below.
+//
+// fetchSignInMethodsForEmail is intentionally still mocked even though the
+// component no longer uses it: that lets us assert the redesigned flow never
+// reaches for the deprecated, enumeration-leaking API again (issue #692).
 
 jest.mock(
   '@firebase/auth',
@@ -41,7 +45,8 @@ jest.mock(
       ...rest
     }: { children?: React.ReactNode; onClick?: () => void } & Record<string, unknown>) => {
       // Strip non-DOM props (variant, color, startIcon, etc.) before
-      // forwarding so React doesn't warn. We only care about onClick + text.
+      // forwarding so React doesn't warn. We keep `type` so a test can assert
+      // the primary action stays a submit button (browser Enter-to-submit).
       const dom: Record<string, unknown> = {};
       const passthroughKeys = ['type', 'className', 'id', 'disabled'];
       for (const k of passthroughKeys) {
@@ -99,24 +104,52 @@ jest.mock(
 import * as React from 'react';
 import { render, fireEvent, screen, waitFor } from '@testing-library/react';
 
-import { Login } from '../Login';
+import { Login, GoogleIcon } from '../Login';
 
 const firebaseAuth = jest.requireMock('@firebase/auth') as {
   signInWithRedirect: jest.Mock;
   fetchSignInMethodsForEmail: jest.Mock;
   sendPasswordResetEmail: jest.Mock;
+  signInWithEmailAndPassword: jest.Mock;
+  createUserWithEmailAndPassword: jest.Mock;
+  updateProfile: jest.Mock;
 };
 
 function makeAuth() {
-  // The component only forwards `auth` to firebase; the signInWithRedirect mock
-  // ignores it. A bare object is sufficient.
+  // The component only forwards `auth` to firebase; the mocks ignore it. A bare
+  // object is sufficient.
   return {} as unknown as import('@firebase/auth').Auth;
 }
 
-describe('Login OAuth click handlers', () => {
-  beforeEach(() => {
-    firebaseAuth.signInWithRedirect.mockReset();
-  });
+/** A Firebase-shaped error: an Error carrying a string `code`. */
+function firebaseError(code: string, message = code): Error {
+  const err = new Error(message) as Error & { code: string };
+  err.code = code;
+  return err;
+}
+
+function resetAllMocks(): void {
+  firebaseAuth.signInWithRedirect.mockReset();
+  firebaseAuth.fetchSignInMethodsForEmail.mockReset();
+  firebaseAuth.sendPasswordResetEmail.mockReset();
+  firebaseAuth.signInWithEmailAndPassword.mockReset();
+  firebaseAuth.createUserWithEmailAndPassword.mockReset();
+  firebaseAuth.updateProfile.mockReset();
+}
+
+/** Drive the UI from the landing screen into the combined sign-in card. */
+function openSignInCard(email?: string, password?: string): void {
+  fireEvent.click(screen.getByText('Sign in with email'));
+  if (email !== undefined) {
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: email } });
+  }
+  if (password !== undefined) {
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: password } });
+  }
+}
+
+describe('Login OAuth click handlers (landing)', () => {
+  beforeEach(resetAllMocks);
 
   test('Google sign-in surfaces an error to UI when signInWithRedirect rejects', async () => {
     firebaseAuth.signInWithRedirect.mockRejectedValueOnce(new Error('popup blocked'));
@@ -124,11 +157,6 @@ describe('Login OAuth click handlers', () => {
     render(<Login disabled={false} auth={makeAuth()} />);
     fireEvent.click(screen.getByText('Sign in with Google'));
 
-    // The error must surface visibly. We use the user-facing error text so
-    // we're not coupled to internal state. Login renders helperText for
-    // emailError on the email-flow forms; since the OAuth failure happens
-    // before any form is shown, we expect the error to be reachable from
-    // the rendered DOM via a text query.
     await waitFor(() => {
       expect(firebaseAuth.signInWithRedirect).toHaveBeenCalledTimes(1);
       expect(screen.queryByText(/popup blocked/i)).not.toBeNull();
@@ -158,9 +186,6 @@ describe('Login OAuth click handlers', () => {
     render(<Login disabled={false} auth={makeAuth()} />);
     fireEvent.click(screen.getByText('Sign in with Google'));
 
-    // The handler must call signInWithRedirect synchronously (or via a
-    // microtask), not deferred to a setTimeout. Without setTimeout(0), the
-    // call fires immediately on click.
     await waitFor(() => {
       expect(firebaseAuth.signInWithRedirect).toHaveBeenCalledTimes(1);
     });
@@ -169,94 +194,487 @@ describe('Login OAuth click handlers', () => {
   });
 });
 
-describe('Login showProviderRedirect flow', () => {
-  beforeEach(() => {
-    firebaseAuth.signInWithRedirect.mockReset();
-    firebaseAuth.fetchSignInMethodsForEmail.mockReset();
-  });
+describe('Login combined sign-in card', () => {
+  beforeEach(resetAllMocks);
 
-  test('renders the OAuth error visibly in the "you already have an account" card', async () => {
-    // Drive the component into the provider-redirect card through observable
-    // behavior: an email whose only sign-in method is google.com lands on the
-    // "you already have an account" card, and clicking "Sign in with Google"
-    // there rejects from signInWithRedirect. The card has no helperText-bearing
-    // TextField, so the OAuth error must be rendered explicitly (role=alert).
-    firebaseAuth.fetchSignInMethodsForEmail.mockResolvedValueOnce(['google.com']);
-    firebaseAuth.signInWithRedirect.mockRejectedValueOnce(new Error('popup blocked by browser'));
-
+  test('"Sign in with email" shows email AND password immediately, with no prefetch step', () => {
     render(<Login disabled={false} auth={makeAuth()} />);
     fireEvent.click(screen.getByText('Sign in with email'));
-    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a@example.com' } });
-    fireEvent.click(screen.getByText('Next'));
 
-    // Now on the provider-redirect card.
+    // Combined card: both fields present at once, no intermediate "Next".
+    expect(screen.getByLabelText('Email')).not.toBeNull();
+    expect(screen.getByLabelText('Password')).not.toBeNull();
+    expect(screen.queryByText('Next')).toBeNull();
+    // The deprecated, enumeration-leaking API must never be consulted.
+    expect(firebaseAuth.fetchSignInMethodsForEmail).not.toHaveBeenCalled();
+  });
+
+  test('submitting credentials calls signInWithEmailAndPassword and never fetchSignInMethodsForEmail', async () => {
+    firebaseAuth.signInWithEmailAndPassword.mockResolvedValueOnce({ user: {} });
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('a@example.com', 'hunter2');
+    fireEvent.click(screen.getByText('Sign in'));
+
     await waitFor(() => {
-      expect(screen.queryByText(/you already have an account/i)).not.toBeNull();
+      expect(firebaseAuth.signInWithEmailAndPassword).toHaveBeenCalledTimes(1);
     });
+    expect(firebaseAuth.signInWithEmailAndPassword).toHaveBeenCalledWith(expect.anything(), 'a@example.com', 'hunter2');
+    expect(firebaseAuth.fetchSignInMethodsForEmail).not.toHaveBeenCalled();
+  });
+
+  test('the "Sign in" action is a submit button so Enter-to-submit works in the browser', () => {
+    // jsdom does not simulate implicit form submission on Enter, so we assert
+    // the structural enabler instead: the primary action is type="submit"
+    // inside the form, which is what makes the browser fire it on Enter.
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard();
+    expect(screen.getByText('Sign in').getAttribute('type')).toBe('submit');
+  });
+
+  test('Cancel is not a submit button (so Enter triggers Sign in, not Cancel)', () => {
+    // Implicit form submission fires the FIRST submit button in tree order, and
+    // Cancel precedes "Sign in" in the DOM. If Cancel were a submit button,
+    // pressing Enter would bounce the user back to the landing screen.
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard();
+    expect(screen.getByText('Cancel').getAttribute('type')).not.toBe('submit');
+  });
+
+  test('transient sign-in failures are reported as transient, not as wrong credentials', async () => {
+    // auth/network-request-failed and auth/too-many-requests are returned
+    // regardless of whether the account exists, so they neither leak existence
+    // nor should be misreported as a bad password.
+    for (const code of ['auth/network-request-failed', 'auth/too-many-requests']) {
+      firebaseAuth.signInWithEmailAndPassword.mockReset();
+      firebaseAuth.signInWithEmailAndPassword.mockRejectedValueOnce(firebaseError(code));
+
+      const { unmount } = render(<Login disabled={false} auth={makeAuth()} />);
+      openSignInCard('a@example.com', 'hunter2');
+      fireEvent.click(screen.getByText('Sign in'));
+
+      await waitFor(() => {
+        expect(screen.getByRole('alert').textContent).toMatch(/try again/i);
+      });
+      expect(screen.getByRole('alert').textContent).not.toMatch(/incorrect email or password/i);
+      unmount();
+    }
+  });
+
+  test('auth/invalid-credential shows a generic error and stays on the sign-in card', async () => {
+    firebaseAuth.signInWithEmailAndPassword.mockRejectedValueOnce(firebaseError('auth/invalid-credential'));
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('a@example.com', 'wrong');
+    fireEvent.click(screen.getByText('Sign in'));
+
+    await waitFor(() => {
+      // Generic, enumeration-safe copy announced via role=alert.
+      expect(screen.getByRole('alert').textContent).toMatch(/incorrect email or password/i);
+    });
+    // Still on the sign-in card with both fields and the recovery affordance.
+    expect(screen.getByLabelText('Password')).not.toBeNull();
+    expect(screen.queryByText('Trouble signing in?')).not.toBeNull();
+    // Does NOT auto-route to the signup card (no enumeration leak): the signup
+    // card's "Save" action must be absent.
+    expect(screen.queryByText('Save')).toBeNull();
+  });
+
+  test('a thrown error without a Firebase code falls back to the generic credential error', async () => {
+    firebaseAuth.signInWithEmailAndPassword.mockRejectedValueOnce(new Error('network is down'));
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('a@example.com', 'whatever');
+    fireEvent.click(screen.getByText('Sign in'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toMatch(/incorrect email or password/i);
+    });
+  });
+
+  test('auth/invalid-email shows a distinct email-format error', async () => {
+    firebaseAuth.signInWithEmailAndPassword.mockRejectedValueOnce(firebaseError('auth/invalid-email'));
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('not-an-email', 'whatever');
+    fireEvent.click(screen.getByText('Sign in'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toMatch(/valid email/i);
+    });
+  });
+
+  test('empty email is rejected before calling firebase', async () => {
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('', 'hunter2');
+    fireEvent.click(screen.getByText('Sign in'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/enter your email address/i)).not.toBeNull();
+    });
+    expect(firebaseAuth.signInWithEmailAndPassword).not.toHaveBeenCalled();
+  });
+
+  test('empty password is rejected before calling firebase', async () => {
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('a@example.com', '');
+    fireEvent.click(screen.getByText('Sign in'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/enter (your|a) password/i)).not.toBeNull();
+    });
+    expect(firebaseAuth.signInWithEmailAndPassword).not.toHaveBeenCalled();
+  });
+
+  test('editing either field clears the credential error', async () => {
+    firebaseAuth.signInWithEmailAndPassword.mockRejectedValueOnce(firebaseError('auth/invalid-credential'));
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('a@example.com', 'wrong');
+    fireEvent.click(screen.getByText('Sign in'));
+    await waitFor(() => {
+      expect(screen.queryByText(/incorrect email or password/i)).not.toBeNull();
+    });
+
+    // Editing the EMAIL field (not just the password) clears the combined error.
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'b@example.com' } });
+    expect(screen.queryByText(/incorrect email or password/i)).toBeNull();
+  });
+
+  test('Cancel returns to the landing screen where the provider buttons live', () => {
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard();
+    fireEvent.click(screen.getByText('Cancel'));
+
     expect(screen.queryByText('Sign in with Google')).not.toBeNull();
-
-    fireEvent.click(screen.getByText('Sign in with Google'));
-
-    await waitFor(() => {
-      expect(screen.getByRole('alert').textContent).toMatch(/popup blocked by browser/i);
-    });
+    expect(screen.queryByText('Sign in with Apple')).not.toBeNull();
   });
 });
 
-describe('Login email-flow error handling', () => {
-  beforeEach(() => {
-    firebaseAuth.fetchSignInMethodsForEmail.mockReset();
-    firebaseAuth.sendPasswordResetEmail.mockReset();
+describe('Login create-account flow', () => {
+  beforeEach(resetAllMocks);
+
+  test('"Create account" opens the signup card carrying the typed email', () => {
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('new@example.com');
+    fireEvent.click(screen.getByText('Create account'));
+
+    // On the signup card, identified by its signup-only "Save" action and name field.
+    expect(screen.queryByText('Save')).not.toBeNull();
+    expect(screen.getByLabelText(/name/i)).not.toBeNull();
+    // Email carried over into the signup card.
+    expect((screen.getByLabelText('Email') as HTMLInputElement).value).toBe('new@example.com');
   });
 
-  test('a rejected fetchSignInMethodsForEmail surfaces a visible error', async () => {
-    firebaseAuth.fetchSignInMethodsForEmail.mockRejectedValueOnce(new Error('too many requests'));
+  test('saving a new account calls createUserWithEmailAndPassword and sets the display name', async () => {
+    const fakeUser = { uid: 'abc' };
+    firebaseAuth.createUserWithEmailAndPassword.mockResolvedValueOnce({ user: fakeUser });
+    firebaseAuth.updateProfile.mockResolvedValueOnce(undefined);
 
     render(<Login disabled={false} auth={makeAuth()} />);
-    fireEvent.click(screen.getByText('Sign in with email'));
-    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a@example.com' } });
-    fireEvent.click(screen.getByText('Next'));
+    openSignInCard('new@example.com');
+    fireEvent.click(screen.getByText('Create account'));
+
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Ada Lovelace' } });
+    fireEvent.change(screen.getByLabelText('Choose password'), { target: { value: 's3cret!' } });
+    fireEvent.click(screen.getByText('Save'));
 
     await waitFor(() => {
-      expect(screen.queryByText(/too many requests/i)).not.toBeNull();
+      expect(firebaseAuth.createUserWithEmailAndPassword).toHaveBeenCalledWith(
+        expect.anything(),
+        'new@example.com',
+        's3cret!',
+      );
+      expect(firebaseAuth.updateProfile).toHaveBeenCalledWith(fakeUser, { displayName: 'Ada Lovelace' });
     });
   });
 
-  test('a rejected sendPasswordResetEmail keeps the recovery card with a visible error', async () => {
-    firebaseAuth.fetchSignInMethodsForEmail.mockResolvedValueOnce(['password']);
-    firebaseAuth.sendPasswordResetEmail.mockRejectedValueOnce(new Error('quota exceeded'));
+  test('email-already-in-use shows a friendly message with a path back to sign-in', async () => {
+    firebaseAuth.createUserWithEmailAndPassword.mockRejectedValueOnce(firebaseError('auth/email-already-in-use'));
 
     render(<Login disabled={false} auth={makeAuth()} />);
-    fireEvent.click(screen.getByText('Sign in with email'));
-    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a@example.com' } });
-    fireEvent.click(screen.getByText('Next'));
+    openSignInCard('taken@example.com');
+    fireEvent.click(screen.getByText('Create account'));
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Someone' } });
+    fireEvent.change(screen.getByLabelText('Choose password'), { target: { value: 's3cret!' } });
+    fireEvent.click(screen.getByText('Save'));
+
     await waitFor(() => {
-      expect(screen.queryByText('Trouble signing in?')).not.toBeNull();
+      expect(screen.queryByText(/already exists/i)).not.toBeNull();
     });
 
+    // The friendly "sign in instead" affordance returns to the combined card.
+    fireEvent.click(screen.getByText(/sign in instead/i));
+    expect(screen.getByLabelText('Password')).not.toBeNull();
+    expect(screen.queryByText('Save')).toBeNull();
+  });
+});
+
+describe('Login password-recovery flow', () => {
+  beforeEach(resetAllMocks);
+
+  test('"Trouble signing in?" then Send shows a neutral, enumeration-safe confirmation', async () => {
+    firebaseAuth.sendPasswordResetEmail.mockResolvedValueOnce(undefined);
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('a@example.com');
     fireEvent.click(screen.getByText('Trouble signing in?'));
     fireEvent.click(screen.getByText('Send'));
 
     await waitFor(() => {
-      // Still on the recovery card (it did NOT advance to the password form)
-      // and the failure is visible.
+      expect(firebaseAuth.sendPasswordResetEmail).toHaveBeenCalledWith(expect.anything(), 'a@example.com');
+      // Neutral confirmation: does not confirm whether the account exists.
+      expect(screen.queryByText(/if an account exists/i)).not.toBeNull();
+    });
+    expect(screen.queryByText(/a@example.com/)).not.toBeNull();
+  });
+
+  test('a rejected sendPasswordResetEmail keeps the recovery card with a visible error', async () => {
+    firebaseAuth.sendPasswordResetEmail.mockRejectedValueOnce(new Error('quota exceeded'));
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('a@example.com');
+    fireEvent.click(screen.getByText('Trouble signing in?'));
+    fireEvent.click(screen.getByText('Send'));
+
+    await waitFor(() => {
+      // Still on the recovery card (did NOT advance to the confirmation) and
+      // the failure is visible.
       expect(screen.queryByText('Recover password')).not.toBeNull();
       expect(screen.queryByText(/quota exceeded/i)).not.toBeNull();
     });
+    expect(screen.queryByText(/if an account exists/i)).toBeNull();
   });
 
-  test('editing the email field clears a stale email error', async () => {
-    render(<Login disabled={false} auth={makeAuth()} />);
-    fireEvent.click(screen.getByText('Sign in with email'));
+  test('Done on the confirmation returns to the sign-in card with no stale error', async () => {
+    firebaseAuth.sendPasswordResetEmail.mockResolvedValueOnce(undefined);
 
-    // Submit with an empty email to produce a validation error.
-    fireEvent.click(screen.getByText('Next'));
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('a@example.com');
+    fireEvent.click(screen.getByText('Trouble signing in?'));
+    fireEvent.click(screen.getByText('Send'));
     await waitFor(() => {
-      expect(screen.queryByText(/Enter your email address/i)).not.toBeNull();
+      expect(screen.queryByText(/if an account exists/i)).not.toBeNull();
     });
 
-    // Typing into the field must clear the stale message.
+    fireEvent.click(screen.getByText('Done'));
+    // Back on the combined sign-in card.
+    expect(screen.getByLabelText('Password')).not.toBeNull();
+    expect(screen.queryByText('Sign in')).not.toBeNull();
+    expect(screen.queryByText(/if an account exists/i)).toBeNull();
+  });
+});
+
+describe('Login field-error clearing', () => {
+  beforeEach(resetAllMocks);
+
+  test('editing the email field clears a stale validation error', async () => {
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('', '');
+
+    fireEvent.click(screen.getByText('Sign in'));
+    await waitFor(() => {
+      expect(screen.queryByText(/enter your email address/i)).not.toBeNull();
+    });
+
     fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a' } });
-    expect(screen.queryByText(/Enter your email address/i)).toBeNull();
+    expect(screen.queryByText(/enter your email address/i)).toBeNull();
+  });
+});
+
+describe('Login signup validation and error mapping', () => {
+  beforeEach(resetAllMocks);
+
+  function openSignupCard(): void {
+    openSignInCard();
+    fireEvent.click(screen.getByText('Create account'));
+  }
+
+  test('empty email is rejected before calling firebase', async () => {
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignupCard();
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/enter your email address/i)).not.toBeNull();
+    });
+    expect(firebaseAuth.createUserWithEmailAndPassword).not.toHaveBeenCalled();
+  });
+
+  test('empty name is rejected before calling firebase', async () => {
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignupCard();
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a@example.com' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/enter your name/i)).not.toBeNull();
+    });
+    expect(firebaseAuth.createUserWithEmailAndPassword).not.toHaveBeenCalled();
+  });
+
+  test('empty password is rejected before calling firebase', async () => {
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignupCard();
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a@example.com' } });
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Someone' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/enter a password/i)).not.toBeNull();
+    });
+    expect(firebaseAuth.createUserWithEmailAndPassword).not.toHaveBeenCalled();
+  });
+
+  test('auth/weak-password maps to a specific password hint', async () => {
+    firebaseAuth.createUserWithEmailAndPassword.mockRejectedValueOnce(firebaseError('auth/weak-password'));
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignupCard();
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a@example.com' } });
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Someone' } });
+    fireEvent.change(screen.getByLabelText('Choose password'), { target: { value: '123' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/at least 6 characters/i)).not.toBeNull();
+    });
+  });
+
+  test('auth/invalid-email maps to an email-format error', async () => {
+    firebaseAuth.createUserWithEmailAndPassword.mockRejectedValueOnce(firebaseError('auth/invalid-email'));
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignupCard();
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'bogus' } });
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Someone' } });
+    fireEvent.change(screen.getByLabelText('Choose password'), { target: { value: 's3cret!' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/valid email/i)).not.toBeNull();
+    });
+  });
+
+  test('an unknown signup error surfaces its message', async () => {
+    firebaseAuth.createUserWithEmailAndPassword.mockRejectedValueOnce(new Error('quota for new users exceeded'));
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignupCard();
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a@example.com' } });
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Someone' } });
+    fireEvent.change(screen.getByLabelText('Choose password'), { target: { value: 's3cret!' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/quota for new users exceeded/i)).not.toBeNull();
+    });
+  });
+});
+
+describe('Login miscellaneous error paths', () => {
+  beforeEach(resetAllMocks);
+
+  test('empty email on the recovery card is rejected before calling firebase', async () => {
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard();
+    fireEvent.click(screen.getByText('Trouble signing in?'));
+    fireEvent.click(screen.getByText('Send'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/enter your email address/i)).not.toBeNull();
+    });
+    expect(firebaseAuth.sendPasswordResetEmail).not.toHaveBeenCalled();
+  });
+
+  test('a non-Error thrown by sign-in still yields the generic credential error', async () => {
+    // A thrown non-object (no `code`, not an Error) must still be handled.
+    firebaseAuth.signInWithEmailAndPassword.mockRejectedValueOnce('catastrophe');
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('a@example.com', 'whatever');
+    fireEvent.click(screen.getByText('Sign in'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert').textContent).toMatch(/incorrect email or password/i);
+    });
+  });
+
+  test('a non-Error OAuth rejection falls back to a generic provider message', async () => {
+    firebaseAuth.signInWithRedirect.mockRejectedValueOnce('nope');
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    fireEvent.click(screen.getByText('Sign in with Google'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/sign in with google failed/i)).not.toBeNull();
+    });
+  });
+
+  test('a non-Error Apple OAuth rejection falls back to a generic provider message', async () => {
+    firebaseAuth.signInWithRedirect.mockRejectedValueOnce('nope');
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    fireEvent.click(screen.getByText('Sign in with Apple'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/sign in with apple failed/i)).not.toBeNull();
+    });
+  });
+
+  test('a non-Error recovery rejection falls back to a generic message', async () => {
+    firebaseAuth.sendPasswordResetEmail.mockRejectedValueOnce('boom');
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('a@example.com');
+    fireEvent.click(screen.getByText('Trouble signing in?'));
+    fireEvent.click(screen.getByText('Send'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/sending the recovery email failed/i)).not.toBeNull();
+    });
+  });
+
+  test('a non-Error signup rejection falls back to a generic message', async () => {
+    firebaseAuth.createUserWithEmailAndPassword.mockRejectedValueOnce('boom');
+
+    render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard();
+    fireEvent.click(screen.getByText('Create account'));
+    fireEvent.change(screen.getByLabelText('Email'), { target: { value: 'a@example.com' } });
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'Someone' } });
+    fireEvent.change(screen.getByLabelText('Choose password'), { target: { value: 's3cret!' } });
+    fireEvent.click(screen.getByText('Save'));
+
+    await waitFor(() => {
+      expect(screen.queryByText(/something unknown went wrong/i)).not.toBeNull();
+    });
+  });
+
+  test('GoogleIcon renders (it is dropped by the Button startIcon mock in flow tests)', () => {
+    const { container } = render(<GoogleIcon />);
+    expect(container.querySelector('[data-component="SvgIcon"]')).not.toBeNull();
+  });
+});
+
+describe('Login rendering guards', () => {
+  beforeEach(resetAllMocks);
+
+  test('when disabled, no login UI is rendered', () => {
+    render(<Login disabled={true} auth={makeAuth()} />);
+    expect(screen.queryByText('Sign in with Google')).toBeNull();
+    expect(screen.queryByText('Sign in with email')).toBeNull();
+  });
+
+  test('the form onSubmit is a no-op guard (submission does not itself sign in)', () => {
+    // The browser fires the submit button's onClick on Enter; the form's own
+    // onSubmit just preventDefaults so the page never navigates. A raw form
+    // submit therefore must not call into firebase.
+    const { container } = render(<Login disabled={false} auth={makeAuth()} />);
+    openSignInCard('a@example.com', 'hunter2');
+    const form = container.querySelector('form');
+    expect(form).not.toBeNull();
+    fireEvent.submit(form as HTMLFormElement);
+    expect(firebaseAuth.signInWithEmailAndPassword).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
Closes #692.

## Problem

The email login flow in `src/app/Login.tsx` decided which card to show by calling Firebase's **deprecated** `fetchSignInMethodsForEmail` and branching on the returned methods. That API was deprecated precisely because it enables email enumeration, and it carries a latent footgun:

When a project enables **Email Enumeration Protection** (a single Firebase-console toggle Firebase recommends, default-ON for projects created after 2023-09-15), `fetchSignInMethodsForEmail` returns `[]` for *every* address. The old flow read that as "no account exists" and routed **every existing email/password user** to the "Create account" card, where signup then failed with `auth/email-already-in-use` — with no in-UI path to the password card or the "Trouble signing in?" recovery link. Enabling a recommended security setting would have silently and completely locked out all email/password users.

## Fix

Replace the method-prefetch router with a single **combined sign-in card** (email + password together) that attempts `signInWithEmailAndPassword` directly and branches on the Firebase error *code*. The flow is now correct whether Enumeration Protection is on or off:

- `invalid-credential` / `wrong-password` / `user-not-found` and any non-Firebase throw collapse to one generic, enumeration-safe message; `invalid-email` gets a distinct message.
- `network-request-failed` / `too-many-requests` are account-agnostic (they leak nothing), so they report a transient "try again" message instead of masquerading as a bad password.
- Password reset shows a **neutral** confirmation ("If an account exists for …") so it stays enumeration-safe even though `sendPasswordResetEmail` silently succeeds for unknown addresses.
- New users reach signup via an always-present "Create account" link rather than auto-routing on `user-not-found` (which would itself leak existence when protection is off).

### Known tradeoff

Removing the prefetch means we can no longer name *which* provider an OAuth-only user signed up with — a wrong password and an OAuth-only account are indistinguishable under protection. The provider-named "you already have an account" redirect card is therefore gone; such users get the generic message and the Apple/Google buttons remain one "Cancel" away on the landing screen. This is inherent to removing enumeration (you can't hide which provider an email uses *and* name it).

## Scope

`Login.tsx` only drives the Firebase client SDK into a signed-in state; `App.tsx`'s `onAuthStateChanged` observer still handles the `idToken` → `POST /session` handoff, so the change is confined to `Login.tsx` and its tests.

## Testing

- 37 tests in `src/app/tests/login.test.tsx`, **100% statement/branch/function/line coverage** on `Login.tsx`.
- Covers: combined card renders both fields with no prefetch; `fetchSignInMethodsForEmail` never called in any path; each error-code branch (incl. transient and non-Firebase throws); create-account + `email-already-in-use` → "sign in instead"; recovery → neutral confirmation and failure-stays-with-error; Enter-to-submit structural guard (Sign in is `type=submit`, Cancel is not); cross-card error clearing; disabled render guard.
- Full pre-commit gate (build, tsc, clippy, rust+python+ts tests, lint) passes.

## Process

Design brainstormed, then adversarially reviewed by a sub-agent before implementation; the completed change was adversarially reviewed by a second fresh sub-agent and iterated to a clean "ship" verdict.

## Note (out of scope)

Passwords are `.trim()`'d before being sent to Firebase on both sign-in and signup (pre-existing on `main`, carried forward unchanged). It's consistent between the two paths, but altering passwords with intentional leading/trailing whitespace is latent; flagging for a possible follow-up.