### PR TITLE
diagram: finish design-token consolidation + dark-mode token parity

### DIFF
--- a/src/app/Home.module.css
+++ b/src/app/Home.module.css
@@ -2,10 +2,11 @@
   flex-grow: 1;
 }
 
-/* Matches the dense Toolbar's min-height (48px); offsets the fixed AppBar so
-   content is not tucked underneath it. */
+/* Offsets the fixed AppBar so content is not tucked underneath it. Derives from
+   the same --toolbar-dense-height token as Toolbar's .dense min-height so the
+   spacer and the dense Toolbar height cannot drift apart. */
 .toolbarSpacer {
-  height: 48px;
+  height: var(--toolbar-dense-height);
 }
 
 /*

--- a/src/app/tests/design-tokens.test.ts
+++ b/src/app/tests/design-tokens.test.ts
@@ -1,0 +1,32 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+// Design-token consolidation contracts for the app shell (issue #799). Asserts
+// stylesheet text directly: the dense-toolbar spacer and the caption variant
+// must derive from the shared theme.css tokens rather than restating literals,
+// so the spacer can't drift from the dense Toolbar height and caption text
+// scales with the rem type scale.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+function readCss(name: string): string {
+  return fs.readFileSync(path.join(__dirname, '..', name), 'utf-8');
+}
+
+describe('app shell design-token coupling', () => {
+  it('the toolbar spacer height comes from --toolbar-dense-height', () => {
+    const css = readCss('Home.module.css');
+    const m = /\.toolbarSpacer\s*\{([^}]*)\}/.exec(css);
+    expect(m).not.toBeNull();
+    expect(m![1]).toContain('height: var(--toolbar-dense-height)');
+  });
+
+  it('the caption typography variant sizes from --font-size-caption', () => {
+    const css = readCss('typography.module.css');
+    const m = /\.caption\s*\{([^}]*)\}/.exec(css);
+    expect(m).not.toBeNull();
+    expect(m![1]).toContain('font-size: var(--font-size-caption)');
+  });
+});

--- a/src/app/typography.module.css
+++ b/src/app/typography.module.css
@@ -52,6 +52,14 @@
   letter-spacing: 0.01071em;
 }
 
+.caption {
+  margin: 0;
+  font-size: var(--font-size-caption);
+  font-weight: 400;
+  line-height: 1.66;
+  letter-spacing: 0.03333em;
+}
+
 .textRight {
   text-align: right;
 }

--- a/src/diagram/Editor.module.css
+++ b/src/diagram/Editor.module.css
@@ -24,7 +24,7 @@
   margin-left: 12px;
   border-radius: 4px;
   background: var(--color-surface);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-2);
 }
 
 .snapshotCardContent {
@@ -51,7 +51,7 @@
 }
 
 .menuButton {
-  color: #666;
+  color: var(--color-text-muted);
   flex: 0 0 auto;
 }
 
@@ -74,7 +74,7 @@
   padding: 0 8px;
   border-radius: 4px;
   background: var(--color-surface);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-2);
 }
 
 @media (min-width: 900px) and (max-width: 1199.95px) {
@@ -116,18 +116,18 @@
 }
 
 .searchButton {
-  color: #aaa;
+  color: var(--color-text-light);
 }
 
 .clearSearchButton {
-  color: #aaa;
+  color: var(--color-text-light);
   cursor: pointer;
 }
 
 .divider {
   width: 1px;
   height: 24px;
-  background: #ddd;
+  background: var(--color-divider);
   flex: 0 0 auto;
 }
 
@@ -138,8 +138,8 @@
   flex: 0 0 auto;
   overflow: hidden;
   max-width: 40%;
-  font-size: 13px;
-  color: var(--color-text-muted, #666);
+  font-size: 0.8125rem;
+  color: var(--color-text-muted);
 }
 
 .breadcrumbLink {
@@ -147,8 +147,8 @@
   border: none;
   padding: 2px 4px;
   cursor: pointer;
-  color: var(--color-primary, #1976d2);
-  font-size: 13px;
+  color: var(--color-primary);
+  font-size: 0.8125rem;
   font-family: inherit;
   border-radius: 2px;
   white-space: nowrap;
@@ -157,7 +157,7 @@
 }
 
 .breadcrumbLink:hover {
-  background: rgba(25, 118, 210, 0.08);
+  background: var(--color-primary-hover);
 }
 
 .breadcrumbCurrent {
@@ -172,12 +172,12 @@
   flex: 0 0 auto;
   width: 16px;
   height: 16px;
-  color: #999;
+  color: var(--color-text-light);
 }
 
 .readOnlyBadge {
-  font-size: 11px;
-  color: #999;
+  font-size: 0.6875rem;
+  color: var(--color-text-light);
   font-style: italic;
   padding: 0 4px;
   white-space: nowrap;
@@ -189,13 +189,13 @@
   right: 8px;
   width: min(var(--panel-width-sm), calc(100vw - 16px));
   padding: 4px 12px;
-  font-size: 12px;
+  font-size: var(--font-size-caption);
   /* Explicit line-height makes the banner's rendered height deterministic (it
      must not depend on the global reset's inherited 1.5, which a host bundle
      may not load) so --shared-model-banner-height can match it. */
   line-height: 1.4;
   color: var(--color-text-muted);
-  background: #fff3e0;
+  background: var(--color-banner-warning-bg);
   border-radius: 4px;
   box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12);
   text-align: center;

--- a/src/diagram/Editor.module.css
+++ b/src/diagram/Editor.module.css
@@ -74,6 +74,8 @@
   padding: 0 8px;
   border-radius: 4px;
   background: var(--color-surface);
+  /* Own the foreground so the native search <input> text flips with the surface. */
+  color: var(--color-text-primary);
   box-shadow: var(--shadow-2);
 }
 

--- a/src/diagram/ErrorDetails.module.css
+++ b/src/diagram/ErrorDetails.module.css
@@ -4,7 +4,7 @@
   box-sizing: border-box;
   border-radius: 4px;
   background: var(--color-surface);
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--shadow-1);
 }
 
 @media (min-width: 900px) and (max-width: 1199.95px) {

--- a/src/diagram/ErrorDetails.module.css
+++ b/src/diagram/ErrorDetails.module.css
@@ -4,6 +4,9 @@
   box-sizing: border-box;
   border-radius: 4px;
   background: var(--color-surface);
+  /* Own the foreground so the "no errors" message stays legible when the
+     surface flips dark. */
+  color: var(--color-text-primary);
   box-shadow: var(--shadow-1);
 }
 

--- a/src/diagram/HostedWebEditor.module.css
+++ b/src/diagram/HostedWebEditor.module.css
@@ -39,6 +39,9 @@
   border: 1px solid var(--color-border);
   border-radius: 4px;
   background: var(--color-surface);
+  /* Own the foreground so the error message stays legible when the surface
+     flips dark. */
+  color: var(--color-text-primary);
 }
 
 .errorTitle {

--- a/src/diagram/HostedWebEditor.module.css
+++ b/src/diagram/HostedWebEditor.module.css
@@ -1,5 +1,5 @@
 .bg {
-  background: #f2f2f2;
+  background: var(--color-background);
   width: 100%;
   height: 100%;
   position: fixed;
@@ -14,7 +14,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  background: #f2f2f2;
+  background: var(--color-background);
 }
 
 /* Embedded variant of the loading/error surface: fills the embed element and

--- a/src/diagram/LineChart.module.css
+++ b/src/diagram/LineChart.module.css
@@ -6,8 +6,8 @@
 .tooltip {
   position: absolute;
   pointer-events: none;
-  background: rgba(255, 255, 255, 0.95);
-  border: 1px solid #ccc;
+  background: var(--color-overlay-surface);
+  border: 1px solid var(--color-border-input);
   border-radius: 4px;
   padding: 6px 8px;
   font-size: 12px;

--- a/src/diagram/ModuleDetails.module.css
+++ b/src/diagram/ModuleDetails.module.css
@@ -13,7 +13,7 @@
   scrollbar-gutter: stable;
   border-radius: 4px;
   background: var(--color-surface);
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--shadow-1);
 }
 
 @media (min-width: 900px) and (max-width: 1199.95px) {
@@ -37,10 +37,10 @@
 }
 
 .header {
-  font-size: 16px;
+  font-size: 1rem;
   font-weight: 500;
   margin-bottom: 12px;
-  color: #333;
+  color: var(--color-text-primary);
 }
 
 .modelRefSection {
@@ -48,24 +48,24 @@
 }
 
 .modelRefLabel {
-  font-size: 12px;
-  color: #666;
+  font-size: var(--font-size-caption);
+  color: var(--color-text-muted);
   margin-bottom: 4px;
 }
 
 .modelRefSelect {
   width: 100%;
   padding: 8px;
-  border: 1px solid #ccc;
+  border: 1px solid var(--color-border-input);
   border-radius: 4px;
-  font-size: 14px;
-  background: #fff;
+  font-size: 0.875rem;
+  background: var(--color-surface);
   cursor: pointer;
   appearance: auto;
 }
 
 .modelRefSelect:focus {
-  outline: 2px solid var(--color-primary, #1976d2);
+  outline: 2px solid var(--color-primary);
   outline-offset: -2px;
 }
 
@@ -80,17 +80,17 @@
 }
 
 .sectionTitle {
-  font-size: 12px;
+  font-size: var(--font-size-caption);
   font-weight: 500;
-  color: #666;
+  color: var(--color-text-muted);
   text-transform: uppercase;
   letter-spacing: 0.5px;
   margin-bottom: 6px;
 }
 
 .emptyMessage {
-  font-size: 13px;
-  color: #999;
+  font-size: 0.8125rem;
+  color: var(--color-text-light);
   font-style: italic;
   padding: 4px 0;
 }
@@ -98,23 +98,23 @@
 .wiringTable {
   width: 100%;
   border-collapse: collapse;
-  font-size: 13px;
+  font-size: 0.8125rem;
 }
 
 .wiringTable th {
   text-align: left;
   font-weight: 500;
-  color: #666;
+  color: var(--color-text-muted);
   padding: 4px 8px;
-  border-bottom: 1px solid #ddd;
-  font-size: 12px;
+  border-bottom: 1px solid var(--color-divider);
+  font-size: var(--font-size-caption);
 }
 
 .wiringTable td {
   padding: 4px 8px;
-  border-bottom: 1px solid #eee;
+  border-bottom: 1px solid var(--color-divider);
   font-family: 'Roboto Mono', monospace;
-  font-size: 12px;
+  font-size: var(--font-size-caption);
 }
 
 .wiringRow {
@@ -138,8 +138,8 @@
 .portList li {
   padding: 3px 0;
   font-family: 'Roboto Mono', monospace;
-  font-size: 12px;
-  color: #333;
+  font-size: var(--font-size-caption);
+  color: var(--color-text-primary);
 }
 
 .unitsEditor {

--- a/src/diagram/ModuleDetails.module.css
+++ b/src/diagram/ModuleDetails.module.css
@@ -13,6 +13,9 @@
   scrollbar-gutter: stable;
   border-radius: 4px;
   background: var(--color-surface);
+  /* Own the foreground so the native <select> and the units/notes wells stay
+     legible when the surface flips dark. */
+  color: var(--color-text-primary);
   box-shadow: var(--shadow-1);
 }
 

--- a/src/diagram/Snapshotter.module.css
+++ b/src/diagram/Snapshotter.module.css
@@ -5,6 +5,8 @@
   margin-right: var(--spacing-1);
   border-radius: 4px;
   background: var(--color-surface);
+  /* Own the foreground so the camera icon (currentColor) flips with the surface. */
+  color: var(--color-text-primary);
   box-shadow: var(--shadow-2);
 }
 

--- a/src/diagram/Snapshotter.module.css
+++ b/src/diagram/Snapshotter.module.css
@@ -4,8 +4,8 @@
   height: 40px;
   margin-right: var(--spacing-1);
   border-radius: 4px;
-  background: #fff;
-  box-shadow: 0px 3px 1px -2px rgba(0,0,0,0.2), 0px 2px 2px 0px rgba(0,0,0,0.14), 0px 1px 5px 0px rgba(0,0,0,0.12);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-2);
 }
 
 .button {

--- a/src/diagram/UndoRedoBar.module.css
+++ b/src/diagram/UndoRedoBar.module.css
@@ -5,7 +5,7 @@
   margin-right: var(--spacing-1);
   border-radius: 4px;
   background: var(--color-surface);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-2);
 }
 
 .divider {

--- a/src/diagram/VariableDetails.module.css
+++ b/src/diagram/VariableDetails.module.css
@@ -9,6 +9,10 @@
   scrollbar-gutter: stable;
   border-radius: 4px;
   background: var(--color-surface);
+  /* Own the foreground so inheriting content -- the equation/units/notes wells
+     and KaTeX (rendered with currentColor) -- stays legible when the surface
+     flips dark. */
+  color: var(--color-text-primary);
   box-shadow: var(--shadow-1);
 }
 

--- a/src/diagram/VariableDetails.module.css
+++ b/src/diagram/VariableDetails.module.css
@@ -9,7 +9,7 @@
   scrollbar-gutter: stable;
   border-radius: 4px;
   background: var(--color-surface);
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--shadow-1);
 }
 
 @media (min-width: 900px) and (max-width: 1199.95px) {

--- a/src/diagram/ZoomBar.module.css
+++ b/src/diagram/ZoomBar.module.css
@@ -5,7 +5,7 @@
   margin-right: var(--spacing-1);
   border-radius: 4px;
   background: var(--color-surface);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-2);
 }
 
 .divider1 {

--- a/src/diagram/components/Accordion.module.css
+++ b/src/diagram/components/Accordion.module.css
@@ -1,7 +1,7 @@
 .accordion {
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
-  background-color: #fff;
+  background-color: var(--color-surface);
 }
 
 .accordion::before {
@@ -32,11 +32,11 @@
 }
 
 .trigger:hover {
-  background-color: rgba(0, 0, 0, 0.04);
+  background-color: var(--color-action-hover);
 }
 
 .trigger:focus-visible {
-  outline: 2px solid #1976d2;
+  outline: 2px solid var(--color-primary);
   outline-offset: -2px;
 }
 
@@ -54,7 +54,7 @@
 .expandIcon {
   display: flex;
   align-items: center;
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--color-text-muted);
   transition: transform 150ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 

--- a/src/diagram/components/Accordion.module.css
+++ b/src/diagram/components/Accordion.module.css
@@ -2,6 +2,9 @@
   border: 1px solid var(--color-border);
   border-radius: 4px;
   background-color: var(--color-surface);
+  /* Pair the surface with its text token so the trigger/content stay legible
+     when --color-surface flips dark. */
+  color: var(--color-text-primary);
 }
 
 .accordion::before {

--- a/src/diagram/components/AppBar.module.css
+++ b/src/diagram/components/AppBar.module.css
@@ -4,12 +4,9 @@
   width: 100%;
   box-sizing: border-box;
   flex-shrink: 0;
-  background-color: #1976d2;
-  color: #fff;
-  box-shadow:
-    0px 2px 4px -1px rgba(0, 0, 0, 0.2),
-    0px 4px 5px 0px rgba(0, 0, 0, 0.14),
-    0px 1px 10px 0px rgba(0, 0, 0, 0.12);
+  background-color: var(--color-primary);
+  color: var(--color-contrast-text);
+  box-shadow: var(--shadow-4);
 }
 
 .positionFixed {

--- a/src/diagram/components/Autocomplete.module.css
+++ b/src/diagram/components/Autocomplete.module.css
@@ -8,6 +8,10 @@
   position: absolute;
   z-index: 1300;
   background: var(--color-surface);
+  /* This popup is portaled, so it can't inherit a foreground from the editor
+     root: pair the surface with its text token so the options stay legible when
+     --color-surface flips dark. */
+  color: var(--color-text-primary);
   border: 1px solid var(--color-border-input);
   border-radius: 4px;
   box-shadow: var(--shadow-1);

--- a/src/diagram/components/Autocomplete.module.css
+++ b/src/diagram/components/Autocomplete.module.css
@@ -7,10 +7,10 @@
 .listbox {
   position: absolute;
   z-index: 1300;
-  background: #fff;
-  border: 1px solid rgba(0, 0, 0, 0.23);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-input);
   border-radius: 4px;
-  box-shadow: 0px 2px 1px -1px rgba(0,0,0,0.2), 0px 1px 1px 0px rgba(0,0,0,0.14), 0px 1px 3px 0px rgba(0,0,0,0.12);
+  box-shadow: var(--shadow-1);
   max-height: 300px;
   overflow-y: auto;
   margin: 0;
@@ -31,5 +31,5 @@
 }
 
 .optionHighlighted {
-  background: #ADD8E6;
+  background: var(--color-option-highlight);
 }

--- a/src/diagram/components/Avatar.module.css
+++ b/src/diagram/components/Avatar.module.css
@@ -11,8 +11,8 @@
   border-radius: 50%;
   overflow: hidden;
   user-select: none;
-  background-color: #bdbdbd;
-  color: #fafafa;
+  background-color: var(--color-avatar-bg);
+  color: var(--color-contrast-text);
 }
 
 .image {

--- a/src/diagram/components/Button.module.css
+++ b/src/diagram/components/Button.module.css
@@ -50,7 +50,7 @@
 }
 
 .textPrimary:hover {
-  background-color: rgba(25, 118, 210, 0.04);
+  background-color: var(--color-primary-hover);
 }
 
 /* text + secondary */
@@ -60,7 +60,7 @@
 }
 
 .textSecondary:hover {
-  background-color: rgba(220, 0, 78, 0.04);
+  background-color: var(--color-secondary-hover);
 }
 
 /* text + error */
@@ -70,51 +70,51 @@
 }
 
 .textError:hover {
-  background-color: rgba(198, 40, 40, 0.04);
+  background-color: var(--color-error-hover);
 }
 
 /* contained + primary */
 .containedPrimary {
-  color: #fff;
+  color: var(--color-contrast-text);
   background-color: var(--color-primary);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-2);
 }
 
 .containedPrimary:hover {
-  background-color: #1565c0;
+  background-color: var(--color-primary-dark);
 }
 
 /* contained + secondary */
 .containedSecondary {
-  color: #fff;
+  color: var(--color-contrast-text);
   background-color: var(--color-secondary);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-2);
 }
 
 .containedSecondary:hover {
-  background-color: #9a0036;
+  background-color: var(--color-secondary-dark);
 }
 
 /* contained + error */
 .containedError {
-  color: #fff;
+  color: var(--color-contrast-text);
   background-color: var(--color-error);
-  box-shadow: var(--shadow-md);
+  box-shadow: var(--shadow-2);
 }
 
 .containedError:hover {
-  background-color: #b71c1c;
+  background-color: var(--color-error-dark);
 }
 
 /* disabled states */
 .disabledText {
-  color: rgba(0, 0, 0, 0.26);
+  color: var(--color-text-disabled);
   pointer-events: none;
 }
 
 .disabledContained {
-  color: rgba(0, 0, 0, 0.26);
-  background-color: rgba(0, 0, 0, 0.12);
+  color: var(--color-text-disabled);
+  background-color: var(--color-divider);
   box-shadow: none;
   pointer-events: none;
 }
@@ -122,49 +122,49 @@
 /* outlined + primary */
 .outlinedPrimary {
   color: var(--color-primary);
-  border: 1px solid rgba(25, 118, 210, 0.5);
+  border: 1px solid var(--color-primary-outline);
   background: transparent;
 }
 
 .outlinedPrimary:hover {
   border-color: var(--color-primary);
-  background-color: rgba(25, 118, 210, 0.04);
+  background-color: var(--color-primary-hover);
 }
 
 /* outlined + secondary */
 .outlinedSecondary {
   color: var(--color-secondary);
-  border: 1px solid rgba(220, 0, 78, 0.5);
+  border: 1px solid var(--color-secondary-outline);
   background: transparent;
 }
 
 .outlinedSecondary:hover {
   border-color: var(--color-secondary);
-  background-color: rgba(220, 0, 78, 0.04);
+  background-color: var(--color-secondary-hover);
 }
 
 /* outlined + error */
 .outlinedError {
   color: var(--color-error);
-  border: 1px solid rgba(198, 40, 40, 0.5);
+  border: 1px solid var(--color-error-outline);
   background: transparent;
 }
 
 .outlinedError:hover {
   border-color: var(--color-error);
-  background-color: rgba(198, 40, 40, 0.04);
+  background-color: var(--color-error-hover);
 }
 
 /* outlined + inherit */
 .outlinedInherit {
   color: inherit;
-  border: 1px solid rgba(0, 0, 0, 0.23);
+  border: 1px solid var(--color-border-input);
   background: transparent;
 }
 
 .outlinedInherit:hover {
-  border-color: rgba(0, 0, 0, 0.87);
-  background-color: rgba(0, 0, 0, 0.04);
+  border-color: var(--color-text-primary);
+  background-color: var(--color-action-hover);
 }
 
 /* text + inherit */
@@ -174,12 +174,12 @@
 }
 
 .textInherit:hover {
-  background-color: rgba(0, 0, 0, 0.04);
+  background-color: var(--color-action-hover);
 }
 
 .disabledOutlined {
-  color: rgba(0, 0, 0, 0.26);
-  border-color: rgba(0, 0, 0, 0.12);
+  color: var(--color-text-disabled);
+  border-color: var(--color-border);
   pointer-events: none;
 }
 

--- a/src/diagram/components/Card.module.css
+++ b/src/diagram/components/Card.module.css
@@ -1,16 +1,16 @@
 .card {
   background-color: var(--color-surface);
-  color: rgba(0, 0, 0, 0.87);
+  color: var(--color-text-primary);
   border-radius: 4px;
   overflow: hidden;
 }
 
 .outlined {
-  border: 1px solid rgba(0, 0, 0, 0.12);
+  border: 1px solid var(--color-border);
 }
 
 .elevation {
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--shadow-1);
 }
 
 .cardContent {

--- a/src/diagram/components/Checkbox.module.css
+++ b/src/diagram/components/Checkbox.module.css
@@ -6,7 +6,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  border: 2px solid rgba(0, 0, 0, 0.54);
+  border: 2px solid var(--color-text-muted);
   background-color: transparent;
   cursor: pointer;
 }
@@ -17,7 +17,7 @@
 }
 
 .checkbox:focus-visible {
-  outline: 2px solid #1976d2;
+  outline: 2px solid var(--color-primary);
   outline-offset: 2px;
 }
 
@@ -26,18 +26,18 @@
 }
 
 .primary[data-state='checked'] {
-  background-color: #1976d2;
+  background-color: var(--color-primary);
 }
 
 .secondary[data-state='checked'] {
-  background-color: #dc004e;
+  background-color: var(--color-secondary);
 }
 
 .indicator {
   display: flex;
   align-items: center;
   justify-content: center;
-  color: #fff;
+  color: var(--color-contrast-text);
 }
 
 .checkIcon {

--- a/src/diagram/components/Dialog.module.css
+++ b/src/diagram/components/Dialog.module.css
@@ -1,5 +1,5 @@
 .overlay {
-  background-color: rgba(0, 0, 0, 0.5);
+  background-color: var(--color-backdrop);
   position: fixed;
   inset: 0;
   z-index: 1200;
@@ -16,12 +16,9 @@
 }
 
 .content {
-  background-color: #fff;
+  background-color: var(--color-surface);
   border-radius: 4px;
-  box-shadow:
-    0px 11px 15px -7px rgba(0, 0, 0, 0.2),
-    0px 24px 38px 3px rgba(0, 0, 0, 0.14),
-    0px 9px 46px 8px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-24);
   position: fixed;
   top: 50%;
   left: 50%;
@@ -55,7 +52,7 @@
   font-size: 1.25rem;
   font-weight: 500;
   line-height: 1.6;
-  color: rgba(0, 0, 0, 0.87);
+  color: var(--color-text-primary);
 }
 
 .dialogContent {
@@ -66,7 +63,7 @@
 
 .contentText {
   margin: 0;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--color-text-muted);
   font-size: 1rem;
   line-height: 1.5;
 }

--- a/src/diagram/components/Drawer.module.css
+++ b/src/diagram/components/Drawer.module.css
@@ -22,6 +22,8 @@
   bottom: 0;
   z-index: 1200;
   background: var(--color-surface);
+  /* Portaled sheet: own the foreground so its contents flip with the surface. */
+  color: var(--color-text-primary);
   overflow-y: auto;
   box-shadow: var(--shadow-16);
   transform: translateX(0);

--- a/src/diagram/components/Drawer.module.css
+++ b/src/diagram/components/Drawer.module.css
@@ -4,7 +4,7 @@
   left: 0;
   right: 0;
   bottom: 0;
-  background: rgba(0, 0, 0, 0.5);
+  background: var(--color-backdrop);
   z-index: 1200;
   opacity: 1;
   transition: opacity 225ms cubic-bezier(0.4, 0, 0.2, 1);
@@ -21,9 +21,9 @@
   left: 0;
   bottom: 0;
   z-index: 1200;
-  background: #fff;
+  background: var(--color-surface);
   overflow-y: auto;
-  box-shadow: 0px 8px 10px -5px rgba(0,0,0,0.2), 0px 16px 24px 2px rgba(0,0,0,0.14), 0px 6px 30px 5px rgba(0,0,0,0.12);
+  box-shadow: var(--shadow-16);
   transform: translateX(0);
   visibility: visible;
   transition: transform 225ms cubic-bezier(0, 0, 0.2, 1);

--- a/src/diagram/components/IconButton.module.css
+++ b/src/diagram/components/IconButton.module.css
@@ -13,12 +13,12 @@
   text-decoration: none;
   text-align: center;
   border-radius: 50%;
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--color-text-muted);
   transition: background-color 150ms cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .iconButton:hover {
-  background-color: rgba(0, 0, 0, 0.04);
+  background-color: var(--color-action-hover);
 }
 
 .iconButton:focus-visible {
@@ -62,7 +62,7 @@
 }
 
 .disabled {
-  color: rgba(0, 0, 0, 0.26);
+  color: var(--color-text-disabled);
   pointer-events: none;
 }
 

--- a/src/diagram/components/InputAdornment.module.css
+++ b/src/diagram/components/InputAdornment.module.css
@@ -4,7 +4,7 @@
   max-height: 2em;
   align-items: center;
   white-space: nowrap;
-  color: rgba(0, 0, 0, 0.54);
+  color: var(--color-text-muted);
 }
 
 .positionStart {

--- a/src/diagram/components/Menu.module.css
+++ b/src/diagram/components/Menu.module.css
@@ -1,12 +1,9 @@
 .menuContent {
   min-width: 120px;
-  background-color: #fff;
+  background-color: var(--color-surface);
   border-radius: 4px;
   padding: 8px 0;
-  box-shadow:
-    0px 5px 5px -3px rgba(0, 0, 0, 0.2),
-    0px 8px 10px 1px rgba(0, 0, 0, 0.14),
-    0px 3px 14px 2px rgba(0, 0, 0, 0.12);
+  box-shadow: var(--shadow-8);
   z-index: 1300;
   animation: fadeIn 0.1s ease-out;
 }
@@ -29,13 +26,13 @@
   font-size: 0.875rem;
   line-height: 1.5;
   cursor: pointer;
-  color: rgba(0, 0, 0, 0.87);
+  color: var(--color-text-primary);
   outline: none;
 }
 
 .menuItem:hover,
 .menuItem:focus {
-  background-color: rgba(0, 0, 0, 0.04);
+  background-color: var(--color-action-hover);
 }
 
 .menuItem[data-disabled] {

--- a/src/diagram/components/Paper.module.css
+++ b/src/diagram/components/Paper.module.css
@@ -1,6 +1,6 @@
 .paper {
-  background-color: #fff;
-  color: rgba(0, 0, 0, 0.87);
+  background-color: var(--color-surface);
+  color: var(--color-text-primary);
   transition: box-shadow 300ms cubic-bezier(0.4, 0, 0.2, 1) 0ms;
   border-radius: 4px;
 }
@@ -10,9 +10,9 @@
 }
 
 .elevation1 {
-  box-shadow: var(--shadow-sm);
+  box-shadow: var(--shadow-1);
 }
 
 .elevation2 {
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--shadow-3);
 }

--- a/src/diagram/components/Snackbar.module.css
+++ b/src/diagram/components/Snackbar.module.css
@@ -13,11 +13,11 @@
 }
 
 .snackbarContent {
-  background: #323232;
-  color: #fff;
+  background: var(--color-snackbar-bg);
+  color: var(--color-contrast-text);
   border-radius: 4px;
   padding: 6px 16px;
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--shadow-3);
   display: flex;
   align-items: center;
   flex-wrap: wrap;

--- a/src/diagram/components/SpeedDial.module.css
+++ b/src/diagram/components/SpeedDial.module.css
@@ -13,20 +13,20 @@
   height: 56px;
   border-radius: 50%;
   background: var(--color-secondary);
-  color: #fff;
+  color: var(--color-contrast-text);
   border: none;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--shadow-3);
   transition: background-color 250ms cubic-bezier(0.4, 0, 0.2, 1);
   outline: none;
   z-index: 1;
 }
 
 .fab:hover {
-  background-color: #9a0036;
+  background-color: var(--color-secondary-dark);
 }
 
 .fab:focus-visible {
@@ -52,13 +52,13 @@
   width: 40px;
   height: 40px;
   border-radius: 50%;
-  background: #e0e0e0;
+  background: var(--color-control-bg);
   border: none;
   cursor: pointer;
   display: flex;
   align-items: center;
   justify-content: center;
-  box-shadow: var(--shadow-lg);
+  box-shadow: var(--shadow-3);
   transform: scale(0);
   opacity: 0;
   transition: transform 200ms cubic-bezier(0.4, 0, 0.2, 1),
@@ -68,7 +68,7 @@
 }
 
 .actionButton:hover {
-  background-color: #d0d0d0;
+  background-color: var(--color-control-bg-hover);
 }
 
 .actionButton:focus-visible {
@@ -83,16 +83,16 @@
 
 .actionButtonSelected {
   background-color: var(--color-secondary);
-  color: #fff;
+  color: var(--color-contrast-text);
 }
 
 .actionButtonSelected:hover {
-  background-color: #9a0036;
+  background-color: var(--color-secondary-dark);
 }
 
 .tooltip {
-  background: #616161;
-  color: #fff;
+  background: var(--color-tooltip-bg);
+  color: var(--color-contrast-text);
   padding: 4px 8px;
   border-radius: 4px;
   font-size: 0.75rem;
@@ -102,7 +102,7 @@
 }
 
 .tooltipArrow {
-  fill: #616161;
+  fill: var(--color-tooltip-bg);
 }
 
 @keyframes tooltipFadeIn {

--- a/src/diagram/components/Tabs.module.css
+++ b/src/diagram/components/Tabs.module.css
@@ -17,7 +17,7 @@
   font-size: 0.875rem;
   font-weight: 500;
   letter-spacing: 0.02857em;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--color-text-muted);
   transition: color 250ms cubic-bezier(0.4, 0, 0.2, 1);
   outline: none;
   box-sizing: border-box;

--- a/src/diagram/components/TextField.module.css
+++ b/src/diagram/components/TextField.module.css
@@ -18,14 +18,14 @@
 /* Outlined variant */
 .outlinedWrapper {
   position: relative;
-  border: 1px solid rgba(0, 0, 0, 0.23);
+  border: 1px solid var(--color-border-input);
   border-radius: 4px;
   transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1),
               box-shadow 200ms cubic-bezier(0.0, 0, 0.2, 1);
 }
 
 .outlinedWrapper:hover {
-  border-color: rgba(0, 0, 0, 0.87);
+  border-color: var(--color-text-primary);
 }
 
 .outlinedFocused {
@@ -51,7 +51,7 @@
 .outlinedLabel {
   display: block;
   margin-bottom: 4px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--color-text-muted);
   font: inherit;
   font-size: 0.875rem;
   line-height: 1.4;
@@ -68,13 +68,13 @@
 /* Standard variant */
 .standardWrapper {
   position: relative;
-  border-bottom: 1px solid rgba(0, 0, 0, 0.42);
+  border-bottom: 1px solid var(--color-border-input);
   transition: border-color 200ms cubic-bezier(0.0, 0, 0.2, 1),
               box-shadow 200ms cubic-bezier(0.0, 0, 0.2, 1);
 }
 
 .standardWrapper:hover {
-  border-color: rgba(0, 0, 0, 0.87);
+  border-color: var(--color-text-primary);
 }
 
 .standardFocused {
@@ -108,7 +108,7 @@
 .standardLabel {
   display: block;
   margin-bottom: 4px;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--color-text-muted);
   font: inherit;
   font-size: 0.875rem;
   line-height: 1.4;
@@ -139,7 +139,7 @@
 .helperText {
   font-size: 0.75rem;
   margin: 3px 14px 0;
-  color: rgba(0, 0, 0, 0.6);
+  color: var(--color-text-muted);
   line-height: 1.66;
 }
 

--- a/src/diagram/components/TextLink.module.css
+++ b/src/diagram/components/TextLink.module.css
@@ -1,5 +1,5 @@
 .link {
-  color: #1976d2;
+  color: var(--color-primary);
   cursor: pointer;
 }
 

--- a/src/diagram/components/Toolbar.module.css
+++ b/src/diagram/components/Toolbar.module.css
@@ -10,8 +10,11 @@
   min-height: 56px;
 }
 
+/* The dense height is shared with the app's fixed-AppBar spacer
+   (src/app/Home.module.css .toolbarSpacer) via this token so the two cannot
+   drift apart. */
 .dense {
-  min-height: 48px;
+  min-height: var(--toolbar-dense-height);
 }
 
 @media (min-width: 600px) {

--- a/src/diagram/drawing/Arrowhead.module.css
+++ b/src/diagram/drawing/Arrowhead.module.css
@@ -9,7 +9,7 @@
   stroke-width: 1;
   stroke-linejoin: round;
   stroke: var(--color-selected);
-  fill: white;
+  fill: var(--color-white);
 }
 
 .arrowheadConnector {
@@ -27,6 +27,6 @@
 }
 
 .arrowheadBg {
-  fill: white;
+  fill: var(--color-white);
   opacity: 0;
 }

--- a/src/diagram/drawing/Connector.module.css
+++ b/src/diagram/drawing/Connector.module.css
@@ -19,7 +19,7 @@
 
 .connectorBg {
   stroke-width: 7px;
-  stroke: white;
+  stroke: var(--color-white);
   opacity: 0;
   fill: none;
 }

--- a/src/diagram/drawing/Group.module.css
+++ b/src/diagram/drawing/Group.module.css
@@ -1,14 +1,14 @@
 .group rect {
   stroke-width: 1px;
-  stroke: #999999;
-  fill: #f5f5f5;
+  stroke: var(--color-text-light);
+  fill: var(--color-field-bg);
   fill-opacity: 0.5;
 }
 
 .group .label {
   font-size: 12px;
   font-weight: 500;
-  fill: #666666;
+  fill: var(--color-text-muted);
   /* Canvas text defaults to text-anchor: middle; groups anchor at the
      top-left so the label sits inside the rect, not straddling its edge. */
   text-anchor: start;

--- a/src/diagram/drawing/Sparkline.module.css
+++ b/src/diagram/drawing/Sparkline.module.css
@@ -8,6 +8,6 @@
 .axis {
   stroke-width: 0.75px;
   stroke-linecap: round;
-  stroke: #999;
+  stroke: var(--color-text-light);
   fill: none;
 }

--- a/src/diagram/tests/theme-tokens.test.ts
+++ b/src/diagram/tests/theme-tokens.test.ts
@@ -1,0 +1,157 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+// Design-token consolidation contracts (issues #799, #709). These assert the
+// stylesheet text directly because jsdom can't resolve cascaded custom
+// properties or do layout. The point is to keep the component library on the
+// theme.css tokens so a single edit (or the dark-mode pass) reaches every
+// surface, instead of literals silently creeping back in.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+function readCss(...segments: string[]): string {
+  return fs.readFileSync(path.join(__dirname, '..', ...segments), 'utf-8');
+}
+
+// A hex color (#abc / #aabbcc / #aabbccff) or an rgb()/rgba() function. The
+// component library expresses every color through a var(--color-*) token, so a
+// raw literal here means a token was missed.
+const COLOR_LITERAL = /#[0-9a-fA-F]{3,8}\b|\brgba?\(/;
+
+describe('component library uses theme tokens, not color literals', () => {
+  const componentsDir = path.join(__dirname, '..', 'components');
+  const files = fs
+    .readdirSync(componentsDir)
+    .filter((f) => f.endsWith('.module.css'))
+    .sort();
+
+  it('finds component CSS modules to check', () => {
+    expect(files.length).toBeGreaterThan(0);
+  });
+
+  it.each(files)('%s contains no hardcoded color literals', (file) => {
+    const css = fs.readFileSync(path.join(componentsDir, file), 'utf-8');
+    const offenders = css
+      .split('\n')
+      .map((line, i) => [i + 1, line] as const)
+      .filter(([, line]) => COLOR_LITERAL.test(line));
+    expect(offenders.map(([n, line]) => `${file}:${n} ${line.trim()}`)).toEqual([]);
+  });
+});
+
+describe('theme.css token contracts', () => {
+  const theme = readCss('theme.css');
+
+  function darkBlock(css: string): string {
+    const m = /\[data-theme="dark"\]\s*\{([\s\S]*?)\}/.exec(css);
+    if (!m) {
+      throw new Error('no [data-theme="dark"] block in theme.css');
+    }
+    return m[1];
+  }
+
+  it('defines the dense-toolbar and caption tokens in :root', () => {
+    expect(theme).toMatch(/--toolbar-dense-height:\s*48px/);
+    expect(theme).toMatch(/--font-size-caption:\s*0\.75rem/);
+  });
+
+  it('renames shadows to the elevation scheme (no sm/md/lg, adds 4/8/16/24)', () => {
+    for (const level of [1, 2, 3, 4, 8, 16, 24]) {
+      expect(theme).toMatch(new RegExp(`--shadow-${level}:`));
+    }
+    expect(theme).not.toMatch(/--shadow-(sm|md|lg)\b/);
+  });
+
+  it('gives the chrome surface/text/border tokens dark-mode values', () => {
+    const dark = darkBlock(theme);
+    for (const token of [
+      '--color-surface',
+      '--color-field-bg',
+      '--color-background',
+      '--color-text-primary',
+      '--color-text-muted',
+      '--color-text-light',
+      '--color-border',
+      '--color-divider',
+      '--color-action-hover',
+    ]) {
+      expect(dark).toContain(`${token}:`);
+    }
+  });
+});
+
+describe('dense-toolbar height is a single source of truth', () => {
+  it('Toolbar .dense derives its min-height from the token', () => {
+    const css = readCss('components', 'Toolbar.module.css');
+    const m = /\.dense\s*\{([^}]*)\}/.exec(css);
+    expect(m).not.toBeNull();
+    expect(m![1]).toContain('min-height: var(--toolbar-dense-height)');
+  });
+});
+
+// Walk the source CSS (diagram + app), skipping generated output, so these
+// contracts hold for every stylesheet rather than a hand-listed subset.
+function sourceCssFiles(): string[] {
+  const roots = [path.join(__dirname, '..'), path.join(__dirname, '..', '..', 'app')];
+  const skip = /(^|\/)(lib|lib\.browser|lib\.module|build|build-component|dist|node_modules)(\/|$)/;
+  const out: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (skip.test(full)) {
+        continue;
+      }
+      if (entry.isDirectory()) {
+        walk(full);
+      } else if (entry.name.endsWith('.css')) {
+        out.push(full);
+      }
+    }
+  };
+  roots.forEach(walk);
+  return out;
+}
+
+describe('source stylesheets only reference defined tokens', () => {
+  const theme = readCss('theme.css');
+  const defined = new Set([...theme.matchAll(/^\s*(--[a-z0-9-]+):/gm)].map((m) => m[1]));
+  const files = sourceCssFiles();
+
+  it('scans the source tree', () => {
+    expect(files.length).toBeGreaterThan(10);
+  });
+
+  it('every var(--token) resolves to a definition in theme.css', () => {
+    const undefinedRefs: string[] = [];
+    for (const file of files) {
+      const css = fs.readFileSync(file, 'utf-8');
+      for (const m of css.matchAll(/var\((--[a-z0-9-]+)/g)) {
+        // --radix-* are injected at runtime by the Radix primitives (e.g. the
+        // accordion content height used for the open/close animation), so they
+        // are deliberately not theme tokens.
+        if (m[1].startsWith('--radix-')) {
+          continue;
+        }
+        if (!defined.has(m[1])) {
+          undefinedRefs.push(`${path.basename(file)}: ${m[1]}`);
+        }
+      }
+    }
+    expect([...new Set(undefinedRefs)]).toEqual([]);
+  });
+
+  it('no source stylesheet uses the retired --shadow-sm/md/lg names', () => {
+    const offenders = files.filter((f) => /var\(--shadow-(sm|md|lg)\)/.test(fs.readFileSync(f, 'utf-8')));
+    expect(offenders.map((f) => path.basename(f))).toEqual([]);
+  });
+});
+
+describe('editor chrome text sizes scale with zoom (rem, not raw px)', () => {
+  it.each(['Editor.module.css', 'ModuleDetails.module.css'])('%s sizes font in rem', (file) => {
+    const css = readCss(file);
+    const rawPx = [...css.matchAll(/font-size:\s*[0-9]+px/g)].map((m) => m[0]);
+    expect(rawPx).toEqual([]);
+  });
+});

--- a/src/diagram/theme.css
+++ b/src/diagram/theme.css
@@ -36,6 +36,12 @@
     var(--shared-model-banner-top) - 8px + var(--shared-model-banner-height) + 4px
   );
 
+  /* Dense toolbar height. The app's fixed AppBar uses a dense Toolbar; the
+     spacer that offsets page content from under it (src/app/Home.module.css
+     .toolbarSpacer) derives from this same token as Toolbar's .dense min-height
+     so the two cannot drift apart. */
+  --toolbar-dense-height: 48px;
+
   /* Spacing (base: 8px grid) */
   --spacing-1: 8px;
   --spacing-1-5: 12px;
@@ -49,72 +55,179 @@
   --spacing-9: 72px;
   --spacing-10: 80px;
 
+  /* Type scale. rem-based so editor/panel text honors the user's browser zoom
+     and root font-size (the raw-px sizes this replaced did not). 0.75rem == 12px
+     at the default root; mirrors MUI's "caption" variant
+     (src/app/typography.module.css). */
+  --font-size-caption: 0.75rem;
+
   /* Palette - Common */
   --color-black: #000000;
   --color-white: #ffffff;
+  /* Ink that sits on a saturated brand fill or a permanently-dark chip
+     (AppBar, contained buttons, the FAB, snackbars, tooltips). Unlike
+     --color-white this NEVER inverts under dark mode: those surfaces stay
+     dark/colored in both themes, so their text must stay light. (MUI's
+     common.white / contrastText.) */
+  --color-contrast-text: #ffffff;
 
   /* Palette - Brand */
   --color-primary: #1976d2;
   --color-secondary: #dc004e;
   --color-selected: #4444dd;
+  /* Hover fills for contained buttons/FAB: the brand color one step darker. */
+  --color-primary-dark: #1565c0;
+  --color-secondary-dark: #9a0036;
+  --color-error-dark: #b71c1c;
+  /* Low-opacity brand tints for text/outlined-button hover backgrounds, and the
+     half-opacity brand outline of outlined buttons. Kept as the literal brand
+     rgba so a single edit retints every state. The breadcrumb link's former
+     0.08 primary hover normalizes onto --color-primary-hover (0.04) -- one
+     hover weight for the whole UI; the link's primary text color and pointer
+     cursor already carry the affordance. */
+  --color-primary-hover: rgba(25, 118, 210, 0.04);
+  --color-secondary-hover: rgba(220, 0, 78, 0.04);
+  --color-error-hover: rgba(198, 40, 40, 0.04);
+  --color-primary-outline: rgba(25, 118, 210, 0.5);
+  --color-secondary-outline: rgba(220, 0, 78, 0.5);
+  --color-error-outline: rgba(198, 40, 40, 0.5);
 
   /* Palette - Status */
   --color-error: #c62828;
   --color-success: #2e7d32;
   --color-warning: #f57f17;
 
-  /* Palette - UI */
+  /* Palette - UI (canvas + chrome shared) */
   --color-target-good: rgb(76, 175, 80);
   --color-target-bad: rgb(244, 67, 54);
   --color-indicator-warning: rgb(255, 152, 0);
   --color-drag-selection: #6363ff;
-  --color-divider: #ddd;
-  --color-text-muted: #666;
-  --color-text-light: #888;
   --color-connector: gray;
+  --color-cloud-stroke: #6388dc;
 
-  /* Surfaces: panel/card backgrounds, borders, and the recessed input wells
-     used by the equation/units/notes editors. Tokenized so light/dark and a
-     future "flatter surfaces" pass change one place instead of ~20 files. */
+  /* Neutral text. Alpha-over-surface (MUI-style) so the one scale reads on any
+     background and flips cleanly in dark mode. The light values equal the hexes
+     they consolidated: muted == the old #666, light is the centroid of the
+     #888/#999/#aaa greys it replaced (so each shifts at most ~one step), primary
+     absorbs #333 and rgba(0,0,0,0.87), disabled the rgba(0,0,0,0.26) greys. */
+  --color-text-primary: rgba(0, 0, 0, 0.87);
+  --color-text-muted: rgba(0, 0, 0, 0.6);
+  --color-text-light: rgba(0, 0, 0, 0.4);
+  --color-text-disabled: rgba(0, 0, 0, 0.26);
+
+  /* Hairlines and surface/input borders. --divider and --border share the MUI
+     0.12 weight (lines between content vs. a surface outline); --border-input is
+     the heavier 0.23 used by text fields, selects, and outlined buttons. They
+     absorb the old #ddd/#eee (->divider/border) and #ccc/0.23/0.42 (->input). */
+  --color-divider: rgba(0, 0, 0, 0.12);
+  --color-border: rgba(0, 0, 0, 0.12);
+  --color-border-input: rgba(0, 0, 0, 0.23);
+
+  /* Action-state overlays and the modal/drawer scrim. */
+  --color-action-hover: rgba(0, 0, 0, 0.04);
+  --color-backdrop: rgba(0, 0, 0, 0.5);
+
+  /* Surfaces: panel/card/menu/dialog backgrounds, the recessed input wells used
+     by the equation/units/notes editors, and the app page background.
+     Tokenized so light/dark and a future "flatter surfaces" pass change one
+     place instead of ~20 files. */
   --color-surface: #ffffff;
-  --color-border: #dddddd;
   --color-field-bg: #f5f5f5;
+  --color-background: #f2f2f2;
+  /* Neutral raised controls: the speed-dial's secondary action buttons. */
+  --color-control-bg: #e0e0e0;
+  --color-control-bg-hover: #d0d0d0;
+  /* Permanently-dark chips that hold --color-contrast-text ink. */
+  --color-snackbar-bg: #323232;
+  --color-tooltip-bg: #616161;
+  /* Translucent overlay surface (the line-chart hover tooltip). */
+  --color-overlay-surface: rgba(255, 255, 255, 0.95);
+  /* Amber wash behind the shared-model banner. */
+  --color-banner-warning-bg: #fff3e0;
+  /* Highlighted option in the autocomplete listbox. */
+  --color-option-highlight: #add8e6;
+  /* Default avatar background (initials chip). */
+  --color-avatar-bg: #bdbdbd;
 
-  /* Elevation shadows. These three triplets were copy-pasted verbatim across a
-     dozen components; tokenizing them lets the "subtler elevation" design
-     direction be dialed in centrally. Values match the prior inline strings. */
-  --shadow-sm:
+  /* Elevation shadows, keyed to MUI's dp elevation levels so the "subtler
+     elevation" design direction can be dialed in centrally. 1/2/3 are the three
+     repeated low triplets; 4/8/16/24 are the distinct higher levels used by the
+     AppBar, menus/popovers, the drawer, and dialogs respectively. */
+  --shadow-1:
     0px 2px 1px -1px rgba(0, 0, 0, 0.2),
     0px 1px 1px 0px rgba(0, 0, 0, 0.14),
     0px 1px 3px 0px rgba(0, 0, 0, 0.12);
-  --shadow-md:
+  --shadow-2:
     0px 3px 1px -2px rgba(0, 0, 0, 0.2),
     0px 2px 2px 0px rgba(0, 0, 0, 0.14),
     0px 1px 5px 0px rgba(0, 0, 0, 0.12);
-  --shadow-lg:
+  --shadow-3:
     0px 3px 5px -1px rgba(0, 0, 0, 0.2),
     0px 6px 10px 0px rgba(0, 0, 0, 0.14),
     0px 1px 18px 0px rgba(0, 0, 0, 0.12);
-
-  /* Diagram - Cloud colors */
-  --color-cloud-stroke: #6388dc;
+  --shadow-4:
+    0px 2px 4px -1px rgba(0, 0, 0, 0.2),
+    0px 4px 5px 0px rgba(0, 0, 0, 0.14),
+    0px 1px 10px 0px rgba(0, 0, 0, 0.12);
+  --shadow-8:
+    0px 5px 5px -3px rgba(0, 0, 0, 0.2),
+    0px 8px 10px 1px rgba(0, 0, 0, 0.14),
+    0px 3px 14px 2px rgba(0, 0, 0, 0.12);
+  --shadow-16:
+    0px 8px 10px -5px rgba(0, 0, 0, 0.2),
+    0px 16px 24px 2px rgba(0, 0, 0, 0.14),
+    0px 6px 30px 5px rgba(0, 0, 0, 0.12);
+  --shadow-24:
+    0px 11px 15px -7px rgba(0, 0, 0, 0.2),
+    0px 24px 38px 3px rgba(0, 0, 0, 0.14),
+    0px 9px 46px 8px rgba(0, 0, 0, 0.12);
 }
 
 /*
- * Dark-mode overrides for the StaticDiagram CANVAS ONLY.
+ * Dark-mode overrides.
  *
  * StaticDiagram (the non-interactive thumbnail/export renderer) wraps its
- * canvas SVG in a [data-theme="dark"] element, so the variables below retheme
- * the canvas primitives (Stock/Flow/Cloud/Connector/Module/etc.) it draws.
- * Nothing else in the app sets data-theme: the interactive editor chrome,
- * the detail panels, and the src/app shell are intentionally light-only for
- * now. Dark-mode parity across those surfaces is a deliberately-unbuilt,
- * best-effort item (see the root CLAUDE.md), so do not assume a dark editor
- * exists just because these canvas tokens do.
+ * canvas SVG in a [data-theme="dark"] element, so the canvas primitives below
+ * (Stock/Flow/Cloud/Connector/Module/group/etc.) retheme there today. The
+ * editor-chrome and component-library tokens below also carry dark values so
+ * that a future dark editor (root CLAUDE.md lists dark mode as a supported,
+ * best-effort target) themes correctly instead of rendering white boxes with
+ * invisible text. Nothing in the shipping app sets data-theme="dark" on the
+ * chrome yet, so these chrome overrides are inert in the current light-only UI
+ * -- they are infrastructure, not a switch being flipped here.
  */
 [data-theme="dark"] {
+  /* Canvas primitives. */
   --color-black: #bbbbbb;
   --color-white: #222222;
   --color-cloud-stroke: #2d498a;
   --color-connector: #777777;
+
+  /* Neutral text / borders / overlays flip to light-on-dark. */
+  --color-text-primary: rgba(255, 255, 255, 0.87);
+  --color-text-muted: rgba(255, 255, 255, 0.6);
+  --color-text-light: rgba(255, 255, 255, 0.4);
+  --color-text-disabled: rgba(255, 255, 255, 0.3);
+  --color-divider: rgba(255, 255, 255, 0.12);
+  --color-border: rgba(255, 255, 255, 0.12);
+  --color-border-input: rgba(255, 255, 255, 0.23);
+  --color-action-hover: rgba(255, 255, 255, 0.08);
+  --color-backdrop: rgba(0, 0, 0, 0.6);
+
+  /* Surfaces darken; the permanently-dark chips and contrast ink do not flip. */
+  --color-surface: #1e1e1e;
+  --color-field-bg: #2a2a2a;
+  --color-background: #121212;
+  --color-control-bg: #424242;
+  --color-control-bg-hover: #4a4a4a;
+  --color-snackbar-bg: #484848;
+  --color-overlay-surface: rgba(40, 40, 40, 0.95);
+  --color-banner-warning-bg: #3a2f1a;
+  --color-option-highlight: #2f4858;
+  --color-avatar-bg: #5f5f5f;
+
+  /* Brand hover tints need more presence on a dark surface to register. */
+  --color-primary-hover: rgba(25, 118, 210, 0.16);
+  --color-secondary-hover: rgba(220, 0, 78, 0.16);
+  --color-error-hover: rgba(198, 40, 40, 0.16);
 }


### PR DESCRIPTION
## Summary

Finishes the design-token consolidation begun by the frontend UX audit (#799) and folds in the component-library dark-mode parity it overlapped (#709), so both are resolved together. `src/diagram/theme.css` becomes a complete light **and** dark token system, and ~30 stylesheets consume it instead of hardcoding literals.

## What changed

1. **Hardcoded colors → tokens (#709 fold-in).** Every `#fff` surface, the named greys/dividers, and the pervasive `rgba(0,0,0,x)` MUI-opacity values now resolve through tokens. Near-duplicate greys/dividers are **normalized** onto a tight scale (`text-primary/muted/light/disabled`, `divider/border/border-input`); a few sub-perceptible shifts result (e.g. `#999`/`#aaa`→light, breadcrumb hover `0.08`→`0.04`), each documented in `theme.css`. Surfaces and always-light contrast ink are kept distinct (`--color-surface` flips in dark; `--color-contrast-text` does not) so button/AppBar text stays white. Every new token has a `[data-theme="dark"]` value.
2. **Shadow tokens.** Unified MUI-elevation scheme: `--shadow-sm/md/lg` → `--shadow-1/2/3`, plus the distinct `--shadow-4/8/16/24` (AppBar/Menu/Drawer/Dialog). Inline elevation strings adopt the tokens.
3. **px → rem typography.** Editor-chrome and detail-panel text moves to rem (honors browser zoom) via a new `caption` (0.75rem) token and app typography variant.
4. **Toolbar coupling.** `--toolbar-dense-height` drives both `Toolbar .dense` min-height and `Home .toolbarSpacer` so they cannot drift.

## Notes on scope

Dark-mode chrome tokens are **infrastructure**: nothing in the shipping app sets `data-theme="dark"` on the editor chrome yet (only StaticDiagram's canvas does), so light rendering is unchanged. Deliberate literal exceptions, left with rationale: Login's branded Google sign-in button, the ErrorToast severity palette (intentionally brighter than the status tokens), and canvas tool-icon greys.

## Tests

New guard tests (`src/diagram/tests/theme-tokens.test.ts`, `src/app/tests/design-tokens.test.ts`) assert the component library stays literal-free, every `var(--token)` resolves to a definition, the chrome tokens carry dark values, no retired shadow names remain, Editor/ModuleDetails are rem-only, and the toolbar/caption couplings hold. Full diagram (1189) and app (98) jest suites, eslint, and tsc all pass.

Fixes #799
Fixes #709

🤖 Generated with [Claude Code](https://claude.com/claude-code)