### PR TITLE
engine: enumerate rank element loops

### DIFF
--- a/src/simlin-engine/src/db/analysis.rs
+++ b/src/simlin-engine/src/db/analysis.rs
@@ -975,7 +975,7 @@ fn emit_agg_routed_edges(
             if let Some(rows) = rows {
                 for crate::db::ltm::ReadSliceRowParts {
                     row_parts,
-                    slot_parts: _,
+                    slot_parts,
                 } in &rows
                 {
                     let from_node = if row_parts.len() == 1 {
@@ -987,6 +987,7 @@ fn emit_agg_routed_edges(
                     let rank_slots = crate::ltm_agg::rank_output_slot_parts_for_row(
                         read_slice,
                         &rank_dim_element_lists,
+                        slot_parts,
                     )
                     .unwrap_or_else(|| fallback_slots.clone());
                     let entry = element_edges.entry(from_node).or_default();

--- a/src/simlin-engine/src/db/analysis.rs
+++ b/src/simlin-engine/src/db/analysis.rs
@@ -470,12 +470,9 @@ fn emit_edges_for_reference(
             // carve-out (`SUM(pop[idx,*])`, reclassified from `Wildcard` by
             // the IR); `Wildcard` here is a variable-backed WHOLE-EXTENT
             // reducer's whole-RHS argument (a full reduction feeding every
-            // target element), a DE-HOISTED array-valued reducer's wildcard
-            // arg (`RANK(pop[*], 1)` -- GH #771: RANK never sets
-            // `in_reducer`, so the IR's #514 reclassification doesn't fire
-            // and the site keeps its syntactic shape; the cross-product is
-            // the intended coarse-but-sound treatment), or a rare
-            // non-reducer whole-array reference -- a hoisted
+            // target element), or a rare non-reducer whole-array reference.
+            // Hoisted scalar reducers and array-valued RANK helpers are
+            // routed through aggregate nodes before they reach this arm: a
             // *synthetic*-agg reducer reference is routed through the agg
             // (`emit_agg_routed_edges`) and a variable-backed PARTIAL
             // reducer's argument is routed by its read slice through the
@@ -968,7 +965,45 @@ fn emit_agg_routed_edges(
         let broadcast_targets: Option<Vec<String>> =
             (!agg.is_synthetic && agg.result_dims.is_empty() && !to_dims.is_empty())
                 .then(|| cartesian_element_names(to_name, to_dims));
-        if let Some(rows) = rows {
+        if agg.array_valued_rank {
+            let fallback_slots: Vec<Vec<String>> = crate::ltm_agg::cartesian_element_parts(
+                &iterated_dims
+                    .iter()
+                    .map(dimension_element_names)
+                    .collect::<Vec<_>>(),
+            );
+            if let Some(rows) = rows {
+                for crate::db::ltm::ReadSliceRowParts {
+                    row_parts,
+                    slot_parts,
+                } in &rows
+                {
+                    let from_node = if row_parts.len() == 1 {
+                        format_element_name(from_name, &row_parts[0])
+                    } else {
+                        let refs: Vec<&str> = row_parts.iter().map(String::as_str).collect();
+                        format_multi_element_name(from_name, &refs)
+                    };
+                    let rank_slots = crate::ltm_agg::rank_output_slot_parts_for_row(
+                        read_slice,
+                        &from_dim_element_lists,
+                        slot_parts,
+                    )
+                    .unwrap_or_else(|| fallback_slots.clone());
+                    let entry = element_edges.entry(from_node).or_default();
+                    for slot in &rank_slots {
+                        entry.insert(agg_node_name(slot));
+                    }
+                }
+            } else {
+                for from_node in cartesian_element_names(from_name, from_dims) {
+                    let entry = element_edges.entry(from_node).or_default();
+                    for slot in &fallback_slots {
+                        entry.insert(agg_node_name(slot));
+                    }
+                }
+            }
+        } else if let Some(rows) = rows {
             for crate::db::ltm::ReadSliceRowParts {
                 row_parts,
                 slot_parts,

--- a/src/simlin-engine/src/db/analysis.rs
+++ b/src/simlin-engine/src/db/analysis.rs
@@ -836,28 +836,31 @@ fn emit_agg_routed_edges(
     // The agg's result-axis dimensions (`AggNode::result_dims`, datamodel-
     // cased), resolved to the `Dimension` objects -- so `cartesian_element_names`
     // / `expand_same_element` and the agg-slot subscripting below can operate
-    // on them directly. The agg's result dims are always dimensions the target
-    // `to` iterates over (they come from the target equation's iterated
-    // dimensions), and -- when the reducer reads its arrayed source by the
-    // matching iterated subscript -- a subset of the arrayed source's dims too,
-    // so we can recover the `Dimension` from `from_dims` (preferred -- it's the
-    // source row axis) or from `to_dims` (needed when `from` is a *scalar*
-    // feeder of the agg, and for a mapped sliced reducer -- GH #534 -- whose
-    // result dim is the target's iterated dim, absent from the source's
-    // declared dims). `read_slice_ok` keys the source-row layout
-    // machinery below off the well-formed slice; it is independent of where the
-    // `Iterated` `Dimension`s come from. The slice is `from`'s OWN
-    // (per-source) slice -- empty for a non-source, which fails the arity
-    // check and degrades to the conservative fallback.
+    // on them directly. Scalar reducers usually derive these from target
+    // iterated dims; array-valued RANK can also derive them from a ranked source
+    // dim or proper StarRange subdimension, so resolve through the project-wide
+    // dimension context before falling back to the local source/target dims.
+    // `read_slice_ok` keys the source-row layout machinery below off the
+    // well-formed slice; it is independent of where the result `Dimension`s
+    // come from. The slice is `from`'s OWN (per-source) slice -- empty for a
+    // non-source, which fails the arity check and degrades to the conservative
+    // fallback.
     let read_slice = agg.source_read_slice(from_name);
     let read_slice_ok = !from_dims.is_empty() && read_slice.len() == from_dims.len();
     let resolve_result_dim = |name: &str| -> Option<crate::dimensions::Dimension> {
         let canon = canonicalize(name);
-        from_dims
-            .iter()
-            .chain(to_dims.iter())
-            .find(|d| d.name() == canon.as_ref())
+        dim_ctx
+            .get(&crate::common::CanonicalDimensionName::from_raw(
+                canon.as_ref(),
+            ))
             .cloned()
+            .or_else(|| {
+                from_dims
+                    .iter()
+                    .chain(to_dims.iter())
+                    .find(|d| d.name() == canon.as_ref())
+                    .cloned()
+            })
     };
     let iterated_dims: Vec<crate::dimensions::Dimension> = agg
         .result_dims
@@ -966,16 +969,13 @@ fn emit_agg_routed_edges(
             (!agg.is_synthetic && agg.result_dims.is_empty() && !to_dims.is_empty())
                 .then(|| cartesian_element_names(to_name, to_dims));
         if agg.array_valued_rank {
-            let fallback_slots: Vec<Vec<String>> = crate::ltm_agg::cartesian_element_parts(
-                &iterated_dims
-                    .iter()
-                    .map(dimension_element_names)
-                    .collect::<Vec<_>>(),
-            );
+            let rank_dim_element_lists: Vec<Vec<String>> =
+                iterated_dims.iter().map(dimension_element_names).collect();
+            let fallback_slots = crate::ltm_agg::cartesian_element_parts(&rank_dim_element_lists);
             if let Some(rows) = rows {
                 for crate::db::ltm::ReadSliceRowParts {
                     row_parts,
-                    slot_parts,
+                    slot_parts: _,
                 } in &rows
                 {
                     let from_node = if row_parts.len() == 1 {
@@ -986,8 +986,7 @@ fn emit_agg_routed_edges(
                     };
                     let rank_slots = crate::ltm_agg::rank_output_slot_parts_for_row(
                         read_slice,
-                        &from_dim_element_lists,
-                        slot_parts,
+                        &rank_dim_element_lists,
                     )
                     .unwrap_or_else(|| fallback_slots.clone());
                     let entry = element_edges.entry(from_node).or_default();

--- a/src/simlin-engine/src/db/element_graph_proptest.rs
+++ b/src/simlin-engine/src/db/element_graph_proptest.rs
@@ -97,11 +97,11 @@ use crate::test_common::TestProject;
 /// referencing variable's own index, to keep the dependency DAG acyclic).
 ///
 /// The reducer patterns are deliberately SUM-only: every reducer here is
-/// hoisted, so the per-reducer agg-hop expectations assume `ThroughAgg`
-/// routing. If a later task adds RANK patterns to the strategy, their
-/// expectations must encode the DE-HOISTED `Direct` routing instead --
-/// RANK is array-valued and never hoisted (GH #771,
-/// `ltm_agg::reducer_is_hoistable`).
+/// scalar-valued, so the per-reducer agg-hop expectations assume scalar
+/// reducer routing. If a later task adds RANK patterns to the strategy, their
+/// expectations must encode the ARRAY-valued RANK agg routing instead --
+/// every read row can feed every rank output slot in its iterated context
+/// (GH #776).
 #[derive(Debug, Clone)]
 enum RefPattern {
     /// `vN` -- bare same-element reference.

--- a/src/simlin-engine/src/db/element_graph_tests.rs
+++ b/src/simlin-engine/src/db/element_graph_tests.rs
@@ -1275,14 +1275,15 @@ fn element_graph_scalar_feeder_of_hoisted_reducer_is_bare_node() {
 }
 
 /// GH #776: `RANK` is array-valued, so each rank output slot depends on the
-/// whole ranked array, not just the same source element. The bare and wildcard
-/// spellings are equivalent dataflow and must both enumerate cross-element
-/// paths for rank-mediated loops.
+/// whole ranked array, not just the same source element. The bare, wildcard,
+/// and active-dimension spellings are equivalent dataflow and must all
+/// enumerate cross-element paths for rank-mediated loops.
 #[test]
-fn element_graph_rank_arg_reads_all_elements_for_bare_and_wildcard_spellings() {
+fn element_graph_rank_arg_reads_all_elements_for_ranked_axis_spellings() {
     for (name, rank_arg) in [
         ("rank_bare_arg", "RANK(pop, 1)"),
         ("rank_wildcard_arg", "RANK(pop[*], 1)"),
+        ("rank_active_dim_arg", "RANK(pop[Region], 1)"),
     ] {
         let project = TestProject::new(name)
             .named_dimension("Region", &["north", "south"])
@@ -1301,6 +1302,27 @@ fn element_graph_rank_arg_reads_all_elements_for_bare_and_wildcard_spellings() {
         assert_no_edge(&result, "pop[north]", "grow[north]");
         assert_no_edge(&result, "pop[south]", "grow[south]");
     }
+}
+
+/// GH #796 review: when multi-source RANK chooses its helper dimensions from
+/// a canonical source, mapped sibling sources must still feed those helper
+/// slots. The non-canonical `b[State]` rows map positionally to `Region`, so
+/// the edge names must land on `agg[r1]`/`agg[r2]`, not dangling `agg[s1]`.
+#[test]
+fn element_graph_rank_mapped_source_uses_result_dimension_slots() {
+    let project = TestProject::new("rank_mapped_source_slots")
+        .named_dimension("Region", &["r1", "r2"])
+        .named_dimension_with_mapping("State", &["s1", "s2"], "Region")
+        .array_aux("a[Region]", "1")
+        .array_aux("b[State]", "2")
+        .array_aux("grow[Region]", "RANK(a[*] + b[*], 1)");
+
+    let result = element_edges(&project);
+    let agg = crate::ltm_agg::synthetic_agg_name(0);
+    assert_edge(&result, "b[s1]", &format!("{agg}[r1]"));
+    assert_edge(&result, "b[s2]", &format!("{agg}[r2]"));
+    assert_no_edge(&result, "b[s1]", &format!("{agg}[s1]"));
+    assert_no_edge(&result, "b[s2]", &format!("{agg}[s2]"));
 }
 
 /// #514 (element graph, scalar feeder of an *arrayed* hoisted reducer): a

--- a/src/simlin-engine/src/db/element_graph_tests.rs
+++ b/src/simlin-engine/src/db/element_graph_tests.rs
@@ -1325,6 +1325,33 @@ fn element_graph_rank_mapped_source_uses_result_dimension_slots() {
     assert_no_edge(&result, "b[s2]", &format!("{agg}[s2]"));
 }
 
+/// GH #796 review follow-up: in `RANK(matrix[Region,*], 1)`, the Region
+/// axis is the per-row context and Product is the ranked axis. A north source
+/// row can feed every north product rank slot, but must not feed south slots.
+#[test]
+fn element_graph_rank_context_axis_stays_pinned_per_row() {
+    let project = TestProject::new("rank_context_axis_pinned")
+        .named_dimension("Region", &["north", "south"])
+        .named_dimension("Product", &["x", "y"])
+        .array_aux("matrix[Region,Product]", "1")
+        .array_aux("ranked[Region,Product]", "RANK(matrix[Region,*], 1)");
+
+    let result = element_edges(&project);
+    let agg = crate::ltm_agg::synthetic_agg_name(0);
+    for product in ["x", "y"] {
+        assert_edge(
+            &result,
+            "matrix[north,x]",
+            &format!("{agg}[north,{product}]"),
+        );
+        assert_no_edge(
+            &result,
+            "matrix[north,x]",
+            &format!("{agg}[south,{product}]"),
+        );
+    }
+}
+
 /// #514 (element graph, scalar feeder of an *arrayed* hoisted reducer): a
 /// sliced reducer over an A2A body whose argument also references a *scalar*,
 /// e.g. `growth[D1] = SUM(matrix[D1,*] * scale)` with `scale` scalar -- the

--- a/src/simlin-engine/src/db/element_graph_tests.rs
+++ b/src/simlin-engine/src/db/element_graph_tests.rs
@@ -1274,6 +1274,35 @@ fn element_graph_scalar_feeder_of_hoisted_reducer_is_bare_node() {
     assert_edge(&result, "pop[boston]", "share[boston]");
 }
 
+/// GH #776: `RANK` is array-valued, so each rank output slot depends on the
+/// whole ranked array, not just the same source element. The bare and wildcard
+/// spellings are equivalent dataflow and must both enumerate cross-element
+/// paths for rank-mediated loops.
+#[test]
+fn element_graph_rank_arg_reads_all_elements_for_bare_and_wildcard_spellings() {
+    for (name, rank_arg) in [
+        ("rank_bare_arg", "RANK(pop, 1)"),
+        ("rank_wildcard_arg", "RANK(pop[*], 1)"),
+    ] {
+        let project = TestProject::new(name)
+            .named_dimension("Region", &["north", "south"])
+            .array_aux("pop[Region]", "100")
+            .array_aux("grow[Region]", rank_arg);
+
+        let result = element_edges(&project);
+        let agg = crate::ltm_agg::synthetic_agg_name(0);
+        for from in ["pop[north]", "pop[south]"] {
+            for slot in ["north", "south"] {
+                assert_edge(&result, from, &format!("{agg}[{slot}]"));
+            }
+        }
+        assert_edge(&result, &format!("{agg}[north]"), "grow[north]");
+        assert_edge(&result, &format!("{agg}[south]"), "grow[south]");
+        assert_no_edge(&result, "pop[north]", "grow[north]");
+        assert_no_edge(&result, "pop[south]", "grow[south]");
+    }
+}
+
 /// #514 (element graph, scalar feeder of an *arrayed* hoisted reducer): a
 /// sliced reducer over an A2A body whose argument also references a *scalar*,
 /// e.g. `growth[D1] = SUM(matrix[D1,*] * scale)` with `scale` scalar -- the

--- a/src/simlin-engine/src/db/ltm/compile.rs
+++ b/src/simlin-engine/src/db/ltm/compile.rs
@@ -410,8 +410,9 @@ struct LoweredLtmVariable {
 /// the agg-hoistable reducer set (`ltm_agg::reducer_kind_from_name`),
 /// which differs: `SIZE` is never hoisted into an agg (its link score is
 /// constant 0) yet Pass-1 decomposes its argument exactly like `SUM`'s
-/// (and `RANK` -- recognized as a reducer, never hoisted post-GH #771 --
-/// is never Pass-1-decomposed either). Deriving the original (text-scan)
+/// (and `RANK` -- recognized as array-valued and routed through its own LTM
+/// agg path post-GH #776 -- is never Pass-1-decomposed either). Deriving the
+/// original (text-scan)
 /// gate from
 /// the wrong set silently stubbed any fragment embedding
 /// `SIZE(<array expression>)` -- the demonstrated GH #738 round-2

--- a/src/simlin-engine/src/db/ltm/link_scores.rs
+++ b/src/simlin-engine/src/db/ltm/link_scores.rs
@@ -2924,19 +2924,96 @@ pub(super) fn emit_agg_to_target_link_scores(
     // denominator carry) via `generate_scalar_to_element_equation`'s
     // per-ident `source_pins`, computed by `source_pins_for_target` below.
 
-    // Positions of an agg's `result_dims` within `to`'s dimensions, so a
-    // target element tuple can be projected onto that agg's slot subscript
-    // (for the link-score name's agg side, and for the per-ident body pins).
-    let positions_in_to_dims = |result_dims: &[String]| -> Vec<usize> {
-        result_dims
-            .iter()
-            .filter_map(|rd| {
-                let canon = crate::common::canonicalize(rd);
-                to_dims.iter().position(|td| td.name() == canon.as_ref())
-            })
-            .collect()
+    let dim_ctx = project_dimensions_context(db, project);
+    #[derive(Clone)]
+    struct AggTargetProjectionAxis {
+        target_pos: usize,
+        target_dim: crate::dimensions::Dimension,
+        result_dim: crate::dimensions::Dimension,
+        mapped_elements: Option<Vec<crate::common::CanonicalElementName>>,
+    }
+    #[derive(Clone)]
+    struct AggTargetProjection {
+        expected_axes: usize,
+        axes: Vec<AggTargetProjectionAxis>,
+    }
+    // Projection of a target element tuple onto an agg's `result_dims`, so the
+    // link-score name, denominator, and per-ident body pin all address the same
+    // helper slot. Exact dimension names use the target element directly
+    // (GH #528). Positionally mapped dims use the same correspondence as A2A
+    // execution: a `Region` target can pin a `State`-dimensioned RANK helper to
+    // the State element read for that Region slot.
+    let target_projection_for_result_dims = |result_dims: &[String]| -> AggTargetProjection {
+        let mut axes = Vec::with_capacity(result_dims.len());
+        for rd in result_dims {
+            let result_canon = crate::common::CanonicalDimensionName::from_raw(rd);
+            if let Some((target_pos, target_dim)) = to_dims
+                .iter()
+                .enumerate()
+                .find(|(_, td)| td.canonical_name() == &result_canon)
+            {
+                axes.push(AggTargetProjectionAxis {
+                    target_pos,
+                    target_dim: target_dim.clone(),
+                    result_dim: target_dim.clone(),
+                    mapped_elements: None,
+                });
+                continue;
+            }
+            let Some(result_dim) = dim_ctx.get(&result_canon).cloned() else {
+                continue;
+            };
+            if let Some((target_pos, target_dim, mapped_elements)) = to_dims
+                .iter()
+                .enumerate()
+                .find_map(|(target_pos, target_dim)| {
+                    dim_ctx
+                        .mapped_element_correspondence(target_dim.canonical_name(), &result_canon)
+                        .map(|mapped_elements| (target_pos, target_dim, mapped_elements))
+                })
+            {
+                axes.push(AggTargetProjectionAxis {
+                    target_pos,
+                    target_dim: target_dim.clone(),
+                    result_dim,
+                    mapped_elements: Some(mapped_elements),
+                });
+            }
+        }
+        AggTargetProjection {
+            expected_axes: result_dims.len(),
+            axes,
+        }
     };
-    let result_dim_positions: Vec<usize> = positions_in_to_dims(&agg.result_dims);
+    let result_dim_projection = target_projection_for_result_dims(&agg.result_dims);
+    let slot_parts_for_target =
+        |projection: &AggTargetProjection, element: &str| -> Option<Vec<String>> {
+            if projection.axes.len() != projection.expected_axes {
+                return None;
+            }
+            let parts: Vec<&str> = if element.is_empty() {
+                Vec::new()
+            } else {
+                element.split(',').collect()
+            };
+            projection
+                .axes
+                .iter()
+                .map(|axis| {
+                    let target_elem = parts.get(axis.target_pos)?;
+                    if let Some(mapped_elements) = &axis.mapped_elements {
+                        let target_elem_name =
+                            crate::common::CanonicalElementName::from_raw(target_elem);
+                        let offset = axis.target_dim.get_offset(&target_elem_name)?;
+                        mapped_elements
+                            .get(offset)
+                            .map(|elem| elem.as_str().to_string())
+                    } else {
+                        Some((*target_elem).to_string())
+                    }
+                })
+                .collect()
+        };
     // The target element projected onto the agg's `result_dims` (the
     // agg-slot subscript), or `None` when the agg is scalar / the
     // projection is empty.
@@ -2944,11 +3021,7 @@ pub(super) fn emit_agg_to_target_link_scores(
         if !agg_is_arrayed {
             return None;
         }
-        let parts: Vec<&str> = element.split(',').collect();
-        let slot: Vec<&str> = result_dim_positions
-            .iter()
-            .filter_map(|&p| parts.get(p).copied())
-            .collect();
+        let slot = slot_parts_for_target(&result_dim_projection, element)?;
         (!slot.is_empty()).then(|| slot.join(","))
     };
     // The agg side of the link-score name for a given target element: the
@@ -2975,22 +3048,25 @@ pub(super) fn emit_agg_to_target_link_scores(
         }
     };
     // The QUALIFIED (`d1·a`) projection of a target element onto an agg's
-    // `result_dims` axes (given their precomputed positions in `to`'s dims)
-    // -- the subscript that agg's ident is pinned to in the
-    // per-target-element equation BODY (one `generate_scalar_to_element_equation`
-    // `source_pins` entry). Qualified like the other pinned deps so
-    // `PREVIOUS(agg[...])` references compile to direct LoadPrevs. `None`
-    // when the projection is empty (a scalar agg; referenced bare, nothing
-    // to pin).
-    let qualified_pin_for_target = |positions: &[usize], element: &str| -> Option<String> {
-        let qualified = crate::ltm_augment::qualify_element_csv(element, &to_dims);
-        let parts: Vec<&str> = qualified.split(',').collect();
-        let slot: Vec<&str> = positions
-            .iter()
-            .filter_map(|&p| parts.get(p).copied())
-            .collect();
-        (!slot.is_empty()).then(|| slot.join(","))
-    };
+    // `result_dims` axes -- the subscript that agg's ident is pinned to in the
+    // per-target-element equation BODY (one
+    // `generate_scalar_to_element_equation` `source_pins` entry). Qualified in
+    // the AGG'S result-dim space, so mapped target dims pin the helper slot they
+    // actually read (`state·s1`), not the target slot (`region·r1`).
+    let qualified_pin_for_target =
+        |projection: &AggTargetProjection, element: &str| -> Option<String> {
+            let slot_parts = slot_parts_for_target(projection, element)?;
+            if slot_parts.is_empty() {
+                return None;
+            }
+            let slot = slot_parts.join(",");
+            let result_dims: Vec<crate::dimensions::Dimension> = projection
+                .axes
+                .iter()
+                .map(|axis| axis.result_dim.clone())
+                .collect();
+            Some(crate::ltm_augment::qualify_element_csv(&slot, &result_dims))
+        };
     // Every ARRAYED agg referenced by the substituted equation needs a body
     // pin (GH #751): the LIVE agg (held live; the GH #528 projection) and
     // every frozen CO-AGG -- another hoisted reducer of the same target,
@@ -2999,16 +3075,16 @@ pub(super) fn emit_agg_to_target_link_scores(
     // Each ident is projected onto ITS OWN `result_dims` positions.
     // `aggs_in_var` yields first-encounter order, so the pin list -- and the
     // emitted equation text -- is deterministic.
-    let arrayed_agg_pin_positions: Vec<(Ident<Canonical>, Vec<usize>)> = {
-        let mut pins: Vec<(Ident<Canonical>, Vec<usize>)> = Vec::new();
+    let arrayed_agg_pin_projections: Vec<(Ident<Canonical>, AggTargetProjection)> = {
+        let mut pins: Vec<(Ident<Canonical>, AggTargetProjection)> = Vec::new();
         if agg_is_arrayed {
-            pins.push((agg_canonical.clone(), result_dim_positions.clone()));
+            pins.push((agg_canonical.clone(), result_dim_projection.clone()));
         }
         for other in agg_nodes.aggs_in_var(to) {
             if other.is_synthetic && other.name != agg.name && !other.result_dims.is_empty() {
                 pins.push((
                     Ident::<Canonical>::new(&other.name),
-                    positions_in_to_dims(&other.result_dims),
+                    target_projection_for_result_dims(&other.result_dims),
                 ));
             }
         }
@@ -3017,10 +3093,10 @@ pub(super) fn emit_agg_to_target_link_scores(
     // The per-ident pin map for one target element: each arrayed agg pinned
     // to the target element's projection onto its own result axes.
     let source_pins_for_target = |element: &str| -> Vec<(Ident<Canonical>, String)> {
-        arrayed_agg_pin_positions
+        arrayed_agg_pin_projections
             .iter()
-            .filter_map(|(ident, positions)| {
-                qualified_pin_for_target(positions, element).map(|slot| (ident.clone(), slot))
+            .filter_map(|(ident, projection)| {
+                qualified_pin_for_target(projection, element).map(|slot| (ident.clone(), slot))
             })
             .collect()
     };

--- a/src/simlin-engine/src/db/ltm/link_scores.rs
+++ b/src/simlin-engine/src/db/ltm/link_scores.rs
@@ -23,7 +23,9 @@ use crate::db::{
 };
 
 use super::compile::{ShapedLinkScore, link_score_equation_text_shaped};
-use super::loops::{ReadSliceRow, cartesian_subscripts, read_slice_rows};
+use super::loops::{
+    ReadSliceRow, ReadSliceRowParts, cartesian_subscripts, read_slice_row_parts, read_slice_rows,
+};
 use super::parse::{
     ltm_equation_dimensions, reconstruct_ltm_var_lowered, retarget_ltm_equation_dims,
 };
@@ -2615,27 +2617,131 @@ pub(super) fn emit_source_to_agg_link_scores(
         .iter()
         .map(crate::ltm_augment::dimension_element_names)
         .collect();
+    let dim_ctx = project_dimensions_context(db, project);
+    if agg.array_valued_rank {
+        let rows: Vec<ReadSliceRowParts> =
+            read_slice_row_parts(agg.source_read_slice(from), &dim_element_lists, dim_ctx)
+                .unwrap_or_else(|| {
+                    crate::ltm_agg::cartesian_element_parts(&dim_element_lists)
+                        .into_iter()
+                        .map(|row_parts| ReadSliceRowParts {
+                            row_parts,
+                            slot_parts: Vec::new(),
+                        })
+                        .collect()
+                });
+
+        let mut coreduced_by_iterated_slot: HashMap<Vec<String>, Vec<String>> = HashMap::new();
+        for row in &rows {
+            coreduced_by_iterated_slot
+                .entry(row.slot_parts.clone())
+                .or_default()
+                .push(row.row_parts.join(","));
+        }
+
+        let rank_dims: Vec<crate::dimensions::Dimension> = agg
+            .result_dims
+            .iter()
+            .filter_map(|dim| {
+                dim_ctx
+                    .get(&crate::common::CanonicalDimensionName::from_raw(dim))
+                    .cloned()
+            })
+            .collect();
+        if rank_dims.len() != agg.result_dims.len() {
+            return;
+        }
+        let rank_dim_element_lists: Vec<Vec<String>> = rank_dims
+            .iter()
+            .map(crate::ltm_augment::dimension_element_names)
+            .collect();
+        let fallback_slots = crate::ltm_agg::cartesian_element_parts(&rank_dim_element_lists);
+
+        for ReadSliceRowParts {
+            row_parts,
+            slot_parts,
+        } in &rows
+        {
+            let row = row_parts.join(",");
+            let qualified_row = crate::ltm_augment::qualify_element_csv(&row, from_dims);
+            let qualified_coreduced: Vec<String> = coreduced_by_iterated_slot[slot_parts]
+                .iter()
+                .map(|e| crate::ltm_augment::qualify_element_csv(e, from_dims))
+                .collect();
+            let rank_slots = crate::ltm_agg::rank_output_slot_parts_for_row(
+                agg.source_read_slice(from),
+                &dim_element_lists,
+                slot_parts,
+            )
+            .unwrap_or_else(|| fallback_slots.clone());
+
+            for slot_parts in &rank_slots {
+                let slot = slot_parts.join(",");
+                let (var_name, equation) = if slot.is_empty() {
+                    (
+                        format!(
+                            "$\u{205A}ltm\u{205A}link_score\u{205A}{}[{}]\u{2192}{}",
+                            from, row, agg.name
+                        ),
+                        crate::ltm_augment::generate_element_to_scalar_equation(
+                            from,
+                            &agg.name,
+                            &qualified_row,
+                            &qualified_coreduced,
+                            &classified.kind,
+                            classified.name,
+                            classified.is_bare,
+                            Some(&body_ctx),
+                        ),
+                    )
+                } else {
+                    (
+                        format!(
+                            "$\u{205A}ltm\u{205A}link_score\u{205A}{}[{}]\u{2192}{}[{}]",
+                            from, row, agg.name, slot
+                        ),
+                        crate::ltm_augment::generate_element_to_reduced_equation(
+                            from,
+                            &agg.name,
+                            &qualified_row,
+                            &crate::ltm_augment::qualify_element_csv(&slot, &rank_dims),
+                            &qualified_coreduced,
+                            &classified.kind,
+                            classified.name,
+                            classified.is_bare,
+                            Some(&body_ctx),
+                        ),
+                    )
+                };
+                vars.push(LtmSyntheticVar {
+                    name: var_name,
+                    equation: datamodel::Equation::Scalar(equation),
+                    dimensions: vec![],
+                    compile_directly: false,
+                });
+            }
+        }
+        return;
+    }
     // The read rows: only the slice the reducer reads -- `from`'s OWN
     // (per-source) slice -- each row paired with its (possibly
     // mapping-remapped, GH #534) agg slot. If the slice doesn't line up
     // with `from`'s axes (shouldn't happen for a hoisted agg whose
     // `sources` include `from`; a non-source's empty slice trips the same
     // arity guard), fall back to all elements / scalar agg.
-    let rows: Vec<ReadSliceRow> = read_slice_rows(
-        agg.source_read_slice(from),
-        &dim_element_lists,
-        project_dimensions_context(db, project),
-    )
-    .unwrap_or_else(|| {
-        let all = cartesian_subscripts(&dim_element_lists);
-        all.iter()
-            .map(|r| ReadSliceRow {
-                row: r.clone(),
-                slot: String::new(),
-                coreduced: all.clone(),
-            })
-            .collect()
-    });
+    let rows: Vec<ReadSliceRow> =
+        read_slice_rows(agg.source_read_slice(from), &dim_element_lists, dim_ctx).unwrap_or_else(
+            || {
+                let all = cartesian_subscripts(&dim_element_lists);
+                all.iter()
+                    .map(|r| ReadSliceRow {
+                        row: r.clone(),
+                        slot: String::new(),
+                        coreduced: all.clone(),
+                    })
+                    .collect()
+            },
+        );
     for ReadSliceRow {
         row,
         slot,

--- a/src/simlin-engine/src/db/ltm/link_scores.rs
+++ b/src/simlin-engine/src/db/ltm/link_scores.rs
@@ -2631,13 +2631,10 @@ pub(super) fn emit_source_to_agg_link_scores(
                         .collect()
                 });
 
-        let mut coreduced_by_iterated_slot: HashMap<Vec<String>, Vec<String>> = HashMap::new();
-        for row in &rows {
-            coreduced_by_iterated_slot
-                .entry(row.slot_parts.clone())
-                .or_default()
-                .push(row.row_parts.join(","));
-        }
+        // RANK compares each row against the whole ranked view. Unlike scalar
+        // reducers, an Iterated axis does not partition rows by result slot.
+        let rank_coreduced_rows: Vec<String> =
+            rows.iter().map(|row| row.row_parts.join(",")).collect();
 
         let rank_dims: Vec<crate::dimensions::Dimension> = agg
             .result_dims
@@ -2659,19 +2656,18 @@ pub(super) fn emit_source_to_agg_link_scores(
 
         for ReadSliceRowParts {
             row_parts,
-            slot_parts,
+            slot_parts: _,
         } in &rows
         {
             let row = row_parts.join(",");
             let qualified_row = crate::ltm_augment::qualify_element_csv(&row, from_dims);
-            let qualified_coreduced: Vec<String> = coreduced_by_iterated_slot[slot_parts]
+            let qualified_coreduced: Vec<String> = rank_coreduced_rows
                 .iter()
                 .map(|e| crate::ltm_augment::qualify_element_csv(e, from_dims))
                 .collect();
             let rank_slots = crate::ltm_agg::rank_output_slot_parts_for_row(
                 agg.source_read_slice(from),
-                &dim_element_lists,
-                slot_parts,
+                &rank_dim_element_lists,
             )
             .unwrap_or_else(|| fallback_slots.clone());
 

--- a/src/simlin-engine/src/db/ltm/link_scores.rs
+++ b/src/simlin-engine/src/db/ltm/link_scores.rs
@@ -2619,9 +2619,10 @@ pub(super) fn emit_source_to_agg_link_scores(
         .collect();
     let dim_ctx = project_dimensions_context(db, project);
     if agg.array_valued_rank {
+        let rank_read_slice = agg.source_read_slice(from);
         let rows: Vec<ReadSliceRowParts> =
-            read_slice_row_parts(agg.source_read_slice(from), &dim_element_lists, dim_ctx)
-                .unwrap_or_else(|| {
+            read_slice_row_parts(rank_read_slice, &dim_element_lists, dim_ctx).unwrap_or_else(
+                || {
                     crate::ltm_agg::cartesian_element_parts(&dim_element_lists)
                         .into_iter()
                         .map(|row_parts| ReadSliceRowParts {
@@ -2629,12 +2630,25 @@ pub(super) fn emit_source_to_agg_link_scores(
                             slot_parts: Vec::new(),
                         })
                         .collect()
-                });
+                },
+            );
 
-        // RANK compares each row against the whole ranked view. Unlike scalar
-        // reducers, an Iterated axis does not partition rows by result slot.
-        let rank_coreduced_rows: Vec<String> =
-            rows.iter().map(|row| row.row_parts.join(",")).collect();
+        let has_reduced_rank_axis = rank_read_slice
+            .iter()
+            .any(|axis| matches!(axis, crate::ltm_agg::AxisRead::Reduced { .. }));
+        // Whole-view RANK compares against every source row. Mixed
+        // context/ranked RANK (`matrix[Region,*]`) compares only rows sharing
+        // the same iterated context slot.
+        let all_rank_rows: Vec<String> = rows.iter().map(|row| row.row_parts.join(",")).collect();
+        let mut rank_rows_by_iterated_slot: HashMap<Vec<String>, Vec<String>> = HashMap::new();
+        if has_reduced_rank_axis {
+            for row in &rows {
+                rank_rows_by_iterated_slot
+                    .entry(row.slot_parts.clone())
+                    .or_default()
+                    .push(row.row_parts.join(","));
+            }
+        }
 
         let rank_dims: Vec<crate::dimensions::Dimension> = agg
             .result_dims
@@ -2656,18 +2670,24 @@ pub(super) fn emit_source_to_agg_link_scores(
 
         for ReadSliceRowParts {
             row_parts,
-            slot_parts: _,
+            slot_parts,
         } in &rows
         {
             let row = row_parts.join(",");
             let qualified_row = crate::ltm_augment::qualify_element_csv(&row, from_dims);
+            let rank_coreduced_rows = if has_reduced_rank_axis {
+                &rank_rows_by_iterated_slot[slot_parts]
+            } else {
+                &all_rank_rows
+            };
             let qualified_coreduced: Vec<String> = rank_coreduced_rows
                 .iter()
                 .map(|e| crate::ltm_augment::qualify_element_csv(e, from_dims))
                 .collect();
             let rank_slots = crate::ltm_agg::rank_output_slot_parts_for_row(
-                agg.source_read_slice(from),
+                rank_read_slice,
                 &rank_dim_element_lists,
+                slot_parts,
             )
             .unwrap_or_else(|| fallback_slots.clone());
 

--- a/src/simlin-engine/src/db/ltm_ir.rs
+++ b/src/simlin-engine/src/db/ltm_ir.rs
@@ -47,11 +47,10 @@ use crate::db::{Db, RefShape, SourceModel, SourceProject, reconstruct_model_vari
 /// according to the shape's normal broadcast/diagonal rules).
 ///
 /// `in_reducer` is true iff [`reducer_keys`] is non-empty: the reference site
-/// occurs syntactically inside an array-reducing builtin call (`SUM`/`MEAN`/
-/// `MIN`/`MAX`/`STDDEV` -- the `crate::ltm_agg::reducer_is_hoistable` set;
-/// `SIZE`, the array-valued `RANK` (GH #771), and the 2-arg `MIN`/`MAX` are
-/// *not* hoisted reducers). It is the coarse signal for "this site belongs to
-/// a reducer read".
+/// occurs syntactically inside an aggregate-routed builtin call
+/// (`SUM`/`MEAN`/`MIN`/`MAX`/`STDDEV`, plus array-valued `RANK`). `SIZE` and
+/// the 2-arg `MIN`/`MAX` are not routed. It is the coarse signal for "this
+/// site belongs to an aggregate read".
 ///
 /// `reducer_keys` carries the canonical printed text of every enclosing
 /// hoistable reducer, outermost to innermost. Routing must match a site to an
@@ -312,8 +311,9 @@ struct WalkCtx<'a> {
 /// dimension same-element case) falling back to [`classify_subscript_shape`]
 /// (`lookup_dims` resolves a referenced variable's dimensions on demand for
 /// the literal-subscript / position checks); `in_reducer` propagates through
-/// `child_in_reducer = in_reducer || reducer_is_hoistable(builtin)` (SIZE
-/// excluded -- its result doesn't depend on element values). Walk order is
+/// `builtin_routes_through_agg(builtin)` (SIZE excluded -- its result doesn't
+/// depend on element values; RANK included via its array-valued agg path).
+/// Walk order is
 /// left-to-right DFS over the AST, matching `enumerate_agg_nodes`, so the
 /// per-source site `Vec`s are deterministic (a salsa requirement on the
 /// cached IR result).
@@ -380,9 +380,9 @@ fn collect_all_reference_sites(
 /// Recursive helper for [`collect_all_reference_sites`]: left-to-right DFS
 /// over an `Expr2` tree, pushing one [`ReferenceSite`] per model-variable
 /// reference (bucketed by source name). `in_reducer` becomes `true` once we
-/// descend into a `reducer_is_hoistable` builtin's argument and stays sticky
-/// (a reducer nested in another reducer's arg is still inside *a* reducer);
-/// `SIZE` is not `reducer_is_hoistable`, so it never sets the flag.
+/// descend into a builtin that can route through an aggregate node and stays
+/// sticky (a reducer nested in another reducer's arg is still inside *a*
+/// reducer); `SIZE` does not route through an agg, so it never sets the flag.
 fn walk_all_in_expr(
     expr: &crate::ast::Expr2,
     ctx: &WalkCtx<'_>,
@@ -450,7 +450,7 @@ fn walk_all_in_expr(
             }
         }
         Expr2::App(builtin, _, _) => {
-            let pushed_reducer_key = crate::ltm_agg::reducer_is_hoistable(builtin);
+            let pushed_reducer_key = crate::ltm_agg::builtin_routes_through_agg(builtin);
             if pushed_reducer_key {
                 reducer_keys.push(crate::patch::expr2_to_string(expr));
             }
@@ -735,14 +735,9 @@ pub(crate) fn model_ltm_reference_sites(
                     // `Direct` `Wildcard` site only ever means "a hoisted
                     // reducer's (ignored) syntactic shape", "a whole-RHS
                     // variable-backed reducer's argument", a NON-hoisting
-                    // builtin's wildcard arg -- `SIZE(pop[*])` and the
-                    // de-hoisted array-valued `RANK(pop[*], 1)` (GH #771):
-                    // neither is `reducer_is_hoistable`, so `in_reducer` is
-                    // never set for their args and this reclassification
-                    // deliberately does NOT fire; the site keeps `Wildcard`
-                    // and takes `emit_edges_for_reference`'s conservative
-                    // cross-product arm, the same coarse-but-sound treatment
-                    // a Direct `DynamicIndex` gets -- or a (rare) bare
+                    // builtin's wildcard arg such as `SIZE(pop[*])`, which
+                    // never sets `in_reducer` and deliberately keeps
+                    // `Wildcard`, or a (rare) bare
                     // non-reducer whole-array reference (`arr[*]` outside
                     // any builtin), which likewise keeps `Wildcard` and the
                     // cross-product. The original #514 AC4.5 invariant

--- a/src/simlin-engine/src/ltm_agg.rs
+++ b/src/simlin-engine/src/ltm_agg.rs
@@ -1057,7 +1057,7 @@ fn agg_candidate_for_builtin(
     if let Some(rank_arg) = array_valued_rank_arg(builtin) {
         let source_vars = rank_source_vars(rank_arg, ctx.variables)?;
         let slices = rank_combined_read_slice(rank_arg, ctx)?;
-        let result_dims = rank_result_dims_from_read_slice(&slices, ctx)?;
+        let result_dims = rank_result_dims_from_read_slice(&slices, ctx, &source_vars)?;
         if result_dims.is_empty() {
             return None;
         }
@@ -1137,11 +1137,16 @@ fn rank_combined_read_slice(rank_arg: &Expr2, ctx: &AggWalkCtx<'_>) -> Option<Co
 fn rank_result_dims_from_read_slice(
     slices: &CombinedReadSlices,
     ctx: &AggWalkCtx<'_>,
+    source_vars: &[String],
 ) -> Option<Vec<String>> {
-    let (source_var, _) = slices
-        .per_var
-        .iter()
-        .find(|(_, slice)| slice.as_slice() == slices.canonical.as_slice())?;
+    // `per_var` is a HashMap; use the sorted source list so mapped axes with
+    // equivalent canonical slices always choose the same display dimension.
+    let source_var = source_vars.iter().find(|var| {
+        slices
+            .per_var
+            .get(var.as_str())
+            .is_some_and(|slice| slice.as_slice() == slices.canonical.as_slice())
+    })?;
     let source_dims = ctx
         .variables
         .get(&Ident::<Canonical>::new(source_var))
@@ -4343,6 +4348,35 @@ mod tests {
         assert!(synthetic[0].array_valued_rank);
         assert_eq!(synthetic[0].result_dims, vec!["Region"]);
         assert_eq!(source_names(synthetic[0]), vec!["pop"]);
+    }
+
+    /// GH #796 review: multi-source RANK result dims must not depend on
+    /// `HashMap` iteration order. When several sources share the canonical
+    /// rank slice but carry differently named mapped axes, choose the first
+    /// source in canonical source-name order -- the same order `AggSource`
+    /// emission uses.
+    #[test]
+    fn rank_multi_source_result_dims_use_sorted_source_order() {
+        let project = TestProject::new("rank_multi_source_dim_order")
+            .named_dimension("Region", &["r1", "r2"])
+            .named_dimension_with_mapping("State", &["s1", "s2"], "Region")
+            // Declare `b` first to make the expected order source-name-based,
+            // not model declaration order.
+            .array_aux("b[State]", "1")
+            .array_aux("a[Region]", "2")
+            .array_aux("r[Region]", "RANK(a[*] + b[*], 1)");
+
+        let result = agg_nodes(&project);
+        let synthetic: Vec<&AggNode> = result.aggs.iter().filter(|a| a.is_synthetic).collect();
+        assert_eq!(
+            synthetic.len(),
+            1,
+            "multi-source RANK must mint one synthetic aggregate node; got: {:?}",
+            result.aggs
+        );
+        assert!(synthetic[0].array_valued_rank);
+        assert_eq!(source_names(synthetic[0]), vec!["a", "b"]);
+        assert_eq!(synthetic[0].result_dims, vec!["Region"]);
     }
 
     /// GH #776 whole-RHS form: `r[Region] = RANK(pop, 1)` uses the same

--- a/src/simlin-engine/src/ltm_agg.rs
+++ b/src/simlin-engine/src/ltm_agg.rs
@@ -1953,22 +1953,42 @@ pub(crate) fn cartesian_element_parts(element_lists: &[Vec<String>]) -> Vec<Vec<
 /// output slot. The output slot elements must come from the helper's
 /// [`AggNode::result_dims`] dimensions, not the current source's declared
 /// dimensions: mapped sibling sources may carry different element names, and
-/// proper StarRange inputs use the subdimension view.
+/// proper StarRange inputs use the subdimension view. When the ranked view
+/// also has reduced axes, `Iterated` axes are context axes and stay fixed to
+/// the row's already-remapped `iterated_slot_parts`; with no reduced axes,
+/// active-dimension spellings like `RANK(pop[D], 1)` rank across the iterated
+/// axis itself and fan out over the whole result dimension.
 pub(crate) fn rank_output_slot_parts_for_row(
     read_slice: &[AxisRead],
     result_dim_element_lists: &[Vec<String>],
+    iterated_slot_parts: &[String],
 ) -> Option<Vec<Vec<String>>> {
+    let has_reduced_axis = read_slice
+        .iter()
+        .any(|axis| matches!(axis, AxisRead::Reduced { .. }));
     let mut result_axis_elements = result_dim_element_lists.iter();
+    let mut iterated_slots = iterated_slot_parts.iter();
     let mut per_output_axis: Vec<Vec<String>> = Vec::new();
     for axis in read_slice {
         match axis {
             AxisRead::Pinned(_) => {}
-            AxisRead::Iterated { .. } | AxisRead::Reduced { .. } => {
+            AxisRead::Iterated { .. } => {
+                let elems = result_axis_elements.next()?;
+                if has_reduced_axis {
+                    per_output_axis.push(vec![iterated_slots.next()?.clone()]);
+                } else {
+                    per_output_axis.push(elems.clone());
+                }
+            }
+            AxisRead::Reduced { .. } => {
                 per_output_axis.push(result_axis_elements.next()?.clone());
             }
         }
     }
     if result_axis_elements.next().is_some() {
+        return None;
+    }
+    if has_reduced_axis && iterated_slots.next().is_some() {
         return None;
     }
     Some(cartesian_element_parts(&per_output_axis))
@@ -4443,7 +4463,8 @@ mod tests {
         assert_eq!(
             rank_output_slot_parts_for_row(
                 &active_dim_read,
-                &[vec!["north".to_string(), "south".to_string()]]
+                &[vec!["north".to_string(), "south".to_string()]],
+                &["north".to_string()],
             ),
             Some(vec![vec!["north".to_string()], vec!["south".to_string()]])
         );
@@ -4452,9 +4473,32 @@ mod tests {
         assert_eq!(
             rank_output_slot_parts_for_row(
                 &mapped_source_read,
-                &[vec!["r1".to_string(), "r2".to_string()]]
+                &[vec!["r1".to_string(), "r2".to_string()]],
+                &[],
             ),
             Some(vec![vec!["r1".to_string()], vec!["r2".to_string()]])
+        );
+
+        let context_plus_ranked_axis = vec![
+            AxisRead::Iterated {
+                dim: "region".to_string(),
+                source_dim: "region".to_string(),
+            },
+            AxisRead::Reduced { subset: None },
+        ];
+        assert_eq!(
+            rank_output_slot_parts_for_row(
+                &context_plus_ranked_axis,
+                &[
+                    vec!["north".to_string(), "south".to_string()],
+                    vec!["x".to_string(), "y".to_string()],
+                ],
+                &["north".to_string()],
+            ),
+            Some(vec![
+                vec!["north".to_string(), "x".to_string()],
+                vec!["north".to_string(), "y".to_string()]
+            ])
         );
     }
 

--- a/src/simlin-engine/src/ltm_agg.rs
+++ b/src/simlin-engine/src/ltm_agg.rs
@@ -1161,12 +1161,46 @@ fn rank_result_dims_from_read_slice(
             AxisRead::Iterated { dim, .. } => {
                 result_dims.push(canonical_dim_to_datamodel(dim, ctx.dm_dims));
             }
-            AxisRead::Reduced { subset: _ } => {
-                result_dims.push(canonical_dim_to_datamodel(source_dim.name(), ctx.dm_dims));
+            AxisRead::Reduced { subset } => {
+                result_dims.push(rank_reduced_axis_result_dim(
+                    source_dim,
+                    subset.as_deref(),
+                    ctx,
+                ));
             }
         }
     }
     Some(result_dims)
+}
+
+fn rank_reduced_axis_result_dim(
+    source_dim: &crate::dimensions::Dimension,
+    subset: Option<&[String]>,
+    ctx: &AggWalkCtx<'_>,
+) -> String {
+    let Some(subset) = subset else {
+        return canonical_dim_to_datamodel(source_dim.name(), ctx.dm_dims);
+    };
+    let source_elems = crate::ltm_augment::dimension_element_names(source_dim);
+    let source_canon = source_dim.canonical_name();
+    for dm_dim in ctx.dm_dims {
+        let candidate = crate::common::CanonicalDimensionName::from_raw(dm_dim.name());
+        let Some(rel) = ctx
+            .dim_ctx
+            .get_subdimension_relation(&candidate, source_canon)
+        else {
+            continue;
+        };
+        let candidate_subset: Option<Vec<String>> = rel
+            .parent_offsets
+            .iter()
+            .map(|&o| source_elems.get(o).cloned())
+            .collect();
+        if candidate_subset.as_deref() == Some(subset) {
+            return dm_dim.name().to_string();
+        }
+    }
+    canonical_dim_to_datamodel(source_dim.name(), ctx.dm_dims)
 }
 
 /// What sort of aggregate node a reducer subexpression maps to.
@@ -1915,32 +1949,26 @@ pub(crate) fn cartesian_element_parts(element_lists: &[Vec<String>]) -> Vec<Vec<
 
 /// The RANK output slots a source row can affect.
 ///
-/// `iterated_slot_parts` are the row's already-remapped `Iterated` axis
-/// coordinates from `read_slice_row_parts`. Each `Iterated` output axis is
-/// fixed to that coordinate, while each `Reduced` output axis ranges over
-/// the ranked extent. `Pinned` axes do not appear in the rank output.
+/// RANK is array-valued, so each non-pinned ranked axis can contribute every
+/// output slot. The output slot elements must come from the helper's
+/// [`AggNode::result_dims`] dimensions, not the current source's declared
+/// dimensions: mapped sibling sources may carry different element names, and
+/// proper StarRange inputs use the subdimension view.
 pub(crate) fn rank_output_slot_parts_for_row(
     read_slice: &[AxisRead],
-    source_dim_element_lists: &[Vec<String>],
-    iterated_slot_parts: &[String],
+    result_dim_element_lists: &[Vec<String>],
 ) -> Option<Vec<Vec<String>>> {
-    if read_slice.len() != source_dim_element_lists.len() {
-        return None;
-    }
-    let mut iterated_slots = iterated_slot_parts.iter();
+    let mut result_axis_elements = result_dim_element_lists.iter();
     let mut per_output_axis: Vec<Vec<String>> = Vec::new();
-    for (axis, elems) in read_slice.iter().zip(source_dim_element_lists) {
+    for axis in read_slice {
         match axis {
             AxisRead::Pinned(_) => {}
-            AxisRead::Iterated { .. } => {
-                per_output_axis.push(vec![iterated_slots.next()?.clone()]);
-            }
-            AxisRead::Reduced { subset } => {
-                per_output_axis.push(subset.clone().unwrap_or_else(|| elems.clone()));
+            AxisRead::Iterated { .. } | AxisRead::Reduced { .. } => {
+                per_output_axis.push(result_axis_elements.next()?.clone());
             }
         }
     }
-    if iterated_slots.next().is_some() {
+    if result_axis_elements.next().is_some() {
         return None;
     }
     Some(cartesian_element_parts(&per_output_axis))
@@ -4377,6 +4405,57 @@ mod tests {
         assert!(synthetic[0].array_valued_rank);
         assert_eq!(source_names(synthetic[0]), vec!["a", "b"]);
         assert_eq!(synthetic[0].result_dims, vec!["Region"]);
+    }
+
+    /// GH #796 review: array-valued RANK over a proper StarRange returns the
+    /// ranked subdimension view. Its synthetic helper must be dimensioned over
+    /// `Core`, not the parent `Region`, or helper slots and source halves drift.
+    #[test]
+    fn rank_star_range_result_dims_preserve_subdimension() {
+        let project = TestProject::new("rank_star_range_subdimension")
+            .named_dimension("Region", &["a", "b", "c"])
+            .named_dimension("Core", &["a", "b"])
+            .array_aux("arr[Region]", "10")
+            .array_aux("ranking[Core]", "RANK(arr[*:Core], 1)");
+
+        let result = agg_nodes(&project);
+        let synthetic: Vec<&AggNode> = result.aggs.iter().filter(|a| a.is_synthetic).collect();
+        assert_eq!(
+            synthetic.len(),
+            1,
+            "subdimension RANK must mint one synthetic aggregate node; got: {:?}",
+            result.aggs
+        );
+        assert!(synthetic[0].array_valued_rank);
+        assert_eq!(synthetic[0].result_dims, vec!["Core"]);
+    }
+
+    /// GH #796 review: the source-to-RANK slot helper is shared by element
+    /// graph edges and link-score names. It must fan active/iterated axes out
+    /// across every RANK output slot and use result-dimension element names,
+    /// not source-dimension names, for mapped sibling sources.
+    #[test]
+    fn rank_output_slots_use_result_dimension_elements() {
+        let active_dim_read = vec![AxisRead::Iterated {
+            dim: "region".to_string(),
+            source_dim: "region".to_string(),
+        }];
+        assert_eq!(
+            rank_output_slot_parts_for_row(
+                &active_dim_read,
+                &[vec!["north".to_string(), "south".to_string()]]
+            ),
+            Some(vec![vec!["north".to_string()], vec!["south".to_string()]])
+        );
+
+        let mapped_source_read = vec![AxisRead::Reduced { subset: None }];
+        assert_eq!(
+            rank_output_slot_parts_for_row(
+                &mapped_source_read,
+                &[vec!["r1".to_string(), "r2".to_string()]]
+            ),
+            Some(vec![vec!["r1".to_string()], vec!["r2".to_string()]])
+        );
     }
 
     /// GH #776 whole-RHS form: `r[Region] = RANK(pop, 1)` uses the same

--- a/src/simlin-engine/src/ltm_agg.rs
+++ b/src/simlin-engine/src/ltm_agg.rs
@@ -82,9 +82,10 @@
 //! one variable read with two different slices (I3b), and a no-`Reduced`
 //! source outside the projection rule (a Pinned-bearing, dim-subset,
 //! permuted, or mapped mix; see [`accept_source_slices`]). `RANK` is
-//! recognized as a reducer but never hoisted (GH #771): it is ARRAY-valued,
-//! so an agg node -- "a scalar value per result slot" -- has no value to
-//! hold for it; see [`reducer_is_hoistable`].
+//! recognized as ARRAY-valued (GH #771) and is represented separately by an
+//! arrayed synthetic agg whose output axes are the ranked argument's
+//! non-pinned axes; each ranked source row feeds every rank-output slot in
+//! its iterated context (GH #776).
 //!
 //! Whole-RHS reduces with a non-trivial slice *are* recognized -- the
 //! variable is the agg, `result_dims` carries the `Iterated` axes' dims, and
@@ -202,19 +203,11 @@ pub(crate) fn reducer_kind_from_name(name: &str, arity: usize) -> Option<Reducer
 /// silently corrupts. The three consumers are
 /// `builtins_visitor::arg_has_bare_var_ref` (the GH #541 arrayed-capture
 /// gate), `ltm_augment::expr_is_array_slice_valued` (the GH #743
-/// unfreezable-`PREVIOUS` detector), and [`reducer_is_hoistable`] (the agg
-/// hoisting gate, GH #771): an agg node *is* "a scalar value per result
-/// slot", and RANK has no such value to name.
-///
-/// Residual of the GH #771 de-hoist: a `RANK(pop, dir)` reference
-/// classifies by its syntactic shape (a bare `pop` is `Bare` -> diagonal
-/// edges), so loops through the rank ORDERING -- element r's rank changing
-/// because element s moved past it -- are not enumerated. This replaces the
-/// strictly-worse pre-#771 state (cross-element loops enumerated through an
-/// ill-shaped scalar agg whose every score was warned-zero); the
-/// alternative -- reclassifying value-shaped reducer args as `DynamicIndex`
-/// -- would recreate the GH #525 phantom pathology (cross-product edges
-/// reading diagonal scores) and was rejected.
+/// unfreezable-`PREVIOUS` detector), and scalar-reducer agg minting
+/// ([`reducer_is_hoistable`], GH #771). LTM still routes RANK references
+/// through synthetic aggs, but those aggs are marked array-valued and their
+/// source→agg half uses the RANK-specific all-read-rows-to-all-output-slots
+/// treatment rather than the scalar reducer row→slot treatment (GH #776).
 pub(crate) fn reducer_collapses_to_scalar(name: &str, arity: usize) -> bool {
     reducer_kind_from_name(name, arity).is_some() && name != "rank"
 }
@@ -246,23 +239,25 @@ fn builtin_reducer_arity<E>(builtin: &BuiltinFn<E>) -> usize {
 /// shape-expressiveness design).
 ///
 /// `SIZE` is recognized as a reducer but never hoisted (its link score is
-/// always 0), and it never sets the element-graph walker's `in_reducer`
-/// marker. `RANK` is recognized but never hoisted either (GH #771): it is
-/// ARRAY-valued, so a scalar agg node for it has an ill-typed equation that
-/// cannot compile -- an agg node exists to give a scalar reduction a name,
-/// and RANK has no scalar reduction to name. Its references stay `Direct`
-/// (a bare arg classifies `Bare` -> diagonal edges, scored by the GH #742
-/// arrayed-capture machinery). This is the predicate the reference-site
-/// IR's AST walk (`db::ltm_ir::walk_all_in_expr`) uses to flip
-/// `child_in_reducer`, and that [`reducer_source_vars`] uses to gate which
-/// subexpressions become aggregate nodes, so the agg enumerator, the
-/// element graph, and the link-score generator all agree on the hoisted set.
+/// always 0). `RANK` is recognized but not scalar-hoistable (GH #771): it is
+/// ARRAY-valued, so it uses the separate array-valued agg path. This
+/// predicate therefore gates only scalar-valued reducer aggs; the
+/// reference-site IR uses [`builtin_routes_through_agg`] so RANK arguments
+/// are still marked as aggregate-routed when an array-valued RANK agg was
+/// minted (GH #776).
 pub(crate) fn reducer_is_hoistable<E>(builtin: &BuiltinFn<E>) -> bool {
     let arity = builtin_reducer_arity(builtin);
     matches!(
         reducer_kind_from_name(builtin.name(), arity),
         Some(ReducerKind::Linear | ReducerKind::Nonlinear)
     ) && reducer_collapses_to_scalar(builtin.name(), arity)
+}
+
+/// `true` when references inside `builtin` may route through an aggregate
+/// node. Scalar reducers use [`reducer_is_hoistable`]; array-valued `RANK`
+/// uses a synthetic arrayed agg whose source half has RANK-specific routing.
+pub(crate) fn builtin_routes_through_agg<E>(builtin: &BuiltinFn<E>) -> bool {
+    reducer_is_hoistable(builtin) || matches!(builtin, BuiltinFn::Rank(_, _))
 }
 
 /// How one *source axis* of a hoisted reducer is consumed.
@@ -446,6 +441,14 @@ pub struct AggNode {
     /// value; `false` when the owning variable already *is* the aggregate
     /// node (its entire dt-equation is exactly this reducer).
     pub is_synthetic: bool,
+    /// `true` for a synthetic helper representing array-valued `RANK`.
+    ///
+    /// A scalar reducer's read-slice rows feed one scalar result slot each
+    /// (`SUM(matrix[D1,*])`: every `matrix[d1,*]` row feeds `agg[d1]`).
+    /// `RANK` is different: every ranked source row can change every rank
+    /// output element in the same iterated context, so the source→agg half
+    /// fans each read row out across all non-pinned result-axis slots.
+    pub array_valued_rank: bool,
 }
 
 impl AggNode {
@@ -732,8 +735,12 @@ fn walk_var_equation(
     next_synthetic_n: &mut usize,
 ) {
     if let Expr2::App(builtin, _, _) = expr
-        && let Some(source_vars) = reducer_source_vars(builtin, ctx.variables)
-        && let Some(slices) = combined_read_slice(builtin, ctx)
+        && let Some(candidate) = agg_candidate_for_builtin(builtin, ctx)
+        // Array-valued RANK helpers are always synthetic. The owning variable
+        // is the final consumer of the rank array, not the rank helper itself;
+        // keeping the normal agg→target half preserves the same projection
+        // path as an inline rank subexpression.
+        && !candidate.array_valued_rank
         // A whole-RHS reducer whose slice/result shape the variable-backed
         // machinery cannot express is NOT variable-backed: it falls through
         // to `walk_subexpr_for_aggs`, which mints a *synthetic* agg for the
@@ -747,12 +754,12 @@ fn walk_var_equation(
         // the CANONICAL (co-source) slice -- a projection feeder's
         // all-`Iterated` slice (GH #767) says nothing about the reducer's
         // result shape.
-        && variable_backed_shape_is_expressible(&slices.canonical, ctx.target_iterated_dims)
+        && variable_backed_shape_is_expressible(&candidate.slices.canonical, ctx.target_iterated_dims)
         // `None` (a structurally-impossible missing per-var slice; see
         // `agg_sources`' rustdoc) falls through to `walk_subexpr_for_aggs`,
         // whose own `agg_sources` call declines identically -- the
         // reference stays on the conservative Direct path.
-        && let Some(sources) = agg_sources(source_vars, &slices, ctx)
+        && let Some(sources) = agg_sources(candidate.source_vars, &candidate.slices, ctx)
     {
         // Whole-RHS reducer: the variable IS the aggregate node. The agg
         // node's result shape is the *reducer's* result shape (the `Iterated`
@@ -762,7 +769,7 @@ fn walk_var_equation(
         // value); a partial reduce keyed by the active A2A dimension
         // (`rowsum[D1] = SUM(matrix[D1, *])`) keeps `[D1]` as its result dims.
         let key = crate::patch::expr2_to_string(expr);
-        let result_dims = result_dims_from_read_slice(&slices.canonical, ctx.dm_dims);
+        let result_dims = candidate.result_dims;
         // DECLINE the degenerate square-source shape (repeated result dim,
         // GH #778/#785): the per-axis emission paths pin subscript indices by
         // dim name and disagree across the duplicated occurrence. Declining
@@ -779,6 +786,7 @@ fn walk_var_equation(
                 AggKind::VariableBacked {
                     var_name: var_name.to_string(),
                     result_dims,
+                    array_valued_rank: false,
                 },
                 sources,
             );
@@ -961,16 +969,9 @@ fn walk_subexpr_for_aggs(
             // slice/result-dims derivation runs only for an actual hoistable
             // reducer App (`reducer_source_vars` is `None` for every other
             // builtin -- it would be wasted work on the non-reducer majority).
-            let source_vars = (!in_reducer)
-                .then(|| reducer_source_vars(builtin, ctx.variables))
+            let candidate = (!in_reducer)
+                .then(|| agg_candidate_for_builtin(builtin, ctx))
                 .flatten();
-            let slices = source_vars
-                .is_some()
-                .then(|| combined_read_slice(builtin, ctx))
-                .flatten();
-            let result_dims = slices
-                .as_ref()
-                .map(|s| result_dims_from_read_slice(&s.canonical, ctx.dm_dims));
             // DECLINE the degenerate square-source shape (repeated result
             // dim, GH #778/#785): the per-axis emission paths pin subscript
             // indices by dim name and disagree across the duplicated
@@ -978,18 +979,17 @@ fn walk_subexpr_for_aggs(
             // `else` descent the not-statically-describable carve-outs take,
             // with `in_reducer` unchanged so the source references keep their
             // conservative Direct shape. See [`result_dims_has_repeated_dim`].
-            let square_source = result_dims
-                .as_deref()
+            let square_source = candidate
+                .as_ref()
+                .map(|c| c.result_dims.as_slice())
                 .is_some_and(result_dims_has_repeated_dim);
             if !square_source
-                && let Some(source_vars) = source_vars
-                && let Some(slices) = slices
-                && let Some(result_dims) = result_dims
+                && let Some(candidate) = candidate
                 // `None` (a structurally-impossible missing per-var slice;
                 // see `agg_sources`' rustdoc) declines the hoist: the `else`
                 // arm descends with `in_reducer` unchanged, exactly like the
                 // not-statically-describable carve-outs.
-                && let Some(sources) = agg_sources(source_vars, &slices, ctx)
+                && let Some(sources) = agg_sources(candidate.source_vars, &candidate.slices, ctx)
             {
                 let key = crate::patch::expr2_to_string(expr);
                 register_agg(
@@ -997,7 +997,10 @@ fn walk_subexpr_for_aggs(
                     next_synthetic_n,
                     &key,
                     owner_var,
-                    AggKind::Synthetic { result_dims },
+                    AggKind::Synthetic {
+                        result_dims: candidate.result_dims,
+                        array_valued_rank: candidate.array_valued_rank,
+                    },
                     sources,
                 );
                 // Descend with `in_reducer = true` so nested reducers are
@@ -1039,14 +1042,140 @@ fn walk_subexpr_for_aggs(
     }
 }
 
+/// A reducer-like builtin that can be represented by an [`AggNode`].
+struct AggCandidate {
+    source_vars: Vec<String>,
+    slices: CombinedReadSlices,
+    result_dims: Vec<String>,
+    array_valued_rank: bool,
+}
+
+fn agg_candidate_for_builtin(
+    builtin: &BuiltinFn<Expr2>,
+    ctx: &AggWalkCtx<'_>,
+) -> Option<AggCandidate> {
+    if let Some(rank_arg) = array_valued_rank_arg(builtin) {
+        let source_vars = rank_source_vars(rank_arg, ctx.variables)?;
+        let slices = rank_combined_read_slice(rank_arg, ctx)?;
+        let result_dims = rank_result_dims_from_read_slice(&slices, ctx)?;
+        if result_dims.is_empty() {
+            return None;
+        }
+        return Some(AggCandidate {
+            source_vars,
+            slices,
+            result_dims,
+            array_valued_rank: true,
+        });
+    }
+
+    let source_vars = reducer_source_vars(builtin, ctx.variables)?;
+    let slices = combined_read_slice(builtin, ctx)?;
+    let result_dims = result_dims_from_read_slice(&slices.canonical, ctx.dm_dims);
+    Some(AggCandidate {
+        source_vars,
+        slices,
+        result_dims,
+        array_valued_rank: false,
+    })
+}
+
+fn array_valued_rank_arg(builtin: &BuiltinFn<Expr2>) -> Option<&Expr2> {
+    match builtin {
+        BuiltinFn::Rank(arg, _) => Some(arg),
+        _ => None,
+    }
+}
+
+/// Model variables referenced by RANK's ranked argument.
+///
+/// The direction argument is intentionally excluded from the agg's sources:
+/// it remains a direct dependency of the target expression. The RANK helper
+/// represents how the ranked array values feed rank slots, and the source
+/// half's scoring machinery assumes that relationship.
+fn rank_source_vars(
+    rank_arg: &Expr2,
+    variables: &HashMap<Ident<Canonical>, crate::variable::Variable>,
+) -> Option<Vec<String>> {
+    let mut sources: Vec<String> = Vec::new();
+    collect_var_refs(rank_arg, &mut sources);
+    sources.retain(|name| variables.contains_key(&Ident::<Canonical>::new(name)));
+    if sources.is_empty() {
+        return None;
+    }
+    let has_arrayed_source = sources.iter().any(|name| {
+        variables
+            .get(&Ident::<Canonical>::new(name))
+            .and_then(|v| v.get_dimensions())
+            .map(|dims| !dims.is_empty())
+            .unwrap_or(false)
+    });
+    if !has_arrayed_source {
+        return None;
+    }
+    sources.sort();
+    sources.dedup();
+    Some(sources)
+}
+
+fn rank_combined_read_slice(rank_arg: &Expr2, ctx: &AggWalkCtx<'_>) -> Option<CombinedReadSlices> {
+    let mut refs: Vec<(String, Vec<AxisRead>)> = Vec::new();
+    let mut ok = true;
+    collect_arrayed_source_slices(rank_arg, ctx, &mut refs, &mut ok);
+    if !ok || refs.is_empty() {
+        return None;
+    }
+    accept_source_slices(refs)
+}
+
+/// RANK's output shape is the ranked argument's non-pinned axis shape.
+///
+/// Scalar reducers use only `Iterated` axes as result dims because the
+/// `Reduced` axes collapse away. RANK is array-valued, so the full output
+/// helper is dimensioned over both the surrounding iterated axes and the
+/// ranked axes; only literal `Pinned` axes disappear.
+fn rank_result_dims_from_read_slice(
+    slices: &CombinedReadSlices,
+    ctx: &AggWalkCtx<'_>,
+) -> Option<Vec<String>> {
+    let (source_var, _) = slices
+        .per_var
+        .iter()
+        .find(|(_, slice)| slice.as_slice() == slices.canonical.as_slice())?;
+    let source_dims = ctx
+        .variables
+        .get(&Ident::<Canonical>::new(source_var))
+        .and_then(|v| v.get_dimensions())?;
+    if source_dims.len() != slices.canonical.len() {
+        return None;
+    }
+    let mut result_dims = Vec::new();
+    for (axis, source_dim) in slices.canonical.iter().zip(source_dims) {
+        match axis {
+            AxisRead::Pinned(_) => {}
+            AxisRead::Iterated { dim, .. } => {
+                result_dims.push(canonical_dim_to_datamodel(dim, ctx.dm_dims));
+            }
+            AxisRead::Reduced { subset: _ } => {
+                result_dims.push(canonical_dim_to_datamodel(source_dim.name(), ctx.dm_dims));
+            }
+        }
+    }
+    Some(result_dims)
+}
+
 /// What sort of aggregate node a reducer subexpression maps to.
 enum AggKind {
     /// A `$⁚ltm⁚agg⁚{n}` auxiliary must be minted.
-    Synthetic { result_dims: Vec<String> },
+    Synthetic {
+        result_dims: Vec<String>,
+        array_valued_rank: bool,
+    },
     /// The owning variable already is the aggregate node.
     VariableBacked {
         var_name: String,
         result_dims: Vec<String>,
+        array_valued_rank: bool,
     },
 }
 
@@ -1120,7 +1249,10 @@ fn register_agg(
     sources: Vec<AggSource>,
 ) {
     let idx = match kind {
-        AggKind::Synthetic { result_dims } => {
+        AggKind::Synthetic {
+            result_dims,
+            array_valued_rank,
+        } => {
             if let Some(&existing) = result.synthetic_by_key.get(key) {
                 existing
             } else {
@@ -1132,6 +1264,7 @@ fn register_agg(
                     result_dims,
                     sources,
                     is_synthetic: true,
+                    array_valued_rank,
                 });
                 let idx = result.aggs.len() - 1;
                 result.synthetic_by_key.insert(key.to_string(), idx);
@@ -1141,6 +1274,7 @@ fn register_agg(
         AggKind::VariableBacked {
             var_name,
             result_dims,
+            array_valued_rank,
         } => {
             // Each whole-RHS-reducer variable is its own aggregate node;
             // never deduped, and not entered in `synthetic_by_key`.
@@ -1150,6 +1284,7 @@ fn register_agg(
                 result_dims,
                 sources,
                 is_synthetic: false,
+                array_valued_rank,
             });
             result.aggs.len() - 1
         }
@@ -1754,6 +1889,56 @@ pub(crate) fn result_dims_has_repeated_dim(result_dims: &[String]) -> bool {
         .iter()
         .enumerate()
         .any(|(i, d)| result_dims[..i].contains(d))
+}
+
+/// Cartesian product of element-name lists, preserving each tuple as parts.
+pub(crate) fn cartesian_element_parts(element_lists: &[Vec<String>]) -> Vec<Vec<String>> {
+    let mut out: Vec<Vec<String>> = vec![Vec::new()];
+    for elems in element_lists {
+        let mut next = Vec::with_capacity(out.len() * elems.len());
+        for prefix in &out {
+            for elem in elems {
+                let mut tuple = prefix.clone();
+                tuple.push(elem.clone());
+                next.push(tuple);
+            }
+        }
+        out = next;
+    }
+    out
+}
+
+/// The RANK output slots a source row can affect.
+///
+/// `iterated_slot_parts` are the row's already-remapped `Iterated` axis
+/// coordinates from `read_slice_row_parts`. Each `Iterated` output axis is
+/// fixed to that coordinate, while each `Reduced` output axis ranges over
+/// the ranked extent. `Pinned` axes do not appear in the rank output.
+pub(crate) fn rank_output_slot_parts_for_row(
+    read_slice: &[AxisRead],
+    source_dim_element_lists: &[Vec<String>],
+    iterated_slot_parts: &[String],
+) -> Option<Vec<Vec<String>>> {
+    if read_slice.len() != source_dim_element_lists.len() {
+        return None;
+    }
+    let mut iterated_slots = iterated_slot_parts.iter();
+    let mut per_output_axis: Vec<Vec<String>> = Vec::new();
+    for (axis, elems) in read_slice.iter().zip(source_dim_element_lists) {
+        match axis {
+            AxisRead::Pinned(_) => {}
+            AxisRead::Iterated { .. } => {
+                per_output_axis.push(vec![iterated_slots.next()?.clone()]);
+            }
+            AxisRead::Reduced { subset } => {
+                per_output_axis.push(subset.clone().unwrap_or_else(|| elems.clone()));
+            }
+        }
+    }
+    if iterated_slots.next().is_some() {
+        return None;
+    }
+    Some(cartesian_element_parts(&per_output_axis))
 }
 
 /// `true` when `name` is a synthetic aggregate-node name (`$⁚ltm⁚agg⁚{n}`).
@@ -4093,12 +4278,11 @@ mod tests {
         assert_eq!(reducer_kind(&size), Some(ReducerKind::Constant));
         assert_eq!(reducer_kind(&abs), None);
 
-        // Hoistable: recognized AND not Constant AND scalar-valued (I5) --
+        // Scalar-hoistable: recognized AND not Constant AND scalar-valued (I5) --
         // SUM / 1-arg MEAN / 1-arg MIN / 1-arg MAX / STDDEV. SIZE is
         // recognized but never hoisted (its link score is always 0); RANK is
-        // recognized but never hoisted (array-valued -- a scalar agg node
-        // for it cannot compile, GH #771); 2-arg MIN/MAX are not recognized
-        // at all.
+        // not scalar-hoistable (array-valued -- it uses its own agg path,
+        // GH #771/#776); 2-arg MIN/MAX are not recognized at all.
         assert!(reducer_is_hoistable(&sum));
         assert!(reducer_is_hoistable(&mean_1));
         assert!(reducer_is_hoistable(&min_1));
@@ -4137,45 +4321,50 @@ mod tests {
         assert_eq!(reducer_kind_from_name("abs", 1), None);
     }
 
-    /// GH #771: a RANK subexpression is NOT hoisted -- RANK is array-valued
-    /// (Vensim VECTOR RANK), so a scalar agg node for it has an ill-typed
-    /// equation. `reducer_is_hoistable` requires
-    /// `reducer_collapses_to_scalar` (invariant I5), keeping the `pop`
-    /// reference on the Direct path (`Bare` -> diagonal edges, scored by
-    /// the GH #742 arrayed-capture machinery).
+    /// GH #776: a RANK subexpression mints an ARRAY-valued synthetic agg,
+    /// not a scalar reducer agg. Its result dims are the ranked argument's
+    /// non-pinned axes, so a bare one-dimensional source ranks over Region.
     #[test]
-    fn rank_subexpression_is_not_hoisted() {
-        let project = TestProject::new("rank_not_hoisted")
+    fn rank_subexpression_mints_array_valued_synthetic_agg() {
+        let project = TestProject::new("rank_array_agg")
             .named_dimension("Region", &["north", "south"])
             .array_aux("pop[Region]", "100")
             .array_aux("scale[Region]", "pop[Region] * 0.01")
             .array_aux("grow[Region]", "scale[Region] * RANK(pop, 1)");
 
         let result = agg_nodes(&project);
-        assert!(
-            result.aggs.is_empty(),
-            "RANK must not mint an aggregate node; got: {:?}",
+        let synthetic: Vec<&AggNode> = result.aggs.iter().filter(|a| a.is_synthetic).collect();
+        assert_eq!(
+            synthetic.len(),
+            1,
+            "RANK must mint one synthetic aggregate node; got: {:?}",
             result.aggs
         );
+        assert!(synthetic[0].array_valued_rank);
+        assert_eq!(synthetic[0].result_dims, vec!["Region"]);
+        assert_eq!(source_names(synthetic[0]), vec!["pop"]);
     }
 
-    /// GH #771 (whole-RHS form): `r[Region] = RANK(pop, 1)` is not a
-    /// variable-backed aggregate node either -- the de-hoist applies to
-    /// both agg kinds (the gate is `reducer_source_vars`'
-    /// `reducer_is_hoistable`, shared by both walks).
+    /// GH #776 whole-RHS form: `r[Region] = RANK(pop, 1)` uses the same
+    /// synthetic array-valued helper as the inline spelling, rather than
+    /// becoming a variable-backed scalar reducer agg.
     #[test]
-    fn rank_whole_rhs_is_not_variable_backed() {
+    fn rank_whole_rhs_mints_synthetic_not_variable_backed() {
         let project = TestProject::new("rank_whole_rhs")
             .named_dimension("Region", &["north", "south"])
             .array_aux("pop[Region]", "100")
             .array_aux("r[Region]", "RANK(pop, 1)");
 
         let result = agg_nodes(&project);
-        assert!(
-            result.aggs.is_empty(),
-            "whole-RHS RANK must not become a variable-backed agg; got: {:?}",
+        let synthetic: Vec<&AggNode> = result.aggs.iter().filter(|a| a.is_synthetic).collect();
+        assert_eq!(
+            synthetic.len(),
+            1,
+            "whole-RHS RANK must mint one synthetic aggregate node; got: {:?}",
             result.aggs
         );
+        assert!(synthetic[0].array_valued_rank);
+        assert!(result.aggs.iter().all(|a| a.is_synthetic));
     }
 
     /// GH #766: a StarRange naming a dimension that is NEITHER the axis's

--- a/src/simlin-engine/src/ltm_augment.rs
+++ b/src/simlin-engine/src/ltm_augment.rs
@@ -1466,8 +1466,8 @@ fn contains_unfreezable_previous(expr: &Expr0) -> bool {
 /// equation whose only reducer is SIZE keeps the changed-first convention
 /// (the whole reducer is freezable as `PREVIOUS(size(...))`), so it does
 /// not reach this gate. RANK is excluded by that predicate: it is
-/// array-valued and never hoisted (GH #771/#742), so its bare arg is a
-/// genuine `Bare` diagonal reference, not this feeder shape.
+/// array-valued and uses its own agg-routing path (GH #771/#776), so its
+/// bare arg is not this scalar-reducer feeder shape.
 fn references_bare_source_inside_reducer(
     expr: &Expr0,
     source: &Ident<Canonical>,

--- a/src/simlin-engine/src/ltm_augment_tests.rs
+++ b/src/simlin-engine/src/ltm_augment_tests.rs
@@ -4472,8 +4472,8 @@ fn references_bare_source_inside_reducer_detects_only_the_dangerous_shape() {
         &frac,
         false
     ));
-    // RANK is array-valued and never hoisted (GH #771/#742): its bare arg is
-    // a genuine Bare diagonal reference, not the feeder shape.
+    // RANK is array-valued and uses its own agg-routing path (GH #771/#776):
+    // its bare arg is not the scalar-reducer feeder shape.
     assert!(!references_bare_source_inside_reducer(
         &parse("RANK(frac, 1)"),
         &frac,

--- a/src/simlin-engine/tests/integration/ltm_array_agg.rs
+++ b/src/simlin-engine/tests/integration/ltm_array_agg.rs
@@ -5077,6 +5077,79 @@ fn previous_of_rank_compiles_per_element() {
     );
 }
 
+/// GH #796 review follow-up: `RANK(matrix[Region,*], 1)` ranks Product within
+/// each Region context. The source-to-RANK helper scores should therefore fan
+/// a north matrix row across north product rank slots only, never into south
+/// rank slots.
+#[test]
+fn rank_context_axis_link_scores_stay_pinned_per_row() {
+    let project = TestProject::new("rank_context_axis_link_scores")
+        .with_sim_time(0.0, 8.0, 1.0)
+        .named_dimension("Region", &["north", "south"])
+        .named_dimension("Product", &["x", "y"])
+        .array_stock("matrix[Region,Product]", "100", &["growth"], &[], None)
+        .array_aux("ranked[Region,Product]", "RANK(matrix[Region,*], 1)")
+        .array_flow(
+            "growth[Region,Product]",
+            "ranked[Region,Product] * 0.01",
+            None,
+        )
+        .build_datamodel();
+
+    let mut db = SimlinDb::default();
+    let sync = sync_from_datamodel_incremental(&mut db, &project, None);
+    set_project_ltm_enabled(&mut db, sync.project, true);
+    let compiled = compile_project_incremental(&db, sync.project, "main")
+        .expect("LTM-enabled compilation should succeed");
+    assert!(
+        assembly_warnings(&db, sync.project).is_empty(),
+        "mixed-context RANK helper scores must compile without warnings"
+    );
+
+    let ltm_vars = model_ltm_variables(&db, sync.models["main"].source_model, sync.project)
+        .vars
+        .clone();
+    let rank_agg = ltm_vars
+        .iter()
+        .find(|v| {
+            v.name.starts_with("$\u{205A}ltm\u{205A}agg\u{205A}")
+                && v.dimensions == vec!["Region".to_string(), "Product".to_string()]
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected Region/Product RANK helper; got: {:?}",
+                ltm_vars
+                    .iter()
+                    .map(|v| (v.name.as_str(), v.dimensions.as_slice()))
+                    .collect::<Vec<_>>()
+            )
+        });
+    for product in ["x", "y"] {
+        let expected = format!(
+            "{LINK_SCORE_PREFIX}matrix[north,x]\u{2192}{}[north,{product}]",
+            rank_agg.name
+        );
+        assert!(
+            ltm_vars.iter().any(|v| v.name == expected),
+            "north row should feed north rank slot {product}; got: {:?}",
+            ltm_vars.iter().map(|v| v.name.as_str()).collect::<Vec<_>>()
+        );
+        let phantom = format!(
+            "{LINK_SCORE_PREFIX}matrix[north,x]\u{2192}{}[south,{product}]",
+            rank_agg.name
+        );
+        assert!(
+            !ltm_vars.iter().any(|v| v.name == phantom),
+            "north row must not feed south rank slot {product}; got: {:?}",
+            ltm_vars.iter().map(|v| v.name.as_str()).collect::<Vec<_>>()
+        );
+    }
+
+    let mut vm = Vm::new(compiled).expect("VM construction should succeed");
+    vm.run_to_end()
+        .expect("VM simulation should run to completion");
+}
+
 /// GH #742, LTM leg: a link-score partial that freezes an array-valued
 /// non-reducing builtin subtree (`PREVIOUS(rank(pop, 1))` inside the
 /// `scale -> grow` partial of `grow[Region] = scale[Region] * RANK(pop, 1)`)

--- a/src/simlin-engine/tests/integration/ltm_array_agg.rs
+++ b/src/simlin-engine/tests/integration/ltm_array_agg.rs
@@ -5150,6 +5150,108 @@ fn rank_context_axis_link_scores_stay_pinned_per_row() {
         .expect("VM simulation should run to completion");
 }
 
+/// GH #796 review follow-up: a RANK helper over a source dimension can feed a
+/// target dimension only through a positional mapping. The source-to-helper
+/// half is over the ranked source's `State` slots, and the helper-to-target
+/// half must project each `Region` target element back to the mapped `State`
+/// helper slot instead of emitting an ill-typed bare helper score.
+#[test]
+fn rank_mapped_helper_slots_score_mapped_targets() {
+    let project = TestProject::new("rank_mapped_helper_target_scores")
+        .with_sim_time(0.0, 8.0, 1.0)
+        .named_dimension("Region", &["r1", "r2"])
+        .named_dimension_with_mapping("State", &["s1", "s2"], "Region")
+        .array_stock("score[State]", "100", &["growth"], &[], None)
+        .array_aux("ranked[Region]", "RANK(score[*], 1)")
+        .array_flow("growth[State]", "ranked * 0.01", None)
+        .build_datamodel();
+
+    let mut db = SimlinDb::default();
+    let sync = sync_from_datamodel_incremental(&mut db, &project, None);
+    set_project_ltm_enabled(&mut db, sync.project, true);
+    let compiled = compile_project_incremental(&db, sync.project, "main")
+        .expect("LTM-enabled compilation should succeed");
+    assert!(
+        assembly_warnings(&db, sync.project).is_empty(),
+        "mapped RANK helper target scores must compile without warnings: {:?}",
+        assembly_warnings(&db, sync.project)
+    );
+
+    let ltm_vars = model_ltm_variables(&db, sync.models["main"].source_model, sync.project)
+        .vars
+        .clone();
+    let rank_agg = ltm_vars
+        .iter()
+        .find(|v| {
+            v.name.starts_with("$\u{205A}ltm\u{205A}agg\u{205A}")
+                && v.dimensions == vec!["State".to_string()]
+        })
+        .unwrap_or_else(|| {
+            panic!(
+                "expected State-dimensioned RANK helper; got: {:?}",
+                ltm_vars
+                    .iter()
+                    .map(|v| (v.name.as_str(), v.dimensions.as_slice()))
+                    .collect::<Vec<_>>()
+            )
+        });
+
+    for (state, region) in [("s1", "r1"), ("s2", "r2")] {
+        let expected = format!(
+            "{LINK_SCORE_PREFIX}{}[{state}]\u{2192}ranked[{region}]",
+            rank_agg.name
+        );
+        assert!(
+            ltm_vars.iter().any(|v| v.name == expected),
+            "rank helper slot {state} should score ranked[{region}]; got: {:?}",
+            ltm_vars.iter().map(|v| v.name.as_str()).collect::<Vec<_>>()
+        );
+        let bare = format!(
+            "{LINK_SCORE_PREFIX}{}\u{2192}ranked[{region}]",
+            rank_agg.name
+        );
+        assert!(
+            !ltm_vars.iter().any(|v| v.name == bare),
+            "mapped target score must not use the bare helper name {bare}"
+        );
+    }
+
+    let loop_through_rank = ltm_vars.iter().any(|v| {
+        v.name.starts_with(LOOP_SCORE_PREFIX)
+            && v.equation.source_text().contains(
+                format!("{LINK_SCORE_PREFIX}{}[s1]\u{2192}ranked[r1]", rank_agg.name).as_str(),
+            )
+            && v.equation.source_text().contains(
+                format!("{LINK_SCORE_PREFIX}score[s1]\u{2192}{}[s1]", rank_agg.name).as_str(),
+            )
+    });
+    assert!(
+        loop_through_rank,
+        "expected a loop score traversing score[s1] through the mapped RANK helper; loop scores: {:?}",
+        ltm_vars
+            .iter()
+            .filter(|v| v.name.starts_with(LOOP_SCORE_PREFIX))
+            .map(|v| (v.name.as_str(), v.equation.source_text()))
+            .collect::<Vec<_>>()
+    );
+
+    let mut vm = Vm::new(compiled).expect("VM construction should succeed");
+    vm.run_to_end()
+        .expect("VM simulation should run to completion");
+    let results = vm.into_results();
+    for (state, region) in [("s1", "r1"), ("s2", "r2")] {
+        let name = format!(
+            "{LINK_SCORE_PREFIX}{}[{state}]\u{2192}ranked[{region}]",
+            rank_agg.name
+        );
+        let series = series_at(&results, offset_of(&results, &name));
+        assert!(
+            series.iter().all(|v| v.is_finite()),
+            "{name} must stay finite; got {series:?}"
+        );
+    }
+}
+
 /// GH #742, LTM leg: a link-score partial that freezes an array-valued
 /// non-reducing builtin subtree (`PREVIOUS(rank(pop, 1))` inside the
 /// `scale -> grow` partial of `grow[Region] = scale[Region] * RANK(pop, 1)`)

--- a/src/simlin-engine/tests/integration/ltm_array_agg.rs
+++ b/src/simlin-engine/tests/integration/ltm_array_agg.rs
@@ -5088,18 +5088,12 @@ fn previous_of_rank_compiles_per_element() {
 /// element from the first post-initial step (pre-fix it read a constant
 /// -100-class value off the 0-stubbed scalar helpers).
 ///
-/// GH #771 (shape-expressiveness T1): `RANK` is no longer hoisted into an
-/// aggregate node -- hoisting requires `reducer_collapses_to_scalar`
-/// (invariant I5), and RANK is array-valued, so the scalar `$⁚ltm⁚agg⁚0`
-/// whose own equation could not compile (and whose agg-routed loop scores
-/// were stubbed to 0 behind one pinned Warning) is never minted. The `pop`
-/// reference inside `RANK(pop, 1)` classifies by its syntactic shape
-/// (`Bare` -> diagonal edges), so this fixture now compiles with ZERO
-/// warnings and the direct `pop → grow` loop is genuinely enumerated.
-/// Residual (documented on `reducer_collapses_to_scalar`): loops through
-/// the rank *ordering* (element r's rank changing because element s moved
-/// past it) are not enumerated; the diagonal `pop → grow` loop scores ~0
-/// here because the ranks are constant in this regime -- pinned below.
+/// GH #776: `RANK` is array-valued, so it routes through an arrayed synthetic
+/// agg rather than a scalar reducer agg. Every ranked source row feeds every
+/// rank output slot in its iterated context, so loops through rank ordering
+/// are enumerated, including cross-element loops. The score remains the
+/// documented conservative delta-ratio stand-in; with constant ranks all
+/// rank-mediated loops score ~0 here.
 #[test]
 fn rank_frozen_subtree_link_score_scores_correctly() {
     let project = TestProject::new("gh742_rank")
@@ -5118,12 +5112,12 @@ fn rank_frozen_subtree_link_score_scores_correctly() {
     let compiled = compile_project_incremental(&db, sync.project, "main")
         .expect("LTM-enabled compilation should succeed");
 
-    // GH #771: RANK is de-hoisted, so no ill-shaped scalar agg exists and
+    // RANK uses an array-valued helper, so no ill-shaped scalar agg exists and
     // NOTHING warns -- the capture helpers and every link/loop score compile.
     let warnings = assembly_warnings(&db, sync.project);
     assert!(
         warnings.is_empty(),
-        "RANK de-hoist must leave zero warnings; got: {warnings:?}"
+        "RANK arrayed agg must leave zero warnings; got: {warnings:?}"
     );
 
     let ltm = model_ltm_variables(&db, sync.models["main"].source_model, sync.project);
@@ -5164,12 +5158,10 @@ fn rank_frozen_subtree_link_score_scores_correctly() {
         }
     }
 
-    // Post-#771 the model has TWO Region-dimensioned loops: the
-    // scale-mediated one (pop -> scale -> grow -> inflow -> pop) and the
-    // direct rank-mediated one (pop -> grow -> inflow -> pop), which only
-    // exists now that the de-hoisted `pop` reference inside `RANK(pop, 1)`
-    // emits diagonal Bare edges. Tell them apart by the link-score names
-    // their loop-score equations reference.
+    // The model has one Region-dimensioned scale-mediated loop
+    // (pop -> scale -> grow -> inflow -> pop) plus scalar rank-mediated
+    // loops through the arrayed RANK helper. Tell them apart by the
+    // link-score names their loop-score equations reference.
     fn eqn_text(v: &LtmSyntheticVar) -> &str {
         match &v.equation {
             datamodel::Equation::Scalar(t) => t,
@@ -5177,27 +5169,19 @@ fn rank_frozen_subtree_link_score_scores_correctly() {
             datamodel::Equation::Arrayed(..) => panic!("unexpected Arrayed loop score"),
         }
     }
-    let region_loops: Vec<&LtmSyntheticVar> = ltm
+    let loop_scores: Vec<&LtmSyntheticVar> = ltm
         .vars
         .iter()
         .filter(|v| v.name.starts_with(LOOP_SCORE_PREFIX))
-        .filter(|v| v.dimensions == vec!["Region".to_string()])
         .collect();
-    assert_eq!(
-        region_loops.len(),
-        2,
-        "expected the scale-mediated and rank-mediated Region loops; got: {:?}",
-        region_loops
-            .iter()
-            .map(|v| v.name.as_str())
-            .collect::<Vec<_>>()
-    );
 
     // The scale-mediated loop scores +1 once the flow-to-stock startup
     // guard clears (grow is linear in scale with a constant rank coefficient).
-    let scale_loop = region_loops
+    let scale_loop = loop_scores
         .iter()
-        .find(|v| eqn_text(v).contains("scale\u{2192}grow"))
+        .find(|v| {
+            v.dimensions == vec!["Region".to_string()] && eqn_text(v).contains("scale\u{2192}grow")
+        })
         .expect("the per-element pop/scale/grow/inflow loop must be scored");
     let base = offset_of(&results, &scale_loop.name);
     for slot in 0..slot_count(scale_loop, &project.dimensions) {
@@ -5210,23 +5194,59 @@ fn rank_frozen_subtree_link_score_scores_correctly() {
         }
     }
 
-    // The rank-mediated loop (pop -> grow direct) scores ~0: the ranks are
-    // constant in this regime, so `grow`'s changed-first partial w.r.t.
-    // `pop` is flat. This pins the documented #771 residual -- the diagonal
-    // pop->grow coupling is enumerated but carries no score here, and
-    // cross-element rank-ordering loops are not enumerated at all.
-    let rank_loop = region_loops
+    // The rank-mediated loops score ~0: ranks are constant in this regime,
+    // so each RANK-helper slot has zero delta and the conservative
+    // delta-ratio source half contributes 0. There are three scalar loops:
+    // north self-rank, south self-rank, and the true cross-element
+    // north/south rank-ordering loop.
+    let rank_agg_name = ltm
+        .vars
         .iter()
-        .find(|v| eqn_text(v).contains("pop\u{2192}grow"))
-        .expect("the direct pop/grow/inflow loop must be scored");
-    let base = offset_of(&results, &rank_loop.name);
-    for slot in 0..slot_count(rank_loop, &project.dimensions) {
-        let series = series_at(&results, base + slot);
+        .find(|v| match &v.equation {
+            datamodel::Equation::ApplyToAll(dims, text) => {
+                dims.len() == 1 && dims[0] == "Region" && text == "rank(pop, 1)"
+            }
+            datamodel::Equation::Scalar(_) | datamodel::Equation::Arrayed(..) => false,
+        })
+        .expect("RANK(pop, 1) must be emitted as an arrayed aggregate helper")
+        .name
+        .clone();
+    let agg = rank_agg_name.as_str();
+    let rank_loops: Vec<&LtmSyntheticVar> = loop_scores
+        .iter()
+        .copied()
+        .filter(|v| eqn_text(v).contains(&format!("pop[north]\u{2192}{agg}")))
+        .chain(loop_scores.iter().copied().filter(|v| {
+            eqn_text(v).contains(&format!("pop[south]\u{2192}{agg}"))
+                && !eqn_text(v).contains(&format!("pop[north]\u{2192}{agg}"))
+        }))
+        .collect();
+    assert_eq!(
+        rank_loops.len(),
+        3,
+        "expected north, south, and cross-element rank-mediated loops; got: {:?}",
+        loop_scores
+            .iter()
+            .map(|v| (v.name.as_str(), eqn_text(v)))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        rank_loops.iter().any(|v| {
+            let text = eqn_text(v);
+            text.contains(&format!("pop[north]\u{2192}{agg}[south]"))
+                && text.contains(&format!("pop[south]\u{2192}{agg}[north]"))
+        }),
+        "expected a cross-element rank-ordering loop through both rank slots"
+    );
+    for rank_loop in rank_loops {
+        assert!(rank_loop.dimensions.is_empty());
+        let series = series_at(&results, offset_of(&results, &rank_loop.name));
         for (step, &v) in series.iter().enumerate().skip(STARTUP_STEPS) {
             assert!(
                 v.abs() < 1e-9,
-                "rank-loop score slot {slot} step {step} must be ~0 (constant ranks); \
-                 got {series:?}"
+                "rank-loop score {} step {step} must be ~0 (constant ranks); \
+                 got {series:?}",
+                rank_loop.name
             );
         }
     }


### PR DESCRIPTION
## Summary

- Represent array-valued `RANK` with synthetic arrayed aggregate helpers while keeping it out of scalar reducer hoisting.
- Route bare and wildcard RANK arguments through the same helper so every ranked source row feeds every rank output slot in its iterated context.
- Emit matching source-to-rank-helper link scores and update LTM tests to cover cross-element rank-mediated loops.

## Tests

- `cargo test -p simlin-engine rank_`
- `cargo test -p simlin-engine ltm_agg::tests`
- Pre-commit hook passed: dependency policy, docs links, project lint rules, Rust fmt/cbindgen/clippy/test, TypeScript lint/build/tsc/test, pysimlin tests.

Fixes #776