### PR TITLE
engine: defend ltm feeder slot pin and agg source slices

### DIFF
--- a/src/simlin-engine/src/db/ltm_unified_tests.rs
+++ b/src/simlin-engine/src/db/ltm_unified_tests.rs
@@ -4625,3 +4625,76 @@ fn scalar_target_reducer_variants_fragments_compile() {
         assert_agg_fragments_compile(eqn, &failures);
     }
 }
+
+/// PR #784 review (P3): a degenerate SQUARE-source agg -- a reducer whose
+/// iterated axes carry the SAME target dim twice (`x[D1] =
+/// 1 + SUM(cube[D1,D1,*] * frac[D1,D1])`, `result_dims == ["D1","D1"]`)
+/// with a square projection feeder (`frac[D1,D1]`) -- must NOT emit the
+/// feeder's per-`(row, slot)` changed-last scores: the per-slot equation
+/// pins each reducer-text index BY DIM NAME, which is ambiguous for the
+/// duplicated dim (pre-fix, every `d1` occurrence pinned to the FIRST slot
+/// part, so the off-diagonal slot `[r1,r2]` froze `frac[r1,r1]` -- a
+/// silently wrong score). The rows are loudly skipped instead
+/// (`emit_ltm_partial_equation_warning`, the GH #743 unfreezable
+/// machinery), mirroring `resolve_mismatched_index_position`'s uniqueness
+/// defense on the co-source body path.
+#[test]
+fn square_source_duplicate_dim_feeder_scores_are_loudly_skipped() {
+    let project = TestProject::new("square_feeder")
+        .with_sim_time(0.0, 5.0, 1.0)
+        .named_dimension("D1", &["R1", "R2"])
+        .named_dimension("D2", &["C1", "C2"])
+        .array_aux("cube[D1,D1,D2]", "1")
+        .array_aux("frac[D1,D1]", "0.0001 * pop[D1]")
+        .array_stock("pop[D1]", "100", &["x"], &[], None)
+        .array_flow("x[D1]", "1 + SUM(cube[D1, D1, *] * frac[D1, D1])", None);
+    let datamodel = project.build_datamodel();
+    let db = SimlinDb::default();
+    let sync = sync_from_datamodel(&db, &datamodel);
+    let model = sync.models["main"].source;
+
+    // Sanity: the square feeder really is accepted as an iterated-dim
+    // projection feeder of the minted synthetic agg (the shape under test
+    // reaches the feeder emitter at all).
+    let aggs = crate::ltm_agg::enumerate_agg_nodes(&db, model, sync.project);
+    let agg = aggs
+        .aggs
+        .iter()
+        .find(|a| a.is_synthetic)
+        .expect("the inline square-source reducer must mint a synthetic agg");
+    assert_eq!(agg.result_dims, vec!["D1", "D1"]);
+    assert!(agg.source_is_projection_feeder("frac"));
+
+    let ltm = model_ltm_variables(&db, model, sync.project);
+    let feeder_prefix = "$\u{205A}ltm\u{205A}link_score\u{205A}frac[";
+    let feeder_vars: Vec<&str> = ltm
+        .vars
+        .iter()
+        .filter(|v| v.name.starts_with(feeder_prefix))
+        .map(|v| v.name.as_str())
+        .collect();
+    assert!(
+        feeder_vars.is_empty(),
+        "ambiguous duplicate-dim slot pins must be loudly skipped, not \
+         emitted with the wrong row frozen; got: {feeder_vars:?}"
+    );
+
+    // The skip is loud: one UnfreezablePartial warning per skipped row,
+    // naming the feeder link-score variable.
+    let diags = model_ltm_variables::accumulated::<CompilationDiagnostic>(&db, model, sync.project);
+    let has_feeder_warning = diags.iter().any(|CompilationDiagnostic(d)| {
+        d.severity == DiagnosticSeverity::Warning
+            && d.variable
+                .as_deref()
+                .is_some_and(|v| v.starts_with(feeder_prefix))
+            && matches!(
+                &d.error,
+                DiagnosticError::Assembly(msg) if msg.contains("could not be generated")
+            )
+    });
+    assert!(
+        has_feeder_warning,
+        "the skipped feeder rows must surface a Warning; got: {:?}",
+        diags.iter().map(|c| &c.0).collect::<Vec<_>>()
+    );
+}

--- a/src/simlin-engine/src/ltm_agg.rs
+++ b/src/simlin-engine/src/ltm_agg.rs
@@ -745,6 +745,11 @@ fn walk_var_equation(
         // all-`Iterated` slice (GH #767) says nothing about the reducer's
         // result shape.
         && variable_backed_shape_is_expressible(&slices.canonical, ctx.target_iterated_dims)
+        // `None` (a structurally-impossible missing per-var slice; see
+        // `agg_sources`' rustdoc) falls through to `walk_subexpr_for_aggs`,
+        // whose own `agg_sources` call declines identically -- the
+        // reference stays on the conservative Direct path.
+        && let Some(sources) = agg_sources(source_vars, &slices, ctx)
     {
         // Whole-RHS reducer: the variable IS the aggregate node. The agg
         // node's result shape is the *reducer's* result shape (the `Iterated`
@@ -755,7 +760,6 @@ fn walk_var_equation(
         // (`rowsum[D1] = SUM(matrix[D1, *])`) keeps `[D1]` as its result dims.
         let key = crate::patch::expr2_to_string(expr);
         let result_dims = result_dims_from_read_slice(&slices.canonical, ctx.dm_dims);
-        let sources = agg_sources(source_vars, &slices, ctx);
         register_agg(
             result,
             next_synthetic_n,
@@ -935,10 +939,14 @@ fn walk_subexpr_for_aggs(
             if !in_reducer
                 && let Some(source_vars) = reducer_source_vars(builtin, ctx.variables)
                 && let Some(slices) = combined_read_slice(builtin, ctx)
+                // `None` (a structurally-impossible missing per-var slice;
+                // see `agg_sources`' rustdoc) declines the hoist: the `else`
+                // arm descends with `in_reducer` unchanged, exactly like the
+                // not-statically-describable carve-outs.
+                && let Some(sources) = agg_sources(source_vars, &slices, ctx)
             {
                 let key = crate::patch::expr2_to_string(expr);
                 let result_dims = result_dims_from_read_slice(&slices.canonical, ctx.dm_dims);
-                let sources = agg_sources(source_vars, &slices, ctx);
                 register_agg(
                     result,
                     next_synthetic_n,
@@ -1005,11 +1013,22 @@ enum AggKind {
 /// for a co-source, the all-`Iterated` projection slice for a feeder
 /// (GH #767); each SCALAR source (a feeder, GH #737) carries an empty
 /// slice (it has no axes -- invariant I2).
+///
+/// Returns `None` -- the caller declines the hoist, keeping the reference
+/// on the conservative Direct path -- if an arrayed source has no
+/// `per_var` entry. That cannot happen by construction
+/// (`reducer_source_vars`/`collect_var_refs` and
+/// `collect_arrayed_source_slices` walk the identical reference surface
+/// with the same arrayed predicate), so the decline is purely defensive
+/// (PR #784 review): the previous canonical-slice fallback would have
+/// mislabelled a projection feeder -- whose slice differs from canonical
+/// BY DESIGN -- as a co-source, silently corrupting the per-`(row, slot)`
+/// link scores downstream.
 fn agg_sources(
     source_vars: Vec<String>,
     slices: &CombinedReadSlices,
     ctx: &AggWalkCtx<'_>,
-) -> Vec<AggSource> {
+) -> Option<Vec<AggSource>> {
     // `reducer_source_vars` already sorts + dedups; re-establishing the
     // invariant locally keeps it independent of the caller.
     let mut names = source_vars;
@@ -1025,23 +1044,11 @@ fn agg_sources(
                 .map(|d| !d.is_empty())
                 .unwrap_or(false);
             let read_slice = if arrayed {
-                // Every arrayed source has a per-var entry by construction
-                // (`reducer_source_vars` and `collect_arrayed_source_slices`
-                // walk the same references); the canonical fallback is
-                // defensive only.
-                debug_assert!(
-                    slices.per_var.contains_key(&var),
-                    "arrayed reducer source {var:?} has no accepted slice"
-                );
-                slices
-                    .per_var
-                    .get(&var)
-                    .cloned()
-                    .unwrap_or_else(|| slices.canonical.clone())
+                slices.per_var.get(&var).cloned()?
             } else {
                 Vec::new()
             };
-            AggSource { var, read_slice }
+            Some(AggSource { var, read_slice })
         })
         .collect()
 }
@@ -3924,6 +3931,72 @@ mod tests {
                 .all(|ag| !ag.reads_var("a") && !ag.reads_var("b")),
             "co-sources with differing slices must still decline; got: {:?}",
             result.aggs
+        );
+    }
+
+    /// PR #784 review (P3), purely defensive: every arrayed reducer source
+    /// has a `per_var` slice by construction (`collect_var_refs` and
+    /// `collect_arrayed_source_slices` walk the identical reference
+    /// surface), but if that invariant ever broke, [`agg_sources`] must
+    /// DECLINE the hoist (`None` -- the reference stays on the conservative
+    /// Direct path) rather than silently substituting the CANONICAL slice:
+    /// for a projection feeder (whose slice differs from canonical by
+    /// design, GH #767) that substitution would mislabel the feeder as a
+    /// co-source and corrupt the per-`(row, slot)` link scores downstream.
+    #[test]
+    fn agg_sources_declines_when_arrayed_source_lacks_per_var_slice() {
+        let project = TestProject::new("agg_sources_invariant")
+            .named_dimension("D1", &["r1", "r2"])
+            .array_aux("pop[D1]", "1")
+            .scalar_aux("scale", "2")
+            .scalar_aux("total", "1 + SUM(pop[*] * scale)");
+        let datamodel = project.build_datamodel();
+        let db = SimlinDb::default();
+        let sync = sync_from_datamodel(&db, &datamodel);
+        let model = sync.models["main"].source;
+        let variables = crate::db::reconstruct_model_variables(&db, model, sync.project);
+        let dm_dims = crate::db::project_datamodel_dims(&db, sync.project);
+        let dim_ctx = crate::db::project_dimensions_context(&db, sync.project);
+        let ctx = AggWalkCtx {
+            variables: &variables,
+            target_iterated_dims: &[],
+            dm_dims: dm_dims.as_slice(),
+            dim_ctx,
+        };
+        let canonical = vec![AxisRead::Reduced { subset: None }];
+
+        // The invariant broken by hand: `pop` (arrayed) absent from `per_var`.
+        let broken = CombinedReadSlices {
+            canonical: canonical.clone(),
+            per_var: HashMap::new(),
+        };
+        assert_eq!(
+            agg_sources(vec!["pop".to_string()], &broken, &ctx),
+            None,
+            "a missing per-var slice for an arrayed source must decline the \
+             hoist, never substitute the canonical slice"
+        );
+
+        // The intact invariant: each source carries its own slice; a scalar
+        // source still gets the empty slice.
+        let intact = CombinedReadSlices {
+            canonical: canonical.clone(),
+            per_var: HashMap::from([("pop".to_string(), canonical.clone())]),
+        };
+        let sources = agg_sources(vec!["scale".to_string(), "pop".to_string()], &intact, &ctx)
+            .expect("an intact per-var map must build the sources");
+        assert_eq!(
+            sources,
+            vec![
+                AggSource {
+                    var: "pop".to_string(),
+                    read_slice: canonical,
+                },
+                AggSource {
+                    var: "scale".to_string(),
+                    read_slice: vec![],
+                },
+            ]
         );
     }
 }

--- a/src/simlin-engine/src/ltm_augment.rs
+++ b/src/simlin-engine/src/ltm_augment.rs
@@ -1858,8 +1858,12 @@ pub(crate) fn generate_scalar_feeder_to_agg_equation(
 /// resolution for that slot), then the feeder's references are frozen.
 ///
 /// Returns `Err` when the text does not parse (the GH #311 loud-failure
-/// contract) or when no feeder occurrence was frozen (the numerator would
-/// be a silent constant 0 -- the GH #743 unfreezable contract).
+/// contract), when no feeder occurrence was frozen (the numerator would
+/// be a silent constant 0 -- the GH #743 unfreezable contract), or when a
+/// slot pin is AMBIGUOUS -- a repeated dim name among `iterated_dims` (a
+/// degenerate square-source agg, PR #784 review) makes the by-name index
+/// resolution unable to tell which slot part an index means, so a pinned
+/// equation could freeze the wrong source row (a silently wrong score).
 pub(crate) fn generate_iterated_feeder_to_agg_equation(
     feeder: &str,
     agg_name: &str,
@@ -1870,7 +1874,12 @@ pub(crate) fn generate_iterated_feeder_to_agg_equation(
     let Ok(Some(ast)) = Expr0::new(agg_equation_text, LexerType::Equation) else {
         return Err(PartialEquationError::new(agg_equation_text));
     };
-    let pinned = pin_iterated_dim_indices(ast, iterated_dims, slot_parts_qualified);
+    // An ambiguous slot pin is the GH #743 unfreezable class: the
+    // changed-last convention cannot be rendered as a correct equation, and
+    // the changed-first one was already ruled out (see above). The caller
+    // warns and skips the row.
+    let pinned = pin_iterated_dim_indices(ast, iterated_dims, slot_parts_qualified)
+        .ok_or_else(|| PartialEquationError::unfreezable(agg_equation_text))?;
     let feeder_ident = Ident::<Canonical>::new(feeder);
     let frozen = print_eqn(&wrap_matching_in_previous(pinned.clone(), &feeder_ident));
     if frozen == print_eqn(&pinned) {
@@ -1899,8 +1908,29 @@ pub(crate) fn generate_iterated_feeder_to_agg_equation(
 /// literals, and indices naming other dimensions are left untouched (a
 /// co-source's `Reduced` wildcard must stay a whole-slice read), and
 /// expression indices are recursed into.
-fn pin_iterated_dim_indices(expr: Expr0, dims: &[String], parts: &[String]) -> Expr0 {
-    match expr {
+///
+/// Returns `None` when an index names a dim that occurs MORE THAN ONCE in
+/// `dims` (a degenerate square-source agg whose slot axes repeat a dim,
+/// PR #784 review): the by-name resolution cannot tell which slot part the
+/// index means, and first-match would pin every occurrence to the FIRST
+/// part -- silently freezing the wrong source row for any off-diagonal
+/// slot. Mirrors [`resolve_mismatched_index_position`]'s uniqueness
+/// defense; the caller converts `None` into the loud unfreezable error.
+fn pin_iterated_dim_indices(expr: Expr0, dims: &[String], parts: &[String]) -> Option<Expr0> {
+    /// The unique position of `name` in `dims`: `None` for an ambiguous
+    /// (repeated) dim name, `Some(None)` for a name not in `dims` (left
+    /// untouched), `Some(Some(pos))` for the unambiguous match.
+    fn unique_dim_position(dims: &[String], name: &str) -> Option<Option<usize>> {
+        let mut it = dims
+            .iter()
+            .enumerate()
+            .filter_map(|(i, d)| (d.as_str() == name).then_some(i));
+        match it.next() {
+            None => Some(None),
+            Some(pos) => it.next().is_none().then_some(Some(pos)),
+        }
+    }
+    Some(match expr {
         Expr0::Const(..) | Expr0::Var(..) => expr,
         Expr0::Subscript(ident, indices, loc) => {
             let indices = indices
@@ -1908,20 +1938,20 @@ fn pin_iterated_dim_indices(expr: Expr0, dims: &[String], parts: &[String]) -> E
                 .map(|idx| match idx {
                     IndexExpr0::Expr(Expr0::Var(name, vloc)) => {
                         let n = canonicalize(name.as_str());
-                        match dims.iter().position(|d| d.as_str() == n.as_ref()) {
-                            Some(pos) => IndexExpr0::Expr(Expr0::Var(
+                        match unique_dim_position(dims, n.as_ref())? {
+                            Some(pos) => Some(IndexExpr0::Expr(Expr0::Var(
                                 RawIdent::new_from_str(&parts[pos]),
                                 vloc,
-                            )),
-                            None => IndexExpr0::Expr(Expr0::Var(name, vloc)),
+                            ))),
+                            None => Some(IndexExpr0::Expr(Expr0::Var(name, vloc))),
                         }
                     }
                     IndexExpr0::Expr(e) => {
-                        IndexExpr0::Expr(pin_iterated_dim_indices(e, dims, parts))
+                        Some(IndexExpr0::Expr(pin_iterated_dim_indices(e, dims, parts)?))
                     }
-                    other => other,
+                    other => Some(other),
                 })
-                .collect();
+                .collect::<Option<Vec<_>>>()?;
             Expr0::Subscript(ident, indices, loc)
         }
         Expr0::App(UntypedBuiltinFn(name, args), loc) => Expr0::App(
@@ -1929,28 +1959,28 @@ fn pin_iterated_dim_indices(expr: Expr0, dims: &[String], parts: &[String]) -> E
                 name,
                 args.into_iter()
                     .map(|a| pin_iterated_dim_indices(a, dims, parts))
-                    .collect(),
+                    .collect::<Option<Vec<_>>>()?,
             ),
             loc,
         ),
         Expr0::Op1(op, arg, loc) => Expr0::Op1(
             op,
-            Box::new(pin_iterated_dim_indices(*arg, dims, parts)),
+            Box::new(pin_iterated_dim_indices(*arg, dims, parts)?),
             loc,
         ),
         Expr0::Op2(op, l, r, loc) => Expr0::Op2(
             op,
-            Box::new(pin_iterated_dim_indices(*l, dims, parts)),
-            Box::new(pin_iterated_dim_indices(*r, dims, parts)),
+            Box::new(pin_iterated_dim_indices(*l, dims, parts)?),
+            Box::new(pin_iterated_dim_indices(*r, dims, parts)?),
             loc,
         ),
         Expr0::If(c, t, f, loc) => Expr0::If(
-            Box::new(pin_iterated_dim_indices(*c, dims, parts)),
-            Box::new(pin_iterated_dim_indices(*t, dims, parts)),
-            Box::new(pin_iterated_dim_indices(*f, dims, parts)),
+            Box::new(pin_iterated_dim_indices(*c, dims, parts)?),
+            Box::new(pin_iterated_dim_indices(*t, dims, parts)?),
+            Box::new(pin_iterated_dim_indices(*f, dims, parts)?),
             loc,
         ),
-    }
+    })
 }
 
 /// Replace every bare `Var(id)` reference in `equation_text` where `id`

--- a/src/simlin-engine/src/ltm_augment_tests.rs
+++ b/src/simlin-engine/src/ltm_augment_tests.rs
@@ -3827,6 +3827,27 @@ fn test_generate_iterated_feeder_to_agg_equation_unfreezable_without_occurrence(
     assert_eq!(err.kind, PartialEquationErrorKind::UnfreezablePartial);
 }
 
+/// PR #784 review (P3): a REPEATED dim name among the iterated slot axes
+/// (a degenerate square-source agg, `SUM(cube[d1,d1,*] * frac[d1,d1])`
+/// with slot dims `[d1, d1]`) makes the by-name slot pin ambiguous --
+/// pre-fix, every `d1` index pinned to the FIRST slot part, so the
+/// off-diagonal slot `[r1, r2]` froze `frac[d1·r1, d1·r1]` (the wrong
+/// source row, a silently wrong score). The generator must bail loudly
+/// instead, mirroring `resolve_mismatched_index_position`'s uniqueness
+/// defense.
+#[test]
+fn test_generate_iterated_feeder_to_agg_equation_bails_on_duplicate_dims() {
+    let err = generate_iterated_feeder_to_agg_equation(
+        "frac",
+        "growth",
+        "sum(cube[d1, d1, *] * frac[d1, d1])",
+        &["d1".to_string(), "d1".to_string()],
+        &["d1\u{B7}r1".to_string(), "d1\u{B7}r2".to_string()],
+    )
+    .expect_err("an ambiguous duplicate-dim slot pin must fail loudly");
+    assert_eq!(err.kind, PartialEquationErrorKind::UnfreezablePartial);
+}
+
 /// `wrap_matching_in_previous` must not double-lag references that are
 /// already inside a `PREVIOUS(...)`/`INIT(...)` call, and must wrap every
 /// other occurrence of the target (including inside nested calls and


### PR DESCRIPTION
Follow-up to #784 (supersedes #786, which conflicted because #784 was squash-merged and the old branch carried the pre-merge history). Fixes the two P3 findings #784's automated review surfaced after merge. Both harden the phase's no-silent-fallback discipline, and the first turned out to be a real reachable defect rather than defense-in-depth.

**Feeder slot pinning on square-source aggs**: a degenerate square-source reducer (`x[D1] = 1 + SUM(cube[D1,D1,*] * frac[D1,D1])`) mints an agg with `result_dims == [D1, D1]`, and `pin_iterated_dim_indices` resolved indices by first-match dim name -- every duplicated-dim index pinned to the first slot part, silently freezing the wrong source row on off-diagonal feeder scores (confident garbage, zero diagnostics). It now mirrors `resolve_mismatched_index_position`'s uniqueness defense: an ambiguous index bails to the existing `UnfreezablePartial` loud-skip channel (per-row warning, no score emitted). RED-verified pre-fix at both fixture and unit level; byte-identical for every non-repeated-dim shape by construction.

**`agg_sources` release-build fallback**: the helper carried a `debug_assert` that every arrayed reducer source has a per-var slice, then silently substituted the canonical slice in release if the invariant ever broke -- which would mislabel a projection feeder as a co-source and corrupt per-(row, slot) derivations. It now returns `Option` and declines the hoist entirely on a missing slice (the same inert conservative degradation as the dynamic-index carve-outs). The reviewer-suggested empty-slice fallback was rejected because an arrayed source wearing the scalar-feeder encoding would flow into the scalar-agg name grammar -- plausibly wrong rather than inert. The two AST walkers were audited as structurally symmetric, so the path is unreachable today; the defense now matches the asserted invariant.

The remaining square-source hazards (co-source and agg-to-target halves still pin by dim name; phantom off-diagonal link scores reach link-level surfaces unwarned) are pre-existing and tracked as #785/#778, with the loop-score cascade gap as #780. Adversarial review of this commit: APPROVE, with the empirical co-source findings appended to #785.