### PR TITLE
build: second supply-chain dependency reduction pass

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -575,8 +575,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "oorandom",
- "plotters",
- "rayon",
  "regex",
  "serde",
  "serde_derive",
@@ -2415,34 +2413,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "plotters"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
-dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
-]
-
-[[package]]
 name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3339,7 +3309,6 @@ dependencies = [
  "simlin-engine",
  "tempfile",
  "tokio",
- "tracing",
 ]
 
 [[package]]
@@ -4187,16 +4156,6 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
-]
-
-[[package]]
-name = "web-sys"
-version = "0.3.95"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
 ]
 
 [[package]]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -148,27 +148,15 @@ importers:
 
   src/diagram:
     dependencies:
-      '@radix-ui/react-accordion':
-        specifier: ^1.2.12
-        version: 1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-checkbox':
-        specifier: ^1.3.3
-        version: 1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-dialog':
         specifier: ^1.1.15
         version: 1.1.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-dropdown-menu':
-        specifier: ^2.1.16
-        version: 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-tabs':
         specifier: ^1.1.13
         version: 1.1.13(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-toast':
         specifier: ^1.2.15
         version: 1.2.15(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-tooltip':
-        specifier: ^1.2.8
-        version: 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@simlin/core':
         specifier: workspace:^
         version: link:../core
@@ -178,9 +166,6 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
-      downshift:
-        specifier: ^9.2.0
-        version: 9.3.2(react@19.2.6)
       katex:
         specifier: ^0.16.28
         version: 0.16.45
@@ -922,21 +907,6 @@ packages:
     resolution: {integrity: sha512-LUdM4Wg7YM9Pq/49nGYySJA0CSQEKnGffFzWV8+6gXN7mGxn+FL1IqvFbuZUtAQcfZgHYDwCE1wwlK7rB7gl2g==}
     engines: {node: '>=20.0.0'}
 
-  '@floating-ui/core@1.7.5':
-    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
-
-  '@floating-ui/dom@1.7.6':
-    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
-
-  '@floating-ui/react-dom@2.1.8':
-    resolution: {integrity: sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==}
-    peerDependencies:
-      react: '>=16.8.0'
-      react-dom: '>=16.8.0'
-
-  '@floating-ui/utils@0.2.11':
-    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
-
   '@google-cloud/firestore@7.11.6':
     resolution: {integrity: sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==}
     engines: {node: '>=14.0.0'}
@@ -1436,58 +1406,6 @@ packages:
   '@radix-ui/primitive@1.1.3':
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
 
-  '@radix-ui/react-accordion@1.2.12':
-    resolution: {integrity: sha512-T4nygeh9YE9dLRPhAHSeOZi7HBXo+0kYIPJXayZfvWOWA0+n3dESrZbjfDPUABkUNym6Hd+f2IR113To8D2GPA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-arrow@1.1.7':
-    resolution: {integrity: sha512-F+M1tLhO+mlQaOWspE8Wstg+z6PwxwRd8oQ8IXceWz92kfAmalTRf0EjrouQeo7QssEPfCn05B4Ihs1K9WQ/7w==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-checkbox@1.3.3':
-    resolution: {integrity: sha512-wBbpv+NQftHDdG86Qc0pIyXk5IR3tM8Vd0nWLKDcX8nNn4nXFOFwsKuqw2okA/1D/mpaAkmuyndrPJTYDNZtFw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-collapsible@1.1.12':
-    resolution: {integrity: sha512-Uu+mSh4agx2ib1uIGPP4/CKNULyajb3p92LsVXmH2EHVMTfZWpll88XJ0j4W0z3f8NK1eYl1+Mf/szHPmcHzyA==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-collection@1.1.7':
     resolution: {integrity: sha512-Fh9rGN0MoI4ZFUNyfFVNU4y9LUz93u9/0K+yLgA2bwRojxM8JU1DyvvMBabnZPBgMWREAJvU2jjVzq+LrFUglw==}
     peerDependencies:
@@ -1554,19 +1472,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-dropdown-menu@2.1.16':
-    resolution: {integrity: sha512-1PLGQEynI/3OX/ftV54COn+3Sud/Mn8vALg2rWnBLnRaGtJDduNW/22XjlGgPdpcIbiQxjKtb7BkcjP00nqfJw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-focus-guards@1.1.3':
     resolution: {integrity: sha512-0rFg/Rj2Q62NCm62jZw0QX7a3sz6QCQU0LpZdNrJX8byRGaGVTqbrW9jAoIAHyMQqsNpeZ81YgSizOt5WXq0Pw==}
     peerDependencies:
@@ -1596,32 +1501,6 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
-        optional: true
-
-  '@radix-ui/react-menu@2.1.16':
-    resolution: {integrity: sha512-72F2T+PLlphrqLcAotYPp0uJMr5SjP5SL01wfEspJbru5Zs5vQaSHb4VB3ZMJPimgHHCHG7gMOeOB9H3Hdmtxg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
-  '@radix-ui/react-popper@1.2.8':
-    resolution: {integrity: sha512-0NJQ4LFFUuWkE7Oxf0htBKS6zLkkjBH+hM1uk7Ng705ReR8m/uelduy1DBo0PyBXPKVnBA6YBlU94MBGXrSBCw==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-portal@1.1.9':
@@ -1711,19 +1590,6 @@ packages:
       '@types/react-dom':
         optional: true
 
-  '@radix-ui/react-tooltip@1.2.8':
-    resolution: {integrity: sha512-tY7sVt1yL9ozIxvmbtN5qtmH2krXcBCfjEiCgKGLqunJHvgvZG2Pcl2oQ3kbcZARb1BGEHdkLzcYGO8ynVlieg==}
-    peerDependencies:
-      '@types/react': '*'
-      '@types/react-dom': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-      '@types/react-dom':
-        optional: true
-
   '@radix-ui/react-use-callback-ref@1.1.1':
     resolution: {integrity: sha512-FkBMwD+qbGQeMu1cOHnuGB6x4yzPjho8ap5WtbEJ26umhgqVXbhekKUQO+hZEL1vU92a3wHwdp0HAcqAUF5iDg==}
     peerDependencies:
@@ -1769,33 +1635,6 @@ packages:
       '@types/react':
         optional: true
 
-  '@radix-ui/react-use-previous@1.1.1':
-    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-rect@1.1.1':
-    resolution: {integrity: sha512-QTYuDesS0VtuHNNvMh+CjlKJ4LJickCMUAqjlE3+j8w+RlRpwyX3apEQKGFzbZGdo7XNG1tXa+bQqIE7HIXT2w==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
-  '@radix-ui/react-use-size@1.1.1':
-    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-
   '@radix-ui/react-visually-hidden@1.2.3':
     resolution: {integrity: sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==}
     peerDependencies:
@@ -1808,9 +1647,6 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
-
-  '@radix-ui/rect@1.1.1':
-    resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
   '@remix-run/router@1.23.2':
     resolution: {integrity: sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==}
@@ -3274,11 +3110,6 @@ packages:
 
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
-
-  downshift@9.3.2:
-    resolution: {integrity: sha512-5VD0WZLQDhipWiDU+K5ili3VDhGrXwlvOlSaSG1Cb0eS4XpssxVuoD09JNgju+bAzxB2Wvlwx+FwTE/FNdrqow==}
-    peerDependencies:
-      react: '>=16.12.0'
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -6714,23 +6545,6 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  '@floating-ui/core@1.7.5':
-    dependencies:
-      '@floating-ui/utils': 0.2.11
-
-  '@floating-ui/dom@1.7.6':
-    dependencies:
-      '@floating-ui/core': 1.7.5
-      '@floating-ui/utils': 0.2.11
-
-  '@floating-ui/react-dom@2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@floating-ui/dom': 1.7.6
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-
-  '@floating-ui/utils@0.2.11': {}
-
   '@google-cloud/firestore@7.11.6':
     dependencies:
       '@opentelemetry/api': 1.9.1
@@ -7398,64 +7212,6 @@ snapshots:
 
   '@radix-ui/primitive@1.1.3': {}
 
-  '@radix-ui/react-accordion@1.2.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collapsible': 1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-arrow@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-checkbox@1.3.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-collapsible@1.1.12(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
   '@radix-ui/react-collection@1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
@@ -7521,21 +7277,6 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-dropdown-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-menu': 2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
   '@radix-ui/react-focus-guards@1.1.3(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       react: 19.2.6
@@ -7559,50 +7300,6 @@ snapshots:
       react: 19.2.6
     optionalDependencies:
       '@types/react': 19.2.14
-
-  '@radix-ui/react-menu@2.1.16(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-collection': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-focus-guards': 1.1.3(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-focus-scope': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      aria-hidden: 1.2.6
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-      react-remove-scroll: 2.7.2(@types/react@19.2.14)(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/react-popper@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@floating-ui/react-dom': 2.1.8(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-arrow': 1.1.7(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-use-rect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/rect': 1.1.1
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
   '@radix-ui/react-portal@1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
@@ -7693,26 +7390,6 @@ snapshots:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
 
-  '@radix-ui/react-tooltip@1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
-    dependencies:
-      '@radix-ui/primitive': 1.1.3
-      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-context': 1.1.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-dismissable-layer': 1.1.11(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-id': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-popper': 1.2.8(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-portal': 1.1.9(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      '@radix-ui/react-slot': 1.2.3(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.14)(react@19.2.6)
-      '@radix-ui/react-visually-hidden': 1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
-      react: 19.2.6
-      react-dom: 19.2.6(react@19.2.6)
-    optionalDependencies:
-      '@types/react': 19.2.14
-      '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
   '@radix-ui/react-use-callback-ref@1.1.1(@types/react@19.2.14)(react@19.2.6)':
     dependencies:
       react: 19.2.6
@@ -7747,26 +7424,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
 
-  '@radix-ui/react-use-previous@1.1.1(@types/react@19.2.14)(react@19.2.6)':
-    dependencies:
-      react: 19.2.6
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@radix-ui/react-use-rect@1.1.1(@types/react@19.2.14)(react@19.2.6)':
-    dependencies:
-      '@radix-ui/rect': 1.1.1
-      react: 19.2.6
-    optionalDependencies:
-      '@types/react': 19.2.14
-
-  '@radix-ui/react-use-size@1.1.1(@types/react@19.2.14)(react@19.2.6)':
-    dependencies:
-      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@19.2.14)(react@19.2.6)
-      react: 19.2.6
-    optionalDependencies:
-      '@types/react': 19.2.14
-
   '@radix-ui/react-visually-hidden@1.2.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
@@ -7775,8 +7432,6 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
-
-  '@radix-ui/rect@1.1.1': {}
 
   '@remix-run/router@1.23.2': {}
 
@@ -9275,15 +8930,6 @@ snapshots:
       dom-serializer: 2.0.0
       domelementtype: 2.3.0
       domhandler: 5.0.3
-
-  downshift@9.3.2(react@19.2.6):
-    dependencies:
-      '@babel/runtime': 7.29.2
-      compute-scroll-into-view: 3.1.1
-      prop-types: 15.8.1
-      react: 19.2.6
-      react-is: 18.3.1
-      tslib: 2.8.1
 
   dunder-proto@1.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -290,9 +290,6 @@ importers:
 
   src/server:
     dependencies:
-      '@google-cloud/firestore':
-        specifier: ^8.3.0
-        version: 8.5.0
       '@iarna/toml':
         specifier: ^2.2.5
         version: 2.2.5
@@ -302,9 +299,6 @@ importers:
       '@simlin/engine':
         specifier: workspace:*
         version: link:../engine
-      cookie-parser:
-        specifier: ^1.4.7
-        version: 1.4.7
       cors:
         specifier: ^2.8.6
         version: 2.8.6
@@ -321,9 +315,6 @@ importers:
         specifier: ^8.1.0
         version: 8.1.0
     devDependencies:
-      '@types/cookie-parser':
-        specifier: ^1.4.10
-        version: 1.4.10(@types/express@5.0.6)
       '@types/cors':
         specifier: ^2.8.19
         version: 2.8.19
@@ -949,10 +940,6 @@ packages:
   '@google-cloud/firestore@7.11.6':
     resolution: {integrity: sha512-EW/O8ktzwLfyWBOsNuhRoMi8lrC3clHM5LVFhGvO1HCsLozCOOXRAlHrYBoE6HL42Sc8yYMuCb2XqcnJ4OOEpw==}
     engines: {node: '>=14.0.0'}
-
-  '@google-cloud/firestore@8.5.0':
-    resolution: {integrity: sha512-1sbtj7JQfsfekrxwHR0s2CAz8+hkpBdiuB7+20VEgI4EWvW3+GhEUqYOQPRoZ2spHyITLN4gaOPmBN17J539yQ==}
-    engines: {node: '>=18'}
 
   '@google-cloud/paginator@5.0.2':
     resolution: {integrity: sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==}
@@ -2405,11 +2392,6 @@ packages:
   '@types/connect@3.4.38':
     resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
 
-  '@types/cookie-parser@1.4.10':
-    resolution: {integrity: sha512-B4xqkqfZ8Wek+rCOeRxsjMS9OgvzebEzzLYw7NHYuvzb7IdxOkI0ZHGgeEBX4PUM7QGVvNSK60T3OvWj3YfBRg==}
-    peerDependencies:
-      '@types/express': '*'
-
   '@types/cors@2.8.19':
     resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
 
@@ -3132,13 +3114,6 @@ packages:
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
-  cookie-parser@1.4.7:
-    resolution: {integrity: sha512-nGUvgXnotP3BsjiLX2ypbQnWoGUPIIfHQNZkkC668ntrzGWEZVW70HDEB1qnNGMicPje6EttlIgzo51YSwNQGw==}
-    engines: {node: '>= 0.8.0'}
-
-  cookie-signature@1.0.6:
-    resolution: {integrity: sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==}
-
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
     engines: {node: '>=6.6.0'}
@@ -3791,10 +3766,6 @@ packages:
   google-gax@4.6.1:
     resolution: {integrity: sha512-V6eky/xz2mcKfAd1Ioxyd6nmA61gao3n01C+YeuIwu3vzM9EDR6wcVzMSIbLMDXWeoi9SHYctXuKYC5uJUT3eQ==}
     engines: {node: '>=14'}
-
-  google-gax@5.0.6:
-    resolution: {integrity: sha512-1kGbqVQBZPAAu4+/R1XxPQKP0ydbNYoLAr4l0ZO2bMV0kLyLW4I1gAk++qBLWt7DPORTzmWRMsCZe86gDjShJA==}
-    engines: {node: '>=18'}
 
   google-logging-utils@0.0.2:
     resolution: {integrity: sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==}
@@ -5077,10 +5048,6 @@ packages:
     resolution: {integrity: sha512-SAzp/O4Yh02jGdRc+uIrGoe87dkN/XtwxfZ4ZyafJHymd79ozp5VG5nyZ7ygqPM5+cpLDjjGnYFUkngonyDPOQ==}
     engines: {node: '>=14.0.0'}
 
-  proto3-json-serializer@3.0.4:
-    resolution: {integrity: sha512-E1sbAYg3aEbXrq0n1ojJkRHQJGE1kaE/O6GLA94y8rnJBfgvOPTOd1b9hOceQK1FFZI9qMh1vBERCyO2ifubcw==}
-    engines: {node: '>=18'}
-
   protobufjs@7.5.7:
     resolution: {integrity: sha512-NGnrxS/nLKUo5nkbVQxlC71sB4hdfImdYIbFeSCidxtwATx0AHRPcANSLd0q5Bb2BkoSWo2iisQhGg5/r+ihbA==}
     engines: {node: '>=12.0.0'}
@@ -5286,17 +5253,9 @@ packages:
     resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
     engines: {node: '>=14'}
 
-  retry-request@8.0.2:
-    resolution: {integrity: sha512-JzFPAfklk1kjR1w76f0QOIhoDkNkSqW8wYKT08n9yysTmZfB+RQ2QoXoTAeOi1HD9ZipTyTAZg3c4pM/jeqgSw==}
-    engines: {node: '>=18'}
-
   retry@0.13.1:
     resolution: {integrity: sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==}
     engines: {node: '>= 4'}
-
-  rimraf@5.0.10:
-    resolution: {integrity: sha512-l0OE8wL34P4nJH/H2ffoaniAokM2qSmrtXHmlpvYr5AVVX8msAyW0l8NVJFDxlSK4u3Uh/f41cQheDVdnYijwQ==}
-    hasBin: true
 
   rollup@4.60.3:
     resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
@@ -5719,10 +5678,6 @@ packages:
   tapable@2.3.3:
     resolution: {integrity: sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==}
     engines: {node: '>=6'}
-
-  teeny-request@10.1.2:
-    resolution: {integrity: sha512-Xj0ZAQ0CeuQn6UxCDPLbFRlgcSTUEyO3+wiepr2grjIjyL/lMMs1Z4OwXn8kLvn/V1OuaEP0UY7Na6UDNNsYrQ==}
-    engines: {node: '>=18'}
 
   teeny-request@9.0.0:
     resolution: {integrity: sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==}
@@ -6788,16 +6743,6 @@ snapshots:
       - supports-color
     optional: true
 
-  '@google-cloud/firestore@8.5.0':
-    dependencies:
-      '@opentelemetry/api': 1.9.1
-      fast-deep-equal: 3.1.3
-      functional-red-black-tree: 1.0.1
-      google-gax: 5.0.6
-      protobufjs: 7.5.7
-    transitivePeerDependencies:
-      - supports-color
-
   '@google-cloud/paginator@5.0.2':
     dependencies:
       arrify: 2.0.1
@@ -6836,6 +6781,7 @@ snapshots:
     dependencies:
       '@grpc/proto-loader': 0.8.1
       '@js-sdsl/ordered-map': 4.4.2
+    optional: true
 
   '@grpc/proto-loader@0.7.15':
     dependencies:
@@ -6851,6 +6797,7 @@ snapshots:
       long: 5.3.2
       protobufjs: 7.5.7
       yargs: 17.7.2
+    optional: true
 
   '@humanfs/core@0.19.2':
     dependencies:
@@ -7108,7 +7055,8 @@ snapshots:
       '@jridgewell/sourcemap-codec': 1.5.5
     optional: true
 
-  '@js-sdsl/ordered-map@4.4.2': {}
+  '@js-sdsl/ordered-map@4.4.2':
+    optional: true
 
   '@jsonjoy.com/base64@1.1.2(tslib@2.8.1)':
     dependencies:
@@ -7342,7 +7290,8 @@ snapshots:
   '@nodable/entities@2.1.0':
     optional: true
 
-  '@opentelemetry/api@1.9.1': {}
+  '@opentelemetry/api@1.9.1':
+    optional: true
 
   '@parcel/watcher-android-arm64@2.5.6':
     optional: true
@@ -7414,28 +7363,38 @@ snapshots:
     dependencies:
       playwright: 1.60.0
 
-  '@protobufjs/aspromise@1.1.2': {}
+  '@protobufjs/aspromise@1.1.2':
+    optional: true
 
-  '@protobufjs/base64@1.1.2': {}
+  '@protobufjs/base64@1.1.2':
+    optional: true
 
-  '@protobufjs/codegen@2.0.5': {}
+  '@protobufjs/codegen@2.0.5':
+    optional: true
 
-  '@protobufjs/eventemitter@1.1.0': {}
+  '@protobufjs/eventemitter@1.1.0':
+    optional: true
 
   '@protobufjs/fetch@1.1.0':
     dependencies:
       '@protobufjs/aspromise': 1.1.2
       '@protobufjs/inquire': 1.1.1
+    optional: true
 
-  '@protobufjs/float@1.0.2': {}
+  '@protobufjs/float@1.0.2':
+    optional: true
 
-  '@protobufjs/inquire@1.1.1': {}
+  '@protobufjs/inquire@1.1.1':
+    optional: true
 
-  '@protobufjs/path@1.1.2': {}
+  '@protobufjs/path@1.1.2':
+    optional: true
 
-  '@protobufjs/pool@1.1.0': {}
+  '@protobufjs/pool@1.1.0':
+    optional: true
 
-  '@protobufjs/utf8@1.1.1': {}
+  '@protobufjs/utf8@1.1.1':
+    optional: true
 
   '@radix-ui/primitive@1.1.3': {}
 
@@ -8371,10 +8330,6 @@ snapshots:
     dependencies:
       '@types/node': 25.7.0
 
-  '@types/cookie-parser@1.4.10(@types/express@5.0.6)':
-    dependencies:
-      '@types/express': 5.0.6
-
   '@types/cors@2.8.19':
     dependencies:
       '@types/node': 25.7.0
@@ -9170,13 +9125,6 @@ snapshots:
 
   convert-source-map@2.0.0: {}
 
-  cookie-parser@1.4.7:
-    dependencies:
-      cookie: 0.7.2
-      cookie-signature: 1.0.6
-
-  cookie-signature@1.0.6: {}
-
   cookie-signature@1.2.2: {}
 
   cookie@0.7.2: {}
@@ -9349,6 +9297,7 @@ snapshots:
       inherits: 2.0.4
       readable-stream: 3.6.2
       stream-shift: 1.0.3
+    optional: true
 
   eastasianwidth@0.2.0: {}
 
@@ -9373,6 +9322,7 @@ snapshots:
   end-of-stream@1.4.5:
     dependencies:
       once: 1.4.0
+    optional: true
 
   enhanced-resolve@5.18.0:
     dependencies:
@@ -9898,7 +9848,8 @@ snapshots:
       hasown: 2.0.3
       is-callable: 1.2.7
 
-  functional-red-black-tree@1.0.1: {}
+  functional-red-black-tree@1.0.1:
+    optional: true
 
   functions-have-names@1.2.3: {}
 
@@ -10059,22 +10010,6 @@ snapshots:
       - encoding
       - supports-color
     optional: true
-
-  google-gax@5.0.6:
-    dependencies:
-      '@grpc/grpc-js': 1.14.3
-      '@grpc/proto-loader': 0.8.1
-      duplexify: 4.1.3
-      google-auth-library: 10.6.2
-      google-logging-utils: 1.1.3
-      node-fetch: 3.3.2
-      object-hash: 3.0.0
-      proto3-json-serializer: 3.0.4
-      protobufjs: 7.5.7
-      retry-request: 8.0.2
-      rimraf: 5.0.10
-    transitivePeerDependencies:
-      - supports-color
 
   google-logging-utils@0.0.2:
     optional: true
@@ -11034,7 +10969,8 @@ snapshots:
 
   lodash-es@4.18.1: {}
 
-  lodash.camelcase@4.3.0: {}
+  lodash.camelcase@4.3.0:
+    optional: true
 
   lodash.clonedeep@4.5.0: {}
 
@@ -11058,7 +10994,8 @@ snapshots:
 
   lodash@4.18.1: {}
 
-  long@5.3.2: {}
+  long@5.3.2:
+    optional: true
 
   longest-streak@3.1.0: {}
 
@@ -11637,7 +11574,8 @@ snapshots:
 
   object-assign@4.1.1: {}
 
-  object-hash@3.0.0: {}
+  object-hash@3.0.0:
+    optional: true
 
   object-inspect@1.13.4: {}
 
@@ -11855,10 +11793,6 @@ snapshots:
       protobufjs: 7.5.7
     optional: true
 
-  proto3-json-serializer@3.0.4:
-    dependencies:
-      protobufjs: 7.5.7
-
   protobufjs@7.5.7:
     dependencies:
       '@protobufjs/aspromise': 1.1.2
@@ -11873,6 +11807,7 @@ snapshots:
       '@protobufjs/utf8': 1.1.1
       '@types/node': 25.7.0
       long: 5.3.2
+    optional: true
 
   proxy-addr@2.0.7:
     dependencies:
@@ -11993,6 +11928,7 @@ snapshots:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
+    optional: true
 
   readdirp@3.6.0:
     dependencies:
@@ -12117,19 +12053,8 @@ snapshots:
       - supports-color
     optional: true
 
-  retry-request@8.0.2:
-    dependencies:
-      extend: 3.0.2
-      teeny-request: 10.1.2
-    transitivePeerDependencies:
-      - supports-color
-
   retry@0.13.1:
     optional: true
-
-  rimraf@5.0.10:
-    dependencies:
-      glob: 10.5.0
 
   rollup@4.60.3:
     dependencies:
@@ -12513,8 +12438,10 @@ snapshots:
   stream-events@1.0.5:
     dependencies:
       stubs: 3.0.0
+    optional: true
 
-  stream-shift@1.0.3: {}
+  stream-shift@1.0.3:
+    optional: true
 
   string-length@4.0.2:
     dependencies:
@@ -12580,6 +12507,7 @@ snapshots:
   string_decoder@1.3.0:
     dependencies:
       safe-buffer: 5.2.1
+    optional: true
 
   stringify-entities@4.0.4:
     dependencies:
@@ -12605,7 +12533,8 @@ snapshots:
   strnum@2.3.0:
     optional: true
 
-  stubs@3.0.0: {}
+  stubs@3.0.0:
+    optional: true
 
   style-to-object@0.4.4:
     dependencies:
@@ -12634,15 +12563,6 @@ snapshots:
       '@pkgr/core': 0.2.9
 
   tapable@2.3.3: {}
-
-  teeny-request@10.1.2:
-    dependencies:
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      node-fetch: 3.3.2
-      stream-events: 1.0.5
-    transitivePeerDependencies:
-      - supports-color
 
   teeny-request@9.0.0:
     dependencies:
@@ -12974,7 +12894,8 @@ snapshots:
     dependencies:
       react: 19.2.6
 
-  util-deprecate@1.0.2: {}
+  util-deprecate@1.0.2:
+    optional: true
 
   uuid@10.0.0: {}
 

--- a/src/diagram/components/Accordion.module.css
+++ b/src/diagram/components/Accordion.module.css
@@ -65,36 +65,24 @@
   transform: rotate(180deg);
 }
 
+/* Animate open/close height without measuring the content: a single-row grid
+   transitions its track from 0fr to 1fr, and the inner element clips its own
+   overflow while the track is collapsing. No JS and no Radix CSS variable. */
 .details {
-  overflow: hidden;
+  display: grid;
+  grid-template-rows: 0fr;
+  transition: grid-template-rows 200ms cubic-bezier(0.87, 0, 0.13, 1);
 }
 
 .details[data-state='open'] {
-  animation: slideDown 200ms cubic-bezier(0.87, 0, 0.13, 1);
-}
-
-.details[data-state='closed'] {
-  animation: slideUp 200ms cubic-bezier(0.87, 0, 0.13, 1);
-}
-
-@keyframes slideDown {
-  from {
-    height: 0;
-  }
-  to {
-    height: var(--radix-accordion-content-height);
-  }
-}
-
-@keyframes slideUp {
-  from {
-    height: var(--radix-accordion-content-height);
-  }
-  to {
-    height: 0;
-  }
+  grid-template-rows: 1fr;
 }
 
 .detailsInner {
+  overflow: hidden;
+  min-height: 0;
+}
+
+.detailsContent {
   padding: 8px 16px 16px;
 }

--- a/src/diagram/components/Accordion.tsx
+++ b/src/diagram/components/Accordion.tsx
@@ -126,12 +126,18 @@ export function AccordionDetails(props: AccordionDetailsProps): React.ReactEleme
       className={clsx(styles.details, className)}
       style={style}
       data-state={open ? 'open' : 'closed'}
+      // The content stays mounted so the grid-rows height transition can run,
+      // but a collapsed panel must not be reachable by keyboard or exposed to
+      // assistive tech (Radix used `hidden`). `inert` on the region itself --
+      // not just the inner wrapper -- removes the whole subtree from tab order
+      // and the a11y tree while keeping it laid out for the transition;
+      // `aria-hidden` makes the a11y-tree removal explicit (and not reliant on
+      // every engine wiring inert into the accessibility tree), so a closed
+      // panel is never announced as an empty region.
+      inert={open ? undefined : true}
+      aria-hidden={open ? undefined : true}
     >
-      {/* The content stays mounted so the grid-rows height transition can run,
-          but a collapsed panel must not be reachable by keyboard or exposed to
-          assistive tech (Radix used `hidden`). `inert` removes the whole
-          subtree from tab order and the a11y tree while keeping it laid out. */}
-      <div className={styles.detailsInner} inert={open ? undefined : true}>
+      <div className={styles.detailsInner}>
         <div className={styles.detailsContent}>{children}</div>
       </div>
     </div>

--- a/src/diagram/components/Accordion.tsx
+++ b/src/diagram/components/Accordion.tsx
@@ -127,7 +127,11 @@ export function AccordionDetails(props: AccordionDetailsProps): React.ReactEleme
       style={style}
       data-state={open ? 'open' : 'closed'}
     >
-      <div className={styles.detailsInner}>
+      {/* The content stays mounted so the grid-rows height transition can run,
+          but a collapsed panel must not be reachable by keyboard or exposed to
+          assistive tech (Radix used `hidden`). `inert` removes the whole
+          subtree from tab order and the a11y tree while keeping it laid out. */}
+      <div className={styles.detailsInner} inert={open ? undefined : true}>
         <div className={styles.detailsContent}>{children}</div>
       </div>
     </div>

--- a/src/diagram/components/Accordion.tsx
+++ b/src/diagram/components/Accordion.tsx
@@ -3,10 +3,30 @@
 // Version 2.0, that can be found in the LICENSE file.
 
 import * as React from 'react';
-import * as RadixAccordion from '@radix-ui/react-accordion';
 import clsx from 'clsx';
 
 import styles from './Accordion.module.css';
+
+interface AccordionContextValue {
+  open: boolean;
+  disabled: boolean;
+  toggle: () => void;
+  triggerId: string;
+  contentId: string;
+}
+
+// Shares the single-item disclosure state between the composed
+// Accordion/AccordionSummary/AccordionDetails parts, the way Radix's internal
+// context did, so callers keep composing them as independent children.
+const AccordionContext = React.createContext<AccordionContextValue | undefined>(undefined);
+
+function useAccordionContext(part: string): AccordionContextValue {
+  const ctx = React.useContext(AccordionContext);
+  if (!ctx) {
+    throw new Error(`${part} must be rendered inside an <Accordion>`);
+  }
+  return ctx;
+}
 
 export interface AccordionProps {
   defaultExpanded?: boolean;
@@ -19,30 +39,40 @@ export interface AccordionProps {
 }
 
 export function Accordion(props: AccordionProps): React.ReactElement {
-  const { defaultExpanded, expanded, onChange, disabled, className, style, children } = props;
+  const { defaultExpanded, expanded, onChange, disabled = false, className, style, children } = props;
 
-  const value = expanded ? 'item' : '';
-  const defaultValue = defaultExpanded ? 'item' : undefined;
+  const isControlled = expanded !== undefined;
+  const [internalOpen, setInternalOpen] = React.useState(defaultExpanded ?? false);
+  const open = isControlled ? expanded : internalOpen;
+
+  const reactId = React.useId();
+  const triggerId = `${reactId}-trigger`;
+  const contentId = `${reactId}-content`;
+
+  const toggle = React.useCallback(() => {
+    if (disabled) {
+      return;
+    }
+    const next = !open;
+    if (!isControlled) {
+      setInternalOpen(next);
+    }
+    if (onChange) {
+      onChange(next);
+    }
+  }, [disabled, open, isControlled, onChange]);
+
+  const ctx = React.useMemo<AccordionContextValue>(
+    () => ({ open, disabled, toggle, triggerId, contentId }),
+    [open, disabled, toggle, triggerId, contentId],
+  );
 
   return (
-    <RadixAccordion.Root
-      type="single"
-      collapsible
-      value={expanded !== undefined ? value : undefined}
-      defaultValue={defaultValue}
-      onValueChange={(newValue) => {
-        if (onChange) {
-          onChange(newValue === 'item');
-        }
-      }}
-      disabled={disabled}
-      className={clsx(styles.accordion, className)}
-      style={style}
-    >
-      <RadixAccordion.Item value="item" className={styles.item}>
-        {children}
-      </RadixAccordion.Item>
-    </RadixAccordion.Root>
+    <div className={clsx(styles.accordion, className)} style={style} data-state={open ? 'open' : 'closed'}>
+      <AccordionContext.Provider value={ctx}>
+        <div className={styles.item}>{children}</div>
+      </AccordionContext.Provider>
+    </div>
   );
 }
 
@@ -55,14 +85,26 @@ export interface AccordionSummaryProps {
 
 export function AccordionSummary(props: AccordionSummaryProps): React.ReactElement {
   const { expandIcon, className, style, children } = props;
+  const { open, disabled, toggle, triggerId, contentId } = useAccordionContext('AccordionSummary');
 
   return (
-    <RadixAccordion.Header className={styles.header}>
-      <RadixAccordion.Trigger className={clsx(styles.trigger, className)} style={style}>
+    <h3 className={styles.header}>
+      <button
+        type="button"
+        id={triggerId}
+        className={clsx(styles.trigger, className)}
+        style={style}
+        aria-expanded={open}
+        aria-controls={contentId}
+        disabled={disabled}
+        data-state={open ? 'open' : 'closed'}
+        data-disabled={disabled ? '' : undefined}
+        onClick={toggle}
+      >
         <span className={styles.content}>{children}</span>
         {expandIcon && <span className={styles.expandIcon}>{expandIcon}</span>}
-      </RadixAccordion.Trigger>
-    </RadixAccordion.Header>
+      </button>
+    </h3>
   );
 }
 
@@ -74,10 +116,20 @@ export interface AccordionDetailsProps {
 
 export function AccordionDetails(props: AccordionDetailsProps): React.ReactElement {
   const { className, style, children } = props;
+  const { open, triggerId, contentId } = useAccordionContext('AccordionDetails');
 
   return (
-    <RadixAccordion.Content className={clsx(styles.details, className)} style={style}>
-      <div className={styles.detailsInner}>{children}</div>
-    </RadixAccordion.Content>
+    <div
+      id={contentId}
+      role="region"
+      aria-labelledby={triggerId}
+      className={clsx(styles.details, className)}
+      style={style}
+      data-state={open ? 'open' : 'closed'}
+    >
+      <div className={styles.detailsInner}>
+        <div className={styles.detailsContent}>{children}</div>
+      </div>
+    </div>
   );
 }

--- a/src/diagram/components/Autocomplete.tsx
+++ b/src/diagram/components/Autocomplete.tsx
@@ -5,10 +5,10 @@
 import * as React from 'react';
 import ReactDOM from 'react-dom';
 
-import { useCombobox } from 'downshift';
 import clsx from 'clsx';
 
 import styles from './Autocomplete.module.css';
+import { useCombobox } from './useCombobox';
 
 export interface AutocompleteRenderInputParams {
   InputProps: {
@@ -26,10 +26,6 @@ interface AutocompleteProps {
   clearOnEscape?: boolean;
   options: string[];
   renderInput: (params: AutocompleteRenderInputParams) => React.ReactNode;
-}
-
-function itemToString(item: string | null): string {
-  return item || '';
 }
 
 export default function Autocomplete(props: AutocompleteProps) {
@@ -56,26 +52,14 @@ export default function Autocomplete(props: AutocompleteProps) {
 
   const { isOpen, getInputProps, getMenuProps, getItemProps, highlightedIndex } = useCombobox({
     items: filteredOptions,
-    itemToString,
     inputValue,
-    selectedItem: value || null,
     onInputValueChange: ({ inputValue: newInputValue }) => {
       setInputValue(newInputValue || '');
     },
     onSelectedItemChange: ({ selectedItem }) => {
       onChange(null, selectedItem || null);
     },
-    stateReducer: (state, actionAndChanges) => {
-      const { type, changes } = actionAndChanges;
-      if (clearOnEscape && type === useCombobox.stateChangeTypes.InputKeyDownEscape) {
-        return {
-          ...changes,
-          selectedItem: null,
-          inputValue: '',
-        };
-      }
-      return changes;
-    },
+    clearOnEscape,
   });
 
   const updateDropdownPosition = React.useCallback(() => {

--- a/src/diagram/components/Checkbox.module.css
+++ b/src/diagram/components/Checkbox.module.css
@@ -1,11 +1,20 @@
+.root {
+  position: relative;
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+}
+
 .checkbox {
   all: unset;
+  /* `all: unset` does not reliably drop the native checkbox glyph across
+     engines; force it off so our own box + indicator render cleanly. */
+  appearance: none;
+  -webkit-appearance: none;
+  box-sizing: border-box;
   width: 18px;
   height: 18px;
   border-radius: 2px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
   border: 2px solid var(--color-text-muted);
   background-color: transparent;
   cursor: pointer;
@@ -34,10 +43,14 @@
 }
 
 .indicator {
+  position: absolute;
+  inset: 0;
   display: flex;
   align-items: center;
   justify-content: center;
   color: var(--color-contrast-text);
+  /* The box itself (the input) owns clicks; the overlay must not intercept. */
+  pointer-events: none;
 }
 
 .checkIcon {

--- a/src/diagram/components/Checkbox.tsx
+++ b/src/diagram/components/Checkbox.tsx
@@ -3,7 +3,6 @@
 // Version 2.0, that can be found in the LICENSE file.
 
 import * as React from 'react';
-import * as RadixCheckbox from '@radix-ui/react-checkbox';
 import clsx from 'clsx';
 
 import styles from './Checkbox.module.css';
@@ -23,21 +22,40 @@ export interface CheckboxProps {
 export default function Checkbox(props: CheckboxProps): React.ReactElement {
   const { checked, defaultChecked, onChange, disabled, name, color = 'primary', className, style } = props;
 
+  // Support both controlled (`checked`) and uncontrolled (`defaultChecked`)
+  // use, mirroring the prior Radix behavior so the rendered data-state always
+  // reflects the live value rather than only the initial prop.
+  const isControlled = checked !== undefined;
+  const [internalChecked, setInternalChecked] = React.useState(defaultChecked ?? false);
+  const isChecked = isControlled ? checked : internalChecked;
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const next = event.target.checked;
+    if (!isControlled) {
+      setInternalChecked(next);
+    }
+    if (onChange) {
+      onChange(next);
+    }
+  };
+
   return (
-    <RadixCheckbox.Root
-      className={clsx(styles.checkbox, color === 'secondary' ? styles.secondary : styles.primary, className)}
-      style={style}
-      checked={checked}
-      defaultChecked={defaultChecked}
-      // Radix's CheckedState is boolean | 'indeterminate'; normalize so the
-      // (checked: boolean) contract our callers type against actually holds.
-      onCheckedChange={onChange ? (state) => onChange(state === true) : undefined}
-      disabled={disabled}
-      name={name}
-    >
-      <RadixCheckbox.Indicator className={styles.indicator}>
-        <CheckIcon className={styles.checkIcon} />
-      </RadixCheckbox.Indicator>
-    </RadixCheckbox.Root>
+    <span className={styles.root}>
+      <input
+        type="checkbox"
+        className={clsx(styles.checkbox, color === 'secondary' ? styles.secondary : styles.primary, className)}
+        style={style}
+        data-state={isChecked ? 'checked' : 'unchecked'}
+        checked={isChecked}
+        onChange={handleChange}
+        disabled={disabled}
+        name={name}
+      />
+      {isChecked && (
+        <span className={styles.indicator} aria-hidden="true">
+          <CheckIcon className={styles.checkIcon} />
+        </span>
+      )}
+    </span>
   );
 }

--- a/src/diagram/components/Menu.tsx
+++ b/src/diagram/components/Menu.tsx
@@ -158,8 +158,8 @@ export function Menu(props: MenuProps): React.ReactElement {
   // portal is appended at the end of <body>, so without this they would have to
   // tab through the whole page to reach it. Also clear skipBlurCloseRef so each
   // open starts clean: an outside-press dismissal closes the menu (calling
-  // onClose) synchronously inside the mousedown listener, which tears down the
-  // mouseup reset before it runs, leaving the flag stranded true for next time.
+  // onClose) synchronously inside the pointerdown listener, which tears down the
+  // pointerup reset before it runs, leaving the flag stranded true for next time.
   React.useEffect(() => {
     if (!open) {
       return;

--- a/src/diagram/components/Menu.tsx
+++ b/src/diagram/components/Menu.tsx
@@ -282,7 +282,13 @@ export function MenuItem(props: MenuItemProps): React.ReactElement {
   return (
     <div
       role="menuitem"
-      tabIndex={disabled ? -1 : 0}
+      // Roving focus: items are not in the document tab sequence. The menu
+      // focuses the first item on open and arrow keys move focus
+      // programmatically, while Tab/Shift+Tab (which we do not intercept) leave
+      // the menu entirely -- nothing here is tabbable -- and the resulting
+      // focus-out dismisses it, matching Radix's menu behavior. With every item
+      // at tabIndex=0 a multi-item menu would instead trap Tab on the next item.
+      tabIndex={-1}
       aria-disabled={disabled || undefined}
       data-disabled={disabled ? '' : undefined}
       className={clsx(styles.menuItem, className)}

--- a/src/diagram/components/Menu.tsx
+++ b/src/diagram/components/Menu.tsx
@@ -85,14 +85,14 @@ export function Menu(props: MenuProps): React.ReactElement {
   const anchorRect = useAnchorRect(anchorEl, open);
   const contentRef = React.useRef<HTMLDivElement>(null);
   // True while a focus move is one the other handlers already own -- a pointer
-  // press (handled by the mousedown listener) or Escape's focus-restore -- so
+  // press (handled by the pointerdown listener) or Escape's focus-restore -- so
   // the blur handler does not also close. It stays false for a genuine keyboard
   // focus-out (Tab/Shift+Tab), which is the only case blur-close should fire.
   const skipBlurCloseRef = React.useRef(false);
 
   // Dismiss on Escape or a pointer press outside the menu, only while open.
   // The listeners are registered after the render that mounts the menu, so the
-  // click that opened it (already past its mousedown) never self-closes it.
+  // press that opened it (already past its pointerdown) never self-closes it.
   React.useEffect(() => {
     if (!open) {
       return;
@@ -102,7 +102,7 @@ export function Menu(props: MenuProps): React.ReactElement {
         event.preventDefault();
         onClose();
         // Keyboard dismissal returns focus to the trigger (Radix did this);
-        // outside-click dismissal does not, so the clicked element keeps focus.
+        // outside-press dismissal does not, so the pressed element keeps focus.
         // The focus move fires a blur synchronously, so guard it from
         // double-closing.
         skipBlurCloseRef.current = true;
@@ -110,7 +110,13 @@ export function Menu(props: MenuProps): React.ReactElement {
         skipBlurCloseRef.current = false;
       }
     };
-    const onMouseDown = (event: MouseEvent): void => {
+    // Use pointerdown in CAPTURE, not mousedown: surfaces like the diagram
+    // canvas preventDefault() on pointerdown for pan/drag, which suppresses the
+    // compatibility mousedown -- a mousedown listener would miss those presses
+    // and the menu would stay stuck open. Capture also runs before the target's
+    // own handlers, so we see the press regardless of what it does (matching
+    // Radix's outside-interaction handling).
+    const onPointerDown = (event: PointerEvent): void => {
       // Any focus shift this press causes is owned here, not by blur-close.
       skipBlurCloseRef.current = true;
       const target = event.target as Node;
@@ -127,16 +133,16 @@ export function Menu(props: MenuProps): React.ReactElement {
       }
       onClose();
     };
-    const onMouseUp = (): void => {
+    const onPointerUp = (): void => {
       skipBlurCloseRef.current = false;
     };
     document.addEventListener('keydown', onKeyDown);
-    document.addEventListener('mousedown', onMouseDown);
-    document.addEventListener('mouseup', onMouseUp);
+    document.addEventListener('pointerdown', onPointerDown, true);
+    document.addEventListener('pointerup', onPointerUp, true);
     return () => {
       document.removeEventListener('keydown', onKeyDown);
-      document.removeEventListener('mousedown', onMouseDown);
-      document.removeEventListener('mouseup', onMouseUp);
+      document.removeEventListener('pointerdown', onPointerDown, true);
+      document.removeEventListener('pointerup', onPointerUp, true);
     };
   }, [open, onClose, anchorEl]);
 

--- a/src/diagram/components/Menu.tsx
+++ b/src/diagram/components/Menu.tsx
@@ -3,7 +3,7 @@
 // Version 2.0, that can be found in the LICENSE file.
 
 import * as React from 'react';
-import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+import ReactDOM from 'react-dom';
 import clsx from 'clsx';
 
 import styles from './Menu.module.css';
@@ -19,6 +19,10 @@ export interface MenuProps {
   style?: React.CSSProperties;
   children?: React.ReactNode;
 }
+
+// Radix closed the menu automatically when an item was chosen; MenuItem reads
+// this to reproduce that close-on-select without each caller wiring onClose.
+const MenuCloseContext = React.createContext<(() => void) | undefined>(undefined);
 
 /**
  * Track an anchor element's viewport rect live while a menu is open.
@@ -79,34 +83,74 @@ export function Menu(props: MenuProps): React.ReactElement {
   const align = anchorOrigin?.horizontal === 'right' ? 'end' : 'start';
 
   const anchorRect = useAnchorRect(anchorEl, open);
+  const contentRef = React.useRef<HTMLDivElement>(null);
 
-  return (
-    <DropdownMenu.Root open={open} onOpenChange={(isOpen) => !isOpen && onClose()}>
-      <DropdownMenu.Trigger asChild>
-        <span
-          style={{
-            position: 'fixed',
-            top: anchorRect?.bottom ?? 0,
-            left: anchorRect?.left ?? 0,
-            width: anchorRect?.width ?? 0,
-            height: 0,
-            pointerEvents: 'none',
-          }}
-        />
-      </DropdownMenu.Trigger>
-      <DropdownMenu.Portal>
-        <DropdownMenu.Content
-          id={id}
-          className={clsx(styles.menuContent, className)}
-          style={style}
-          side={side}
-          align={align}
-          sideOffset={0}
-        >
-          {children}
-        </DropdownMenu.Content>
-      </DropdownMenu.Portal>
-    </DropdownMenu.Root>
+  // Dismiss on Escape or a pointer press outside the menu, only while open.
+  // The listeners are registered after the render that mounts the menu, so the
+  // click that opened it (already past its mousedown) never self-closes it.
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    const onKeyDown = (event: KeyboardEvent): void => {
+      if (event.key === 'Escape') {
+        onClose();
+      }
+    };
+    const onMouseDown = (event: MouseEvent): void => {
+      const content = contentRef.current;
+      if (content && !content.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    document.addEventListener('mousedown', onMouseDown);
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.removeEventListener('mousedown', onMouseDown);
+    };
+  }, [open, onClose]);
+
+  // Position the content as a fixed overlay derived directly from the live
+  // anchor rect -- top/bottom from the vertical origin, left/right from the
+  // horizontal one -- so we never need to measure the menu's own size.
+  const contentStyle: React.CSSProperties = { position: 'fixed', zIndex: 1300, ...style };
+  if (anchorRect) {
+    if (side === 'bottom') {
+      contentStyle.top = anchorRect.bottom;
+    } else {
+      contentStyle.bottom = window.innerHeight - anchorRect.top;
+    }
+    if (align === 'start') {
+      contentStyle.left = anchorRect.left;
+    } else {
+      contentStyle.right = window.innerWidth - anchorRect.right;
+    }
+  }
+
+  return ReactDOM.createPortal(
+    <>
+      {/* The proxy carries aria-haspopup and mirrors the anchor rect; it gives
+          assistive tech a stable popup owner and pins the anchor geometry the
+          positioning test asserts against (issue #710). */}
+      <span
+        aria-haspopup="menu"
+        style={{
+          position: 'fixed',
+          top: anchorRect?.bottom ?? 0,
+          left: anchorRect?.left ?? 0,
+          width: anchorRect?.width ?? 0,
+          height: 0,
+          pointerEvents: 'none',
+        }}
+      />
+      {open && (
+        <div ref={contentRef} id={id} role="menu" className={clsx(styles.menuContent, className)} style={contentStyle}>
+          <MenuCloseContext.Provider value={onClose}>{children}</MenuCloseContext.Provider>
+        </div>
+      )}
+    </>,
+    document.body,
   );
 }
 
@@ -120,19 +164,35 @@ export interface MenuItemProps {
 
 export function MenuItem(props: MenuItemProps): React.ReactElement {
   const { onClick, disabled, className, style, children } = props;
+  const close = React.useContext(MenuCloseContext);
+
+  const activate = (event: React.MouseEvent | React.KeyboardEvent): void => {
+    if (disabled) {
+      return;
+    }
+    if (onClick) {
+      onClick(event as React.MouseEvent);
+    }
+    close?.();
+  };
 
   return (
-    <DropdownMenu.Item
+    <div
+      role="menuitem"
+      tabIndex={disabled ? -1 : 0}
+      aria-disabled={disabled || undefined}
+      data-disabled={disabled ? '' : undefined}
       className={clsx(styles.menuItem, className)}
       style={style}
-      disabled={disabled}
-      onSelect={(event) => {
-        if (onClick) {
-          onClick(event as unknown as React.MouseEvent);
+      onClick={activate}
+      onKeyDown={(event) => {
+        if (event.key === 'Enter' || event.key === ' ') {
+          event.preventDefault();
+          activate(event);
         }
       }}
     >
       {children}
-    </DropdownMenu.Item>
+    </div>
   );
 }

--- a/src/diagram/components/Menu.tsx
+++ b/src/diagram/components/Menu.tsx
@@ -84,6 +84,11 @@ export function Menu(props: MenuProps): React.ReactElement {
 
   const anchorRect = useAnchorRect(anchorEl, open);
   const contentRef = React.useRef<HTMLDivElement>(null);
+  // True while a focus move is one the other handlers already own -- a pointer
+  // press (handled by the mousedown listener) or Escape's focus-restore -- so
+  // the blur handler does not also close. It stays false for a genuine keyboard
+  // focus-out (Tab/Shift+Tab), which is the only case blur-close should fire.
+  const skipBlurCloseRef = React.useRef(false);
 
   // Dismiss on Escape or a pointer press outside the menu, only while open.
   // The listeners are registered after the render that mounts the menu, so the
@@ -94,13 +99,20 @@ export function Menu(props: MenuProps): React.ReactElement {
     }
     const onKeyDown = (event: KeyboardEvent): void => {
       if (event.key === 'Escape') {
+        event.preventDefault();
         onClose();
         // Keyboard dismissal returns focus to the trigger (Radix did this);
         // outside-click dismissal does not, so the clicked element keeps focus.
+        // The focus move fires a blur synchronously, so guard it from
+        // double-closing.
+        skipBlurCloseRef.current = true;
         anchorEl?.focus();
+        skipBlurCloseRef.current = false;
       }
     };
     const onMouseDown = (event: MouseEvent): void => {
+      // Any focus shift this press causes is owned here, not by blur-close.
+      skipBlurCloseRef.current = true;
       const target = event.target as Node;
       const content = contentRef.current;
       // The anchor is logically part of the trigger, so a press on it is not
@@ -115,11 +127,16 @@ export function Menu(props: MenuProps): React.ReactElement {
       }
       onClose();
     };
+    const onMouseUp = (): void => {
+      skipBlurCloseRef.current = false;
+    };
     document.addEventListener('keydown', onKeyDown);
     document.addEventListener('mousedown', onMouseDown);
+    document.addEventListener('mouseup', onMouseUp);
     return () => {
       document.removeEventListener('keydown', onKeyDown);
       document.removeEventListener('mousedown', onMouseDown);
+      document.removeEventListener('mouseup', onMouseUp);
     };
   }, [open, onClose, anchorEl]);
 
@@ -169,14 +186,16 @@ export function Menu(props: MenuProps): React.ReactElement {
     }
   };
 
-  // Tabbing (or any focus move) out of the menu dismisses it. A move BETWEEN
-  // items, or back to the anchor (the Escape path focuses it), is not "out".
+  // A genuine keyboard focus-out of the menu (Tab/Shift+Tab) dismisses it --
+  // including Shift+Tab back to the trigger. A move BETWEEN items is not "out",
+  // and pointer- or Escape-driven focus moves are owned by their own handlers
+  // (skipBlurCloseRef), so they do not double-close here.
   const onContentBlur = (event: React.FocusEvent<HTMLDivElement>): void => {
     const next = event.relatedTarget as Node | null;
-    if (!next) {
+    if (!next || skipBlurCloseRef.current) {
       return;
     }
-    if (contentRef.current?.contains(next) || anchorEl?.contains(next)) {
+    if (contentRef.current?.contains(next)) {
       return;
     }
     onClose();

--- a/src/diagram/components/Menu.tsx
+++ b/src/diagram/components/Menu.tsx
@@ -95,13 +95,25 @@ export function Menu(props: MenuProps): React.ReactElement {
     const onKeyDown = (event: KeyboardEvent): void => {
       if (event.key === 'Escape') {
         onClose();
+        // Keyboard dismissal returns focus to the trigger (Radix did this);
+        // outside-click dismissal does not, so the clicked element keeps focus.
+        anchorEl?.focus();
       }
     };
     const onMouseDown = (event: MouseEvent): void => {
+      const target = event.target as Node;
       const content = contentRef.current;
-      if (content && !content.contains(event.target as Node)) {
-        onClose();
+      // The anchor is logically part of the trigger, so a press on it is not
+      // "outside": treating it as outside would close the menu on the same
+      // press that a toggling trigger handler then reopens (a redundant
+      // close->reopen flicker), and would defeat a trigger meant to toggle.
+      if (content && content.contains(target)) {
+        return;
       }
+      if (anchorEl && anchorEl.contains(target)) {
+        return;
+      }
+      onClose();
     };
     document.addEventListener('keydown', onKeyDown);
     document.addEventListener('mousedown', onMouseDown);
@@ -109,7 +121,66 @@ export function Menu(props: MenuProps): React.ReactElement {
       document.removeEventListener('keydown', onKeyDown);
       document.removeEventListener('mousedown', onMouseDown);
     };
-  }, [open, onClose]);
+  }, [open, onClose, anchorEl]);
+
+  const enabledItems = React.useCallback(
+    (): HTMLElement[] =>
+      Array.from(
+        contentRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]:not([aria-disabled="true"])') ?? [],
+      ),
+    [],
+  );
+
+  // Move focus into the menu when it opens so keyboard users land on it; the
+  // portal is appended at the end of <body>, so without this they would have to
+  // tab through the whole page to reach it.
+  React.useEffect(() => {
+    if (!open) {
+      return;
+    }
+    enabledItems()[0]?.focus();
+  }, [open, enabledItems]);
+
+  const onContentKeyDown = (event: React.KeyboardEvent<HTMLDivElement>): void => {
+    const items = enabledItems();
+    if (items.length === 0) {
+      return;
+    }
+    const current = items.indexOf(document.activeElement as HTMLElement);
+    switch (event.key) {
+      case 'ArrowDown':
+        event.preventDefault();
+        items[(current + 1) % items.length]?.focus();
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        items[(current - 1 + items.length) % items.length]?.focus();
+        break;
+      case 'Home':
+        event.preventDefault();
+        items[0]?.focus();
+        break;
+      case 'End':
+        event.preventDefault();
+        items[items.length - 1]?.focus();
+        break;
+      default:
+        break;
+    }
+  };
+
+  // Tabbing (or any focus move) out of the menu dismisses it. A move BETWEEN
+  // items, or back to the anchor (the Escape path focuses it), is not "out".
+  const onContentBlur = (event: React.FocusEvent<HTMLDivElement>): void => {
+    const next = event.relatedTarget as Node | null;
+    if (!next) {
+      return;
+    }
+    if (contentRef.current?.contains(next) || anchorEl?.contains(next)) {
+      return;
+    }
+    onClose();
+  };
 
   // Position the content as a fixed overlay derived directly from the live
   // anchor rect -- top/bottom from the vertical origin, left/right from the
@@ -145,7 +216,15 @@ export function Menu(props: MenuProps): React.ReactElement {
         }}
       />
       {open && (
-        <div ref={contentRef} id={id} role="menu" className={clsx(styles.menuContent, className)} style={contentStyle}>
+        <div
+          ref={contentRef}
+          id={id}
+          role="menu"
+          className={clsx(styles.menuContent, className)}
+          style={contentStyle}
+          onKeyDown={onContentKeyDown}
+          onBlur={onContentBlur}
+        >
           <MenuCloseContext.Provider value={onClose}>{children}</MenuCloseContext.Provider>
         </div>
       )}

--- a/src/diagram/components/Menu.tsx
+++ b/src/diagram/components/Menu.tsx
@@ -150,11 +150,15 @@ export function Menu(props: MenuProps): React.ReactElement {
 
   // Move focus into the menu when it opens so keyboard users land on it; the
   // portal is appended at the end of <body>, so without this they would have to
-  // tab through the whole page to reach it.
+  // tab through the whole page to reach it. Also clear skipBlurCloseRef so each
+  // open starts clean: an outside-press dismissal closes the menu (calling
+  // onClose) synchronously inside the mousedown listener, which tears down the
+  // mouseup reset before it runs, leaving the flag stranded true for next time.
   React.useEffect(() => {
     if (!open) {
       return;
     }
+    skipBlurCloseRef.current = false;
     enabledItems()[0]?.focus();
   }, [open, enabledItems]);
 
@@ -186,16 +190,17 @@ export function Menu(props: MenuProps): React.ReactElement {
     }
   };
 
-  // A genuine keyboard focus-out of the menu (Tab/Shift+Tab) dismisses it --
-  // including Shift+Tab back to the trigger. A move BETWEEN items is not "out",
-  // and pointer- or Escape-driven focus moves are owned by their own handlers
+  // A genuine keyboard focus-out of the menu dismisses it -- Tab/Shift+Tab to
+  // another element, back to the trigger, or out to browser chrome (where
+  // relatedTarget is null). Only a move BETWEEN items stays open; pointer- and
+  // Escape-driven focus moves are owned by their own handlers
   // (skipBlurCloseRef), so they do not double-close here.
   const onContentBlur = (event: React.FocusEvent<HTMLDivElement>): void => {
-    const next = event.relatedTarget as Node | null;
-    if (!next || skipBlurCloseRef.current) {
+    if (skipBlurCloseRef.current) {
       return;
     }
-    if (contentRef.current?.contains(next)) {
+    const next = event.relatedTarget as Node | null;
+    if (next && contentRef.current?.contains(next)) {
       return;
     }
     onClose();

--- a/src/diagram/components/SpeedDial.module.css
+++ b/src/diagram/components/SpeedDial.module.css
@@ -90,24 +90,45 @@
   background-color: var(--color-secondary-dark);
 }
 
+/* CSS-only tooltip to the right of its action button. Hidden until the action
+   is hovered or focused; an 8px gap and a left-pointing arrow mirror the prior
+   Radix tooltip's side="right" sideOffset={8}. The 300ms show delay reproduces
+   delayDuration={300}; hiding is immediate. */
 .tooltip {
+  position: absolute;
+  left: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  margin-left: 8px;
   background: var(--color-tooltip-bg);
   color: var(--color-contrast-text);
   padding: 4px 8px;
   border-radius: 4px;
   font-size: 0.75rem;
   font-family: inherit;
+  white-space: nowrap;
   z-index: 1400;
-  animation: tooltipFadeIn 150ms ease-out;
+  pointer-events: none;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 150ms ease-out, visibility 0s linear 150ms;
 }
 
-.tooltipArrow {
-  fill: var(--color-tooltip-bg);
+.tooltip::before {
+  content: '';
+  position: absolute;
+  right: 100%;
+  top: 50%;
+  transform: translateY(-50%);
+  border: 4px solid transparent;
+  border-right-color: var(--color-tooltip-bg);
 }
 
-@keyframes tooltipFadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+.action:hover .tooltip,
+.action:focus-within .tooltip {
+  opacity: 1;
+  visibility: visible;
+  transition: opacity 150ms ease-out 300ms, visibility 0s linear 300ms;
 }
 
 .iconWrapper {

--- a/src/diagram/components/SpeedDial.tsx
+++ b/src/diagram/components/SpeedDial.tsx
@@ -3,7 +3,6 @@
 // Version 2.0, that can be found in the LICENSE file.
 
 import * as React from 'react';
-import * as Tooltip from '@radix-ui/react-tooltip';
 
 import clsx from 'clsx';
 
@@ -59,11 +58,9 @@ export default function SpeedDial(props: SpeedDialProps): React.ReactElement {
         {enrichedIcon}
       </button>
       {open && (
-        <Tooltip.Provider delayDuration={300}>
-          <div className={styles.actions} role="menu">
-            {children}
-          </div>
-        </Tooltip.Provider>
+        <div className={styles.actions} role="menu">
+          {children}
+        </div>
       )}
     </div>
   );
@@ -81,29 +78,25 @@ export function SpeedDialAction(props: SpeedDialActionProps): React.ReactElement
   const { icon, title, className, onClick, selected } = props;
   return (
     <div className={styles.action} role="menuitem">
-      <Tooltip.Root>
-        <Tooltip.Trigger asChild>
-          <button
-            className={clsx(
-              styles.actionButton,
-              styles.actionButtonOpen,
-              selected && styles.actionButtonSelected,
-              className,
-            )}
-            onClick={onClick}
-            aria-label={title}
-            type="button"
-          >
-            {icon}
-          </button>
-        </Tooltip.Trigger>
-        <Tooltip.Portal>
-          <Tooltip.Content className={styles.tooltip} side="right" sideOffset={8} collisionPadding={16}>
-            {title}
-            <Tooltip.Arrow className={styles.tooltipArrow} />
-          </Tooltip.Content>
-        </Tooltip.Portal>
-      </Tooltip.Root>
+      <button
+        className={clsx(
+          styles.actionButton,
+          styles.actionButtonOpen,
+          selected && styles.actionButtonSelected,
+          className,
+        )}
+        onClick={onClick}
+        aria-label={title}
+        type="button"
+      >
+        {icon}
+      </button>
+      {/* CSS-only tooltip: shown on hover/focus of the action via the sibling
+          selectors in the stylesheet. aria-hidden because the button's
+          aria-label already conveys the name to assistive tech. */}
+      <span className={styles.tooltip} role="tooltip" aria-hidden="true">
+        {title}
+      </span>
     </div>
   );
 }

--- a/src/diagram/components/TextField.tsx
+++ b/src/diagram/components/TextField.tsx
@@ -129,7 +129,7 @@ export default function TextField(props: TextFieldProps): React.ReactElement {
               onKeyPress={onKeyPress}
               {...rest}
               {...restInputProps}
-              // After the spreads: restInputProps (downshift's
+              // After the spreads: restInputProps (the combobox
               // getInputProps() when used inside Autocomplete) must win for
               // value/onChange/keyboard handling, but the rendered id has
               // to stay inputId so <label htmlFor={inputId}> keeps pointing

--- a/src/diagram/components/useCombobox.ts
+++ b/src/diagram/components/useCombobox.ts
@@ -72,6 +72,27 @@ export function useCombobox(config: UseComboboxConfig): UseComboboxResult {
   const inputId = `${baseId}-input`;
   const itemId = (index: number) => `${baseId}-item-${index}`;
 
+  // Whether a pointer press is currently down. A blur caused by a mouse click
+  // (dismissing the list or pressing elsewhere) must NOT auto-commit the
+  // highlighted option; only a keyboard-driven blur (tab away) accepts it, which
+  // matches downshift. Always-on so mouseup always fires and the flag is never
+  // stranded.
+  const pointerDownRef = React.useRef(false);
+  React.useEffect(() => {
+    const onPointerDown = (): void => {
+      pointerDownRef.current = true;
+    };
+    const onPointerUp = (): void => {
+      pointerDownRef.current = false;
+    };
+    document.addEventListener('mousedown', onPointerDown, true);
+    document.addEventListener('mouseup', onPointerUp, true);
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown, true);
+      document.removeEventListener('mouseup', onPointerUp, true);
+    };
+  }, []);
+
   // Keep the keyboard-highlighted option visible: focus stays on the input
   // (combobox pattern), so arrowing past the fold of a list taller than the
   // popup would otherwise move the highlight off-screen with nothing scrolling.
@@ -159,8 +180,15 @@ export function useCombobox(config: UseComboboxConfig): UseComboboxResult {
     // same affordance downshift gave the wiring editor's selects.
     onClick: () => setIsOpen(true),
     onBlur: () => {
-      setIsOpen(false);
-      setHighlightedIndex(-1);
+      // A keyboard blur (tab away) with an active highlight accepts that option,
+      // the way downshift did, so keyboard users don't lose the choice they
+      // navigated to. A mouse-driven blur (click elsewhere) just closes.
+      if (!pointerDownRef.current && isOpen && highlightedIndex >= 0 && highlightedIndex < items.length) {
+        selectItem(items[highlightedIndex]);
+      } else {
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+      }
     },
   });
 

--- a/src/diagram/components/useCombobox.ts
+++ b/src/diagram/components/useCombobox.ts
@@ -74,11 +74,15 @@ export function useCombobox(config: UseComboboxConfig): UseComboboxResult {
 
   const selectItem = React.useCallback(
     (item: string) => {
+      // Set the field text to the chosen item (downshift did this). Without it
+      // an uncontrolled consumer -- one that does not feed `value` back in --
+      // would keep showing the partial text the user typed, not the selection.
+      onInputValueChange({ inputValue: item });
       onSelectedItemChange({ selectedItem: item });
       setIsOpen(false);
       setHighlightedIndex(-1);
     },
-    [onSelectedItemChange],
+    [onInputValueChange, onSelectedItemChange],
   );
 
   const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/src/diagram/components/useCombobox.ts
+++ b/src/diagram/components/useCombobox.ts
@@ -72,24 +72,24 @@ export function useCombobox(config: UseComboboxConfig): UseComboboxResult {
   const inputId = `${baseId}-input`;
   const itemId = (index: number) => `${baseId}-item-${index}`;
 
-  // Whether a pointer press is currently down. A blur caused by a mouse click
-  // (dismissing the list or pressing elsewhere) must NOT auto-commit the
+  // Whether a mouse press is what is causing the current input blur. A blur from
+  // a click (dismissing the list or pressing elsewhere) must NOT auto-commit the
   // highlighted option; only a keyboard-driven blur (tab away) accepts it, which
-  // matches downshift. Always-on so mouseup always fires and the flag is never
-  // stranded.
+  // matches downshift. The click-induced blur fires synchronously in the same
+  // task as the mousedown, so a deferred reset clears the flag right after that
+  // blur -- it can never strand true (no reliance on a mouseup that a release
+  // outside the window might never deliver).
   const pointerDownRef = React.useRef(false);
   React.useEffect(() => {
     const onPointerDown = (): void => {
       pointerDownRef.current = true;
-    };
-    const onPointerUp = (): void => {
-      pointerDownRef.current = false;
+      setTimeout(() => {
+        pointerDownRef.current = false;
+      }, 0);
     };
     document.addEventListener('mousedown', onPointerDown, true);
-    document.addEventListener('mouseup', onPointerUp, true);
     return () => {
       document.removeEventListener('mousedown', onPointerDown, true);
-      document.removeEventListener('mouseup', onPointerUp, true);
     };
   }, []);
 

--- a/src/diagram/components/useCombobox.ts
+++ b/src/diagram/components/useCombobox.ts
@@ -72,6 +72,18 @@ export function useCombobox(config: UseComboboxConfig): UseComboboxResult {
   const inputId = `${baseId}-input`;
   const itemId = (index: number) => `${baseId}-item-${index}`;
 
+  // Keep the keyboard-highlighted option visible: focus stays on the input
+  // (combobox pattern), so arrowing past the fold of a list taller than the
+  // popup would otherwise move the highlight off-screen with nothing scrolling.
+  // `block: 'nearest'` only scrolls when the row is actually out of view.
+  React.useEffect(() => {
+    if (!isOpen || highlightedIndex < 0) {
+      return;
+    }
+    const el = document.getElementById(`${baseId}-item-${highlightedIndex}`);
+    el?.scrollIntoView?.({ block: 'nearest' });
+  }, [isOpen, highlightedIndex, baseId]);
+
   const selectItem = React.useCallback(
     (item: string) => {
       // Set the field text to the chosen item (downshift did this). Without it

--- a/src/diagram/components/useCombobox.ts
+++ b/src/diagram/components/useCombobox.ts
@@ -73,13 +73,17 @@ export function useCombobox(config: UseComboboxConfig): UseComboboxResult {
   const inputId = `${baseId}-input`;
   const itemId = (index: number) => `${baseId}-item-${index}`;
 
-  // Whether a mouse press is what is causing the current input blur. A blur from
-  // a click (dismissing the list or pressing elsewhere) must NOT auto-commit the
-  // highlighted option; only a keyboard-driven blur (tab away) accepts it, which
-  // matches downshift. The click-induced blur fires synchronously in the same
-  // task as the mousedown, so a deferred reset clears the flag right after that
-  // blur -- it can never strand true (no reliance on a mouseup that a release
-  // outside the window might never deliver).
+  // Whether a pointer press is what is causing the current input blur. A blur
+  // from a press (dismissing the list or pressing elsewhere) must NOT auto-commit
+  // the highlighted option; only a keyboard-driven blur (tab away) accepts it,
+  // which matches downshift. We listen on `pointerdown` (not `mousedown`):
+  // pointerdown fires for both mouse and touch and -- crucially on touch -- BEFORE
+  // the focus shift, so the flag is already set when the blur fires (a synthetic
+  // mousedown would arrive too late and the tap-outside would wrongly commit).
+  // The press-induced blur fires synchronously in the same task as the
+  // pointerdown, so a deferred reset clears the flag right after that blur -- it
+  // can never strand true (no reliance on a pointerup that a release outside the
+  // window might never deliver).
   const pointerDownRef = React.useRef(false);
   React.useEffect(() => {
     const onPointerDown = (): void => {
@@ -88,9 +92,9 @@ export function useCombobox(config: UseComboboxConfig): UseComboboxResult {
         pointerDownRef.current = false;
       }, 0);
     };
-    document.addEventListener('mousedown', onPointerDown, true);
+    document.addEventListener('pointerdown', onPointerDown, true);
     return () => {
-      document.removeEventListener('mousedown', onPointerDown, true);
+      document.removeEventListener('pointerdown', onPointerDown, true);
     };
   }, []);
 

--- a/src/diagram/components/useCombobox.ts
+++ b/src/diagram/components/useCombobox.ts
@@ -98,6 +98,32 @@ export function useCombobox(config: UseComboboxConfig): UseComboboxResult {
     };
   }, []);
 
+  // Dismiss the list on a pointer press outside the field and the listbox.
+  // Blur alone is not enough: a press on a surface that prevents the focus
+  // change (e.g. the diagram canvas preventDefault()s pointerdown for pan/drag)
+  // never blurs the input, so the portaled listbox would stay open over it.
+  // Capture phase runs before such handlers, and we match the field/listbox by
+  // their ids (the listbox is portaled, so it is not a DOM descendant here).
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const onOutsidePointerDown = (event: PointerEvent): void => {
+      const target = event.target as Node;
+      const input = document.getElementById(inputId);
+      const menu = document.getElementById(menuId);
+      if (input?.contains(target) || menu?.contains(target)) {
+        return;
+      }
+      setIsOpen(false);
+      setHighlightedIndex(-1);
+    };
+    document.addEventListener('pointerdown', onOutsidePointerDown, true);
+    return () => {
+      document.removeEventListener('pointerdown', onOutsidePointerDown, true);
+    };
+  }, [isOpen, inputId, menuId]);
+
   // Keep the keyboard-highlighted option visible: focus stays on the input
   // (combobox pattern), so arrowing past the fold of a list taller than the
   // popup would otherwise move the highlight off-screen with nothing scrolling.

--- a/src/diagram/components/useCombobox.ts
+++ b/src/diagram/components/useCombobox.ts
@@ -1,0 +1,168 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+
+// A small, dependency-free combobox state machine covering exactly what the
+// Autocomplete component needs: a filter-as-you-type listbox over a string[]
+// with keyboard navigation and the WAI-ARIA combobox attributes. It replaces
+// downshift's useCombobox (whose full feature surface we never used) while
+// preserving the same return shape (getInputProps/getMenuProps/getItemProps/
+// isOpen/highlightedIndex) so callers compose it identically.
+
+export interface UseComboboxConfig {
+  /** The currently displayed (already-filtered) items. */
+  items: string[];
+  /** The controlled text shown in the input. */
+  inputValue: string;
+  /** Emitted on every keystroke; the caller owns inputValue. */
+  onInputValueChange: (changes: { inputValue: string }) => void;
+  /** Emitted when an item is chosen (click or Enter) or cleared via Escape. */
+  onSelectedItemChange: (changes: { selectedItem: string | null }) => void;
+  /** When true, Escape clears the selection and input (else it just closes). */
+  clearOnEscape?: boolean;
+}
+
+export interface ComboboxInputProps {
+  role: 'combobox';
+  'aria-expanded': boolean;
+  'aria-controls': string;
+  'aria-autocomplete': 'list';
+  'aria-activedescendant'?: string;
+  autoComplete: 'off';
+  id: string;
+  value: string;
+  onChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  onClick: () => void;
+  onBlur: () => void;
+}
+
+export interface ComboboxMenuProps {
+  role: 'listbox';
+  id: string;
+}
+
+export interface ComboboxItemProps {
+  role: 'option';
+  id: string;
+  'aria-selected': boolean;
+  onMouseMove: () => void;
+  onMouseDown: (event: React.MouseEvent) => void;
+  onClick: () => void;
+}
+
+export interface UseComboboxResult {
+  isOpen: boolean;
+  highlightedIndex: number;
+  getInputProps: () => ComboboxInputProps;
+  getMenuProps: () => ComboboxMenuProps;
+  getItemProps: (options: { item: string; index: number }) => ComboboxItemProps;
+}
+
+export function useCombobox(config: UseComboboxConfig): UseComboboxResult {
+  const { items, inputValue, onInputValueChange, onSelectedItemChange, clearOnEscape } = config;
+
+  const [isOpen, setIsOpen] = React.useState(false);
+  const [highlightedIndex, setHighlightedIndex] = React.useState(-1);
+
+  const baseId = React.useId();
+  const menuId = `${baseId}-menu`;
+  const inputId = `${baseId}-input`;
+  const itemId = (index: number) => `${baseId}-item-${index}`;
+
+  const selectItem = React.useCallback(
+    (item: string) => {
+      onSelectedItemChange({ selectedItem: item });
+      setIsOpen(false);
+      setHighlightedIndex(-1);
+    },
+    [onSelectedItemChange],
+  );
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
+    switch (event.key) {
+      case 'ArrowDown': {
+        event.preventDefault();
+        if (!isOpen) {
+          setIsOpen(true);
+          setHighlightedIndex(items.length > 0 ? 0 : -1);
+        } else {
+          setHighlightedIndex((prev) => Math.min(prev + 1, items.length - 1));
+        }
+        break;
+      }
+      case 'ArrowUp': {
+        event.preventDefault();
+        if (!isOpen) {
+          setIsOpen(true);
+          setHighlightedIndex(items.length - 1);
+        } else {
+          setHighlightedIndex((prev) => Math.max(prev - 1, 0));
+        }
+        break;
+      }
+      case 'Enter': {
+        if (isOpen && highlightedIndex >= 0 && highlightedIndex < items.length) {
+          event.preventDefault();
+          selectItem(items[highlightedIndex]);
+        }
+        break;
+      }
+      case 'Escape': {
+        if (clearOnEscape) {
+          onSelectedItemChange({ selectedItem: null });
+          onInputValueChange({ inputValue: '' });
+        }
+        setIsOpen(false);
+        setHighlightedIndex(-1);
+        break;
+      }
+      default:
+        break;
+    }
+  };
+
+  const getInputProps = (): ComboboxInputProps => ({
+    role: 'combobox',
+    'aria-expanded': isOpen,
+    'aria-controls': menuId,
+    'aria-autocomplete': 'list',
+    'aria-activedescendant': isOpen && highlightedIndex >= 0 ? itemId(highlightedIndex) : undefined,
+    autoComplete: 'off',
+    id: inputId,
+    value: inputValue,
+    onChange: (event) => {
+      onInputValueChange({ inputValue: event.target.value });
+      setIsOpen(true);
+      setHighlightedIndex(-1);
+    },
+    onKeyDown: handleKeyDown,
+    // Clicking the field opens the list (showing all items when empty), the
+    // same affordance downshift gave the wiring editor's selects.
+    onClick: () => setIsOpen(true),
+    onBlur: () => {
+      setIsOpen(false);
+      setHighlightedIndex(-1);
+    },
+  });
+
+  const getMenuProps = (): ComboboxMenuProps => ({
+    role: 'listbox',
+    id: menuId,
+  });
+
+  const getItemProps = ({ item, index }: { item: string; index: number }): ComboboxItemProps => ({
+    role: 'option',
+    id: itemId(index),
+    'aria-selected': highlightedIndex === index,
+    onMouseMove: () => setHighlightedIndex(index),
+    // Keep focus on the input so the trailing blur doesn't beat the click and
+    // close the listbox before the selection registers.
+    onMouseDown: (event) => event.preventDefault(),
+    onClick: () => selectItem(item),
+  });
+
+  return { isOpen, highlightedIndex, getInputProps, getMenuProps, getItemProps };
+}

--- a/src/diagram/components/useCombobox.ts
+++ b/src/diagram/components/useCombobox.ts
@@ -50,6 +50,7 @@ export interface ComboboxItemProps {
   'aria-selected': boolean;
   onMouseMove: () => void;
   onMouseDown: (event: React.MouseEvent) => void;
+  onPointerDown: (event: React.PointerEvent) => void;
   onClick: () => void;
 }
 
@@ -202,9 +203,13 @@ export function useCombobox(config: UseComboboxConfig): UseComboboxResult {
     id: itemId(index),
     'aria-selected': highlightedIndex === index,
     onMouseMove: () => setHighlightedIndex(index),
-    // Keep focus on the input so the trailing blur doesn't beat the click and
-    // close the listbox before the selection registers.
+    // Keep focus on the input across both mouse and touch, so the trailing blur
+    // doesn't beat the click/tap and close (unmount) the listbox before the
+    // selection registers. onMouseDown covers the mouse compatibility blur;
+    // onPointerDown fires first for touch (and mouse), before the focus shift, so
+    // tapping an option on a touch device still selects it.
     onMouseDown: (event) => event.preventDefault(),
+    onPointerDown: (event) => event.preventDefault(),
     onClick: () => selectItem(item),
   });
 

--- a/src/diagram/package.json
+++ b/src/diagram/package.json
@@ -44,17 +44,12 @@
     "react-dom": "^19.0.0"
   },
   "dependencies": {
-    "@radix-ui/react-accordion": "^1.2.12",
-    "@radix-ui/react-checkbox": "^1.3.3",
     "@radix-ui/react-dialog": "^1.1.15",
-    "@radix-ui/react-dropdown-menu": "^2.1.16",
     "@radix-ui/react-tabs": "^1.1.13",
     "@radix-ui/react-toast": "^1.2.15",
-    "@radix-ui/react-tooltip": "^1.2.8",
     "@simlin/core": "workspace:^",
     "@simlin/engine": "workspace:^",
     "clsx": "^2.1.1",
-    "downshift": "^9.2.0",
     "katex": "^0.16.28",
     "slate": "^0.123.0",
     "slate-dom": "^0.123.0",

--- a/src/diagram/tests/accordion.test.tsx
+++ b/src/diagram/tests/accordion.test.tsx
@@ -1,0 +1,71 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { render, fireEvent, screen } from '@testing-library/react';
+import { Accordion, AccordionSummary, AccordionDetails } from '../components/Accordion';
+
+function renderAccordion(props: React.ComponentProps<typeof Accordion> = {}) {
+  return render(
+    <Accordion {...props}>
+      <AccordionSummary expandIcon={<span data-testid="icon">v</span>}>Summary</AccordionSummary>
+      <AccordionDetails>Details body</AccordionDetails>
+    </Accordion>,
+  );
+}
+
+describe('Accordion', () => {
+  test('renders the summary as a button and exposes a region', () => {
+    renderAccordion();
+    const trigger = screen.getByRole('button', { name: /summary/i });
+    expect(trigger).not.toBeNull();
+    const region = screen.getByRole('region');
+    expect(region.getAttribute('aria-labelledby')).toBe(trigger.getAttribute('id'));
+    expect(trigger.getAttribute('aria-controls')).toBe(region.getAttribute('id'));
+  });
+
+  test('is collapsed by default and toggles open on click', () => {
+    renderAccordion();
+    const trigger = screen.getByRole('button', { name: /summary/i });
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+    expect(trigger.getAttribute('data-state')).toBe('closed');
+
+    fireEvent.click(trigger);
+    expect(trigger.getAttribute('aria-expanded')).toBe('true');
+    expect(trigger.getAttribute('data-state')).toBe('open');
+    expect(screen.getByRole('region').getAttribute('data-state')).toBe('open');
+  });
+
+  test('respects defaultExpanded for uncontrolled use', () => {
+    renderAccordion({ defaultExpanded: true });
+    expect(screen.getByRole('button', { name: /summary/i }).getAttribute('aria-expanded')).toBe('true');
+  });
+
+  test('controlled mode reflects the expanded prop and does not self-toggle', () => {
+    const onChange = jest.fn();
+    renderAccordion({ expanded: false, onChange });
+    const trigger = screen.getByRole('button', { name: /summary/i });
+
+    fireEvent.click(trigger);
+    // Controlled: state only changes when the parent updates the prop.
+    expect(onChange).toHaveBeenCalledWith(true);
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  test('disabled does not toggle or fire onChange', () => {
+    const onChange = jest.fn();
+    renderAccordion({ disabled: true, onChange });
+    const trigger = screen.getByRole('button', { name: /summary/i });
+    expect(trigger).toHaveProperty('disabled', true);
+
+    fireEvent.click(trigger);
+    expect(onChange).not.toHaveBeenCalled();
+    expect(trigger.getAttribute('aria-expanded')).toBe('false');
+  });
+
+  test('renders the expand icon', () => {
+    renderAccordion();
+    expect(screen.getByTestId('icon')).not.toBeNull();
+  });
+});

--- a/src/diagram/tests/accordion.test.tsx
+++ b/src/diagram/tests/accordion.test.tsx
@@ -68,4 +68,15 @@ describe('Accordion', () => {
     renderAccordion();
     expect(screen.getByTestId('icon')).not.toBeNull();
   });
+
+  test('collapsed content is inert and becomes interactive when opened', () => {
+    renderAccordion();
+    const region = screen.getByRole('region');
+    // Collapsed: the content subtree is inert (not keyboard-reachable).
+    expect(region.querySelector('[inert]')).not.toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: /summary/i }));
+    // Open: the inert attribute is gone, so the content is interactive.
+    expect(region.querySelector('[inert]')).toBeNull();
+  });
 });

--- a/src/diagram/tests/accordion.test.tsx
+++ b/src/diagram/tests/accordion.test.tsx
@@ -16,13 +16,24 @@ function renderAccordion(props: React.ComponentProps<typeof Accordion> = {}) {
 }
 
 describe('Accordion', () => {
-  test('renders the summary as a button and exposes a region', () => {
-    renderAccordion();
+  test('wires the region to the summary button', () => {
+    // Collapsed, the region is inert (removed from the a11y tree), so query it
+    // through the DOM rather than getByRole, which filters inaccessible nodes.
+    const { container } = renderAccordion();
     const trigger = screen.getByRole('button', { name: /summary/i });
-    expect(trigger).not.toBeNull();
-    const region = screen.getByRole('region');
-    expect(region.getAttribute('aria-labelledby')).toBe(trigger.getAttribute('id'));
-    expect(trigger.getAttribute('aria-controls')).toBe(region.getAttribute('id'));
+    const region = container.querySelector('[role="region"]');
+    expect(region).not.toBeNull();
+    expect(region?.getAttribute('aria-labelledby')).toBe(trigger.getAttribute('id'));
+    expect(trigger.getAttribute('aria-controls')).toBe(region?.getAttribute('id'));
+  });
+
+  test('the region is hidden from assistive tech until expanded', () => {
+    renderAccordion();
+    // Collapsed: getByRole excludes the inert region.
+    expect(screen.queryByRole('region')).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /summary/i }));
+    // Expanded: the region is exposed again.
+    expect(screen.queryByRole('region')).not.toBeNull();
   });
 
   test('is collapsed by default and toggles open on click', () => {
@@ -70,13 +81,13 @@ describe('Accordion', () => {
   });
 
   test('collapsed content is inert and becomes interactive when opened', () => {
-    renderAccordion();
-    const region = screen.getByRole('region');
-    // Collapsed: the content subtree is inert (not keyboard-reachable).
-    expect(region.querySelector('[inert]')).not.toBeNull();
+    const { container } = renderAccordion();
+    const region = container.querySelector('[role="region"]');
+    // Collapsed: the region subtree is inert (not keyboard-reachable).
+    expect(region?.hasAttribute('inert')).toBe(true);
 
     fireEvent.click(screen.getByRole('button', { name: /summary/i }));
     // Open: the inert attribute is gone, so the content is interactive.
-    expect(region.querySelector('[inert]')).toBeNull();
+    expect(region?.hasAttribute('inert')).toBe(false);
   });
 });

--- a/src/diagram/tests/autocomplete.test.tsx
+++ b/src/diagram/tests/autocomplete.test.tsx
@@ -3,7 +3,7 @@
 // Version 2.0, that can be found in the LICENSE file.
 
 import * as React from 'react';
-import { render, fireEvent, screen, waitFor, act } from '@testing-library/react';
+import { render, fireEvent, screen, waitFor, act, createEvent } from '@testing-library/react';
 import Autocomplete from '../components/Autocomplete';
 
 // Simple controlled component to test Autocomplete with external value changes.
@@ -215,6 +215,35 @@ describe('Autocomplete', () => {
     fireEvent.blur(input);
 
     expect(onChange).not.toHaveBeenCalled();
+  });
+
+  test('option press prevents default on pointerdown so touch taps keep focus', async () => {
+    // On touch, focus can shift on pointerdown (before the synthesized
+    // mousedown); preventing it keeps focus on the input so the list is not
+    // unmounted by a blur before the tap's click selects the option.
+    render(
+      <Autocomplete
+        value={null}
+        options={['apple', 'apricot']}
+        onChange={() => {}}
+        renderInput={(params) => (
+          <div ref={params.InputProps.ref}>
+            <input {...params.inputProps} data-testid="autocomplete-input" />
+          </div>
+        )}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('autocomplete-input'), { target: { value: 'ap' } });
+    const option = await screen.findByText('apple');
+
+    const pointerDown = createEvent.pointerDown(option);
+    fireEvent(option, pointerDown);
+    expect(pointerDown.defaultPrevented).toBe(true);
+
+    const mouseDown = createEvent.mouseDown(option);
+    fireEvent(option, mouseDown);
+    expect(mouseDown.defaultPrevented).toBe(true);
   });
 
   test('selecting an option fills the input even when uncontrolled', async () => {

--- a/src/diagram/tests/autocomplete.test.tsx
+++ b/src/diagram/tests/autocomplete.test.tsx
@@ -168,6 +168,55 @@ describe('Autocomplete', () => {
     }
   });
 
+  test('commits the highlighted option on keyboard blur (tab away)', () => {
+    const onChange = jest.fn();
+    render(
+      <Autocomplete
+        value={null}
+        options={['apple', 'apricot', 'avocado']}
+        onChange={onChange}
+        renderInput={(params) => (
+          <div ref={params.InputProps.ref}>
+            <input {...params.inputProps} data-testid="autocomplete-input" />
+          </div>
+        )}
+      />,
+    );
+
+    const input = screen.getByTestId('autocomplete-input');
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // highlight 'apple'
+    fireEvent.blur(input);
+
+    expect(onChange).toHaveBeenCalledWith(null, 'apple');
+  });
+
+  test('does not commit the highlight on a mouse-driven blur', () => {
+    const onChange = jest.fn();
+    render(
+      <Autocomplete
+        value={null}
+        options={['apple', 'apricot', 'avocado']}
+        onChange={onChange}
+        renderInput={(params) => (
+          <div ref={params.InputProps.ref}>
+            <input {...params.inputProps} data-testid="autocomplete-input" />
+          </div>
+        )}
+      />,
+    );
+
+    const input = screen.getByTestId('autocomplete-input');
+    fireEvent.change(input, { target: { value: 'a' } });
+    fireEvent.keyDown(input, { key: 'ArrowDown' }); // highlight 'apple'
+    // A pointer press in progress means this blur is a click elsewhere, not a
+    // tab-away, so the highlight must not be auto-committed.
+    fireEvent.mouseDown(document.body);
+    fireEvent.blur(input);
+
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
   test('selecting an option fills the input even when uncontrolled', async () => {
     // The parent ignores onChange (value stays null), so the input text must
     // come from the component itself -- downshift used to set it on select.

--- a/src/diagram/tests/autocomplete.test.tsx
+++ b/src/diagram/tests/autocomplete.test.tsx
@@ -168,6 +168,33 @@ describe('Autocomplete', () => {
     }
   });
 
+  test('closes the list on an outside pointer press even without an input blur', async () => {
+    render(
+      <Autocomplete
+        value={null}
+        options={['apple', 'apricot']}
+        onChange={() => {}}
+        renderInput={(params) => (
+          <div ref={params.InputProps.ref}>
+            <input {...params.inputProps} data-testid="autocomplete-input" />
+          </div>
+        )}
+      />,
+    );
+
+    fireEvent.change(screen.getByTestId('autocomplete-input'), { target: { value: 'ap' } });
+    await screen.findByText('apple');
+
+    // A press on a surface that prevents the focus change never blurs the input
+    // (here we simply do not fire blur), so the list must close on the pointer
+    // press itself.
+    fireEvent.pointerDown(document.body);
+
+    await waitFor(() => {
+      expect(screen.queryByText('apple')).toBeNull();
+    });
+  });
+
   test('commits the highlighted option on keyboard blur (tab away)', () => {
     const onChange = jest.fn();
     render(

--- a/src/diagram/tests/autocomplete.test.tsx
+++ b/src/diagram/tests/autocomplete.test.tsx
@@ -135,6 +135,39 @@ describe('Autocomplete', () => {
     });
   });
 
+  test('scrolls the keyboard-highlighted option into view', async () => {
+    // jsdom does not implement scrollIntoView, so install a stub to observe the
+    // call (the component guards with optional chaining for exactly this reason).
+    const scrollFn = jest.fn();
+    (HTMLElement.prototype as unknown as { scrollIntoView: unknown }).scrollIntoView = scrollFn;
+    try {
+      render(
+        <Autocomplete
+          value={null}
+          options={['apple', 'apricot', 'avocado']}
+          onChange={() => {}}
+          renderInput={(params) => (
+            <div ref={params.InputProps.ref}>
+              <input {...params.inputProps} data-testid="autocomplete-input" />
+            </div>
+          )}
+        />,
+      );
+
+      const input = screen.getByTestId('autocomplete-input');
+      fireEvent.change(input, { target: { value: 'a' } });
+      await screen.findByText('apple');
+
+      // Arrow navigation must scroll the now-highlighted row into view.
+      fireEvent.keyDown(input, { key: 'ArrowDown' });
+      await waitFor(() => {
+        expect(scrollFn).toHaveBeenCalled();
+      });
+    } finally {
+      delete (HTMLElement.prototype as unknown as { scrollIntoView?: unknown }).scrollIntoView;
+    }
+  });
+
   test('selecting an option fills the input even when uncontrolled', async () => {
     // The parent ignores onChange (value stays null), so the input text must
     // come from the component itself -- downshift used to set it on select.

--- a/src/diagram/tests/autocomplete.test.tsx
+++ b/src/diagram/tests/autocomplete.test.tsx
@@ -135,6 +135,33 @@ describe('Autocomplete', () => {
     });
   });
 
+  test('selecting an option fills the input even when uncontrolled', async () => {
+    // The parent ignores onChange (value stays null), so the input text must
+    // come from the component itself -- downshift used to set it on select.
+    render(
+      <Autocomplete
+        value={null}
+        options={['apple', 'apricot', 'banana']}
+        onChange={() => {}}
+        renderInput={(params) => (
+          <div ref={params.InputProps.ref}>
+            <input {...params.inputProps} data-testid="autocomplete-input" />
+          </div>
+        )}
+      />,
+    );
+
+    const input = screen.getByTestId('autocomplete-input') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'ap' } });
+
+    const apple = await screen.findByText('apple');
+    fireEvent.click(apple);
+
+    await waitFor(() => {
+      expect(input.value).toBe('apple');
+    });
+  });
+
   test('clearOnEscape clears selection on Escape key', async () => {
     const onChange = jest.fn();
     render(

--- a/src/diagram/tests/autocomplete.test.tsx
+++ b/src/diagram/tests/autocomplete.test.tsx
@@ -191,7 +191,7 @@ describe('Autocomplete', () => {
     expect(onChange).toHaveBeenCalledWith(null, 'apple');
   });
 
-  test('does not commit the highlight on a mouse-driven blur', () => {
+  test('does not commit the highlight on a pointer-driven blur (mouse or touch)', () => {
     const onChange = jest.fn();
     render(
       <Autocomplete
@@ -209,9 +209,11 @@ describe('Autocomplete', () => {
     const input = screen.getByTestId('autocomplete-input');
     fireEvent.change(input, { target: { value: 'a' } });
     fireEvent.keyDown(input, { key: 'ArrowDown' }); // highlight 'apple'
-    // A pointer press in progress means this blur is a click elsewhere, not a
-    // tab-away, so the highlight must not be auto-committed.
-    fireEvent.mouseDown(document.body);
+    // A pointer press in progress means this blur is a tap/click elsewhere, not a
+    // tab-away, so the highlight must not be auto-committed. pointerdown fires for
+    // both mouse and touch, and on touch precedes the focus shift -- which is why
+    // the tracker keys on it rather than mousedown.
+    fireEvent.pointerDown(document.body);
     fireEvent.blur(input);
 
     expect(onChange).not.toHaveBeenCalled();

--- a/src/diagram/tests/menu.test.tsx
+++ b/src/diagram/tests/menu.test.tsx
@@ -30,7 +30,7 @@ function mockRect(el: HTMLElement, initial: { top: number; left: number; width: 
   };
 }
 
-// The proxy span Radix anchors to is the (asChild) trigger; it carries
+// The proxy span the menu renders to mirror the anchor rect; it carries
 // aria-haspopup="menu" and is the only position:fixed element we render.
 function getProxySpan(): HTMLElement {
   const el = document.querySelector<HTMLElement>('[aria-haspopup="menu"]');

--- a/src/diagram/tests/menu.test.tsx
+++ b/src/diagram/tests/menu.test.tsx
@@ -256,4 +256,50 @@ describe('Menu dismissal and keyboard', () => {
     expect(onClose).toHaveBeenCalledTimes(1);
     anchor.remove();
   });
+
+  it('dismisses when focus leaves to browser chrome (null relatedTarget)', () => {
+    const anchor = document.createElement('button');
+    document.body.appendChild(anchor);
+    const onClose = jest.fn();
+    render(
+      <Menu anchorEl={anchor} open onClose={onClose}>
+        <MenuItem>One</MenuItem>
+      </Menu>,
+    );
+    // Tab from the only item often blurs to browser chrome / body with a null
+    // relatedTarget; focus has still left the menu, so it must close.
+    const item = screen.getByRole('menuitem');
+    fireEvent.blur(item, { relatedTarget: null });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    anchor.remove();
+  });
+
+  it('still closes on keyboard focus-out after a prior outside-click dismissal', () => {
+    // Regression: the outside-press path sets skipBlurCloseRef and closes inside
+    // the mousedown listener, tearing down the mouseup reset before it fires.
+    // Reopening must clear the stranded flag so keyboard focus-out still closes.
+    const anchor = document.createElement('button');
+    const outside = document.createElement('div');
+    document.body.append(anchor, outside);
+    const onClose = jest.fn();
+    const tree = (open: boolean) => (
+      <Menu anchorEl={anchor} open={open} onClose={onClose}>
+        <MenuItem>One</MenuItem>
+      </Menu>
+    );
+    const { rerender } = render(tree(true));
+
+    fireEvent.mouseDown(outside); // dismiss via outside press (strands the flag)
+    expect(onClose).toHaveBeenCalledTimes(1);
+
+    rerender(tree(false)); // close
+    rerender(tree(true)); // reopen -> flag must be cleared
+
+    const item = screen.getByRole('menuitem');
+    fireEvent.blur(item, { relatedTarget: outside });
+    expect(onClose).toHaveBeenCalledTimes(2);
+
+    anchor.remove();
+    outside.remove();
+  });
 });

--- a/src/diagram/tests/menu.test.tsx
+++ b/src/diagram/tests/menu.test.tsx
@@ -162,6 +162,21 @@ describe('Menu dismissal and keyboard', () => {
     expect(document.activeElement).toBe(items[0]);
   });
 
+  it('keeps items out of the document tab sequence (roving focus)', () => {
+    // Items use tabIndex=-1 so Tab/Shift+Tab leave the menu (and the resulting
+    // focus-out dismisses it) instead of cycling between items; navigation
+    // within the menu is via the arrow keys, exercised separately.
+    render(
+      <Menu anchorEl={document.createElement('button')} open onClose={() => {}}>
+        <MenuItem>First</MenuItem>
+        <MenuItem>Second</MenuItem>
+      </Menu>,
+    );
+    for (const item of screen.getAllByRole('menuitem')) {
+      expect(item.tabIndex).toBe(-1);
+    }
+  });
+
   it('arrow keys move focus between items, wrapping', () => {
     render(
       <Menu anchorEl={document.createElement('button')} open onClose={() => {}}>

--- a/src/diagram/tests/menu.test.tsx
+++ b/src/diagram/tests/menu.test.tsx
@@ -267,7 +267,7 @@ describe('Menu dismissal and keyboard', () => {
       </Menu>,
     );
     // Shift+Tab can land focus on the trigger; that is still leaving the menu,
-    // so it must close (no mouse press happened, so it is not exempted).
+    // so it must close (no pointer press happened, so it is not exempted).
     const item = screen.getByRole('menuitem');
     fireEvent.blur(item, { relatedTarget: anchor });
     expect(onClose).toHaveBeenCalledTimes(1);
@@ -293,7 +293,7 @@ describe('Menu dismissal and keyboard', () => {
 
   it('still closes on keyboard focus-out after a prior outside-click dismissal', () => {
     // Regression: the outside-press path sets skipBlurCloseRef and closes inside
-    // the mousedown listener, tearing down the mouseup reset before it fires.
+    // the pointerdown listener, tearing down the pointerup reset before it fires.
     // Reopening must clear the stranded flag so keyboard focus-out still closes.
     const anchor = document.createElement('button');
     const outside = document.createElement('div');

--- a/src/diagram/tests/menu.test.tsx
+++ b/src/diagram/tests/menu.test.tsx
@@ -217,7 +217,7 @@ describe('Menu dismissal and keyboard', () => {
         <MenuItem>One</MenuItem>
       </Menu>,
     );
-    fireEvent.mouseDown(anchor);
+    fireEvent.pointerDown(anchor);
     expect(onClose).not.toHaveBeenCalled();
     anchor.remove();
   });
@@ -232,7 +232,9 @@ describe('Menu dismissal and keyboard', () => {
         <MenuItem>One</MenuItem>
       </Menu>,
     );
-    fireEvent.mouseDown(outside);
+    // pointerdown (not mousedown): surfaces like the canvas preventDefault the
+    // compatibility mouse event, so the dismiss listener must observe pointers.
+    fireEvent.pointerDown(outside);
     expect(onClose).toHaveBeenCalledTimes(1);
     anchor.remove();
     outside.remove();
@@ -304,7 +306,7 @@ describe('Menu dismissal and keyboard', () => {
     );
     const { rerender } = render(tree(true));
 
-    fireEvent.mouseDown(outside); // dismiss via outside press (strands the flag)
+    fireEvent.pointerDown(outside); // dismiss via outside press (strands the flag)
     expect(onClose).toHaveBeenCalledTimes(1);
 
     rerender(tree(false)); // close

--- a/src/diagram/tests/menu.test.tsx
+++ b/src/diagram/tests/menu.test.tsx
@@ -3,7 +3,7 @@
 // Version 2.0, that can be found in the LICENSE file.
 
 import * as React from 'react';
-import { render, act } from '@testing-library/react';
+import { render, act, fireEvent, screen } from '@testing-library/react';
 
 import { Menu, MenuItem } from '../components/Menu';
 
@@ -147,5 +147,96 @@ describe('Menu anchor positioning (issue #710)', () => {
     expect(getProxySpan().style.left).toBe('600px');
 
     anchor.remove();
+  });
+});
+
+describe('Menu dismissal and keyboard', () => {
+  it('moves focus to the first menu item when opened', () => {
+    render(
+      <Menu anchorEl={document.createElement('button')} open onClose={() => {}}>
+        <MenuItem>First</MenuItem>
+        <MenuItem>Second</MenuItem>
+      </Menu>,
+    );
+    const items = screen.getAllByRole('menuitem');
+    expect(document.activeElement).toBe(items[0]);
+  });
+
+  it('arrow keys move focus between items, wrapping', () => {
+    render(
+      <Menu anchorEl={document.createElement('button')} open onClose={() => {}}>
+        <MenuItem>First</MenuItem>
+        <MenuItem>Second</MenuItem>
+      </Menu>,
+    );
+    const items = screen.getAllByRole('menuitem');
+    fireEvent.keyDown(items[0], { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(items[1]);
+    fireEvent.keyDown(items[1], { key: 'ArrowDown' });
+    expect(document.activeElement).toBe(items[0]); // wraps
+    fireEvent.keyDown(items[0], { key: 'ArrowUp' });
+    expect(document.activeElement).toBe(items[1]); // wraps backward
+  });
+
+  it('Escape closes and returns focus to the anchor', () => {
+    const anchor = document.createElement('button');
+    document.body.appendChild(anchor);
+    const onClose = jest.fn();
+    render(
+      <Menu anchorEl={anchor} open onClose={onClose}>
+        <MenuItem>One</MenuItem>
+      </Menu>,
+    );
+    fireEvent.keyDown(document.body, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    expect(document.activeElement).toBe(anchor);
+    anchor.remove();
+  });
+
+  it('a press on the anchor is not treated as an outside dismissal', () => {
+    const anchor = document.createElement('button');
+    document.body.appendChild(anchor);
+    const onClose = jest.fn();
+    render(
+      <Menu anchorEl={anchor} open onClose={onClose}>
+        <MenuItem>One</MenuItem>
+      </Menu>,
+    );
+    fireEvent.mouseDown(anchor);
+    expect(onClose).not.toHaveBeenCalled();
+    anchor.remove();
+  });
+
+  it('a press outside the menu and anchor dismisses it', () => {
+    const anchor = document.createElement('button');
+    const outside = document.createElement('div');
+    document.body.append(anchor, outside);
+    const onClose = jest.fn();
+    render(
+      <Menu anchorEl={anchor} open onClose={onClose}>
+        <MenuItem>One</MenuItem>
+      </Menu>,
+    );
+    fireEvent.mouseDown(outside);
+    expect(onClose).toHaveBeenCalledTimes(1);
+    anchor.remove();
+    outside.remove();
+  });
+
+  it('dismisses when focus leaves the menu (tab-out)', () => {
+    const anchor = document.createElement('button');
+    const outside = document.createElement('button');
+    document.body.append(anchor, outside);
+    const onClose = jest.fn();
+    render(
+      <Menu anchorEl={anchor} open onClose={onClose}>
+        <MenuItem>One</MenuItem>
+      </Menu>,
+    );
+    const item = screen.getByRole('menuitem');
+    fireEvent.blur(item, { relatedTarget: outside });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    anchor.remove();
+    outside.remove();
   });
 });

--- a/src/diagram/tests/menu.test.tsx
+++ b/src/diagram/tests/menu.test.tsx
@@ -239,4 +239,21 @@ describe('Menu dismissal and keyboard', () => {
     anchor.remove();
     outside.remove();
   });
+
+  it('dismisses when keyboard focus moves back to the trigger (shift+tab)', () => {
+    const anchor = document.createElement('button');
+    document.body.appendChild(anchor);
+    const onClose = jest.fn();
+    render(
+      <Menu anchorEl={anchor} open onClose={onClose}>
+        <MenuItem>One</MenuItem>
+      </Menu>,
+    );
+    // Shift+Tab can land focus on the trigger; that is still leaving the menu,
+    // so it must close (no mouse press happened, so it is not exempted).
+    const item = screen.getByRole('menuitem');
+    fireEvent.blur(item, { relatedTarget: anchor });
+    expect(onClose).toHaveBeenCalledTimes(1);
+    anchor.remove();
+  });
 });

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -7,7 +7,6 @@ import * as path from 'path';
 import { IncomingMessage, ServerResponse } from 'http';
 
 import * as admin from 'firebase-admin';
-import cookieParser from 'cookie-parser';
 import cors from 'cors';
 import express from 'express';
 import helmet from 'helmet';
@@ -128,7 +127,6 @@ class App {
     // put the redirect before the request logger to remove noise
     this.app.use(redirectToHttps);
     this.app.use(requestLogger);
-    this.app.use(cookieParser());
     this.app.use(seshcookie(this.app.get('authentication').seshcookie));
 
     // etags don't work well on Google App Engine, and we don't have

--- a/src/server/models/db-firestore.ts
+++ b/src/server/models/db-firestore.ts
@@ -2,6 +2,7 @@
 // Use of this source code is governed by the Apache License,
 // Version 2.0, that can be found in the LICENSE file.
 
+import { getApps, initializeApp } from 'firebase-admin/app';
 import { Firestore, getFirestore } from 'firebase-admin/firestore';
 
 import { File } from '../schemas/file_pb';
@@ -36,6 +37,14 @@ export class FirestoreDatabase implements Database {
 }
 
 export async function createFirestoreDatabase(_opts: DatabaseOptions): Promise<Database> {
+  // getFirestore() resolves against the default Firebase app and throws
+  // `app/no-app` if none has been initialized. App bootstrap calls
+  // admin.initializeApp() before building the DB, but standalone callers (e.g.
+  // scripts/debug-import.mjs) do not -- so initialize on demand when no app
+  // exists yet. The previous `new Firestore()` had no such prerequisite.
+  if (getApps().length === 0) {
+    initializeApp();
+  }
   const client = getFirestore();
   const db = new FirestoreDatabase(client);
   await db.init();

--- a/src/server/models/db-firestore.ts
+++ b/src/server/models/db-firestore.ts
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the Apache License,
 // Version 2.0, that can be found in the LICENSE file.
 
-import { Firestore } from '@google-cloud/firestore';
+import { Firestore, getFirestore } from 'firebase-admin/firestore';
 
 import { File } from '../schemas/file_pb';
 import { Preview } from '../schemas/preview_pb';
@@ -36,7 +36,7 @@ export class FirestoreDatabase implements Database {
 }
 
 export async function createFirestoreDatabase(_opts: DatabaseOptions): Promise<Database> {
-  const client = new Firestore();
+  const client = getFirestore();
   const db = new FirestoreDatabase(client);
   await db.init();
   return db;

--- a/src/server/models/table-firestore.ts
+++ b/src/server/models/table-firestore.ts
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the Apache License,
 // Version 2.0, that can be found in the LICENSE file.
 
-import { CollectionReference, FieldPath, Firestore } from '@google-cloud/firestore';
+import { CollectionReference, FieldPath, Firestore } from 'firebase-admin/firestore';
 import { Message } from 'google-protobuf';
 
 import { Query, SerializableClass, Table } from './table';

--- a/src/server/package.json
+++ b/src/server/package.json
@@ -8,11 +8,9 @@
   "private": true,
   "main": "lib",
   "dependencies": {
-    "@google-cloud/firestore": "^8.3.0",
     "@iarna/toml": "^2.2.5",
     "@simlin/core": "workspace:*",
     "@simlin/engine": "workspace:*",
-    "cookie-parser": "^1.4.7",
     "cors": "^2.8.6",
     "express": "^5.2.1",
     "firebase-admin": "^13.6.1",
@@ -20,7 +18,6 @@
     "helmet": "^8.1.0"
   },
   "devDependencies": {
-    "@types/cookie-parser": "^1.4.10",
     "@types/cors": "^2.8.19",
     "@types/express": "^5.0.6",
     "@types/google-protobuf": "^3.15.12",

--- a/src/server/tests/db-firestore.test.ts
+++ b/src/server/tests/db-firestore.test.ts
@@ -1,0 +1,43 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+// getFirestore() resolves against the default Firebase app, so
+// createFirestoreDatabase must ensure one exists -- standalone callers (e.g.
+// scripts/debug-import.mjs) reach createDatabase without App bootstrap having
+// run admin.initializeApp(). These tests pin that on-demand init contract.
+
+import { getApps, initializeApp } from 'firebase-admin/app';
+import { getFirestore } from 'firebase-admin/firestore';
+import { createFirestoreDatabase } from '../models/db-firestore';
+
+jest.mock('firebase-admin/app', () => ({
+  getApps: jest.fn(),
+  initializeApp: jest.fn(),
+}));
+
+jest.mock('firebase-admin/firestore', () => ({
+  // FirestoreTable's constructor only needs `db.collection(name)`; init() is a
+  // no-op, so a minimal stub client is enough to drive createFirestoreDatabase.
+  getFirestore: jest.fn(() => ({ collection: () => ({}) })),
+}));
+
+describe('createFirestoreDatabase', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('initializes a default app on demand when none exists', async () => {
+    (getApps as jest.Mock).mockReturnValue([]);
+    await createFirestoreDatabase({ backend: 'firestore' });
+    expect(initializeApp).toHaveBeenCalledTimes(1);
+    expect(getFirestore).toHaveBeenCalledTimes(1);
+  });
+
+  test('reuses an already-initialized app (no double init)', async () => {
+    (getApps as jest.Mock).mockReturnValue([{}]);
+    await createFirestoreDatabase({ backend: 'firestore' });
+    expect(initializeApp).not.toHaveBeenCalled();
+    expect(getFirestore).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/server/tests/session-auth.test.ts
+++ b/src/server/tests/session-auth.test.ts
@@ -9,7 +9,6 @@
 // the user onto req.user, and DELETE /session clears the cookie.
 
 import express from 'express';
-import cookieParser from 'cookie-parser';
 import { seshcookie } from '../seshcookie/seshcookie';
 import http from 'http';
 
@@ -35,7 +34,6 @@ function fakeUserTable(known: Record<string, FakeUser>) {
 function createTestApp(): express.Express {
   const app = express();
 
-  app.use(cookieParser());
   app.use(
     seshcookie({
       key: 'test-key-for-encryption-1234',
@@ -140,7 +138,6 @@ describe('seshcookie-backed session auth', () => {
 
   it('a session naming an unknown user does not populate req.user', async () => {
     const app = express();
-    app.use(cookieParser());
     app.use(
       seshcookie({
         key: 'test-key-for-encryption-1234',

--- a/src/simlin-engine/Cargo.toml
+++ b/src/simlin-engine/Cargo.toml
@@ -71,7 +71,10 @@ csv = "1"
 rand = "0.9"
 proptest = "1.5"
 jsonschema = { version = "0.26", default-features = false }
-criterion = { version = "0.5", features = ["html_reports"] }
+# default features pull in the plotters HTML-report stack (plotters,
+# criterion-plot, tinytemplate, cast, oorandom, ...); we only ever read the
+# terminal summary, so trim to the bench-runner harness alone.
+criterion = { version = "0.5", default-features = false, features = ["cargo_bench_support"] }
 sha2 = "0.10"
 test-generator = { version = "0.3.0", git = "https://github.com/bpowers/test-generator", rev = "b78145bfb6a6f81425dfd6fbacb9c03624e79b2c" }
 ed25519-dalek = "2"

--- a/src/simlin-mcp-core/Cargo.toml
+++ b/src/simlin-mcp-core/Cargo.toml
@@ -14,7 +14,6 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["rt-multi-thread", "macros", "fs"] }
 anyhow = "1"
-tracing = "0.1"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary

A follow-up to PR #719: a fresh attribution audit of both lockfiles (Rust workspace crates + all JS packages), verifying actual call sites before cutting. Everything removed is dead weight, a redundant pin, or replaceable by a small amount of tested code we own.

|  | Before | After | Delta |
|---|---|---|---|
| Cargo.lock crates | 467 | 463 | -4 |
| pnpm-lock packages | 1346 | 1320 | -26 |

The headline counts undersell it: the biggest wins are deduplicating parallel transitive trees (firestore/gax) and evicting the `@floating-ui`/popper positioning stack, both of which trade many duplicated/heavy packages for owned code.

## server: redundant firestore pin + dead cookie-parser

`firebase-admin` already bundles `@google-cloud/firestore` and re-exports its full type surface (plus an app-aware `getFirestore()`) from `firebase-admin/firestore`. The server *also* pinned `@google-cloud/firestore@^8.3.0`, which resolved to `8.5.0` next to firebase-admin's `7.11.6`; the two diverge below `google-gax` (4.x vs 5.x), dragging parallel copies of `google-gax`, `google-auth-library`, the grpc proto loader, and `node-fetch` into the tree. Retargeted the two import sites at `firebase-admin/firestore` and swapped `new Firestore()` for `getFirestore()` (the admin app is already initialized before the DB is built). The runtime API used (collection/doc/where/runTransaction, `FieldPath.documentId()`) is stable across 7.x/8.x.

`cookieParser()` was registered as middleware but nothing reads `req.cookies`/`req.signedCookies` (seshcookie parses the Cookie header itself). Removed it + `@types/cookie-parser` and the duplicate `cookie-signature` copy it pulled.

## build: criterion plotters trim + unused tracing

`criterion` is now `default-features = false, features = ["cargo_bench_support"]`, dropping the `plotters`/`plotters-backend`/`plotters-svg`/`web-sys` stack (we only read the terminal summary; the bench harnesses report in-chat). Removed the declared-but-unused `tracing` dependency from `simlin-mcp-core` (Closes #803).

## diagram: reimplement 4 UI components, drop 5 deps

Replaced five third-party UI dependencies with small owned implementations, keeping each component's public API and its existing tests as the contract. This **fully evicts the `@floating-ui/*` + `react-popper` positioning stack** and `downshift`.

- **Accordion** -- context-backed single-item disclosure; the open/close height animation is a JS-free `grid-template-rows` `0fr<->1fr` transition (no more Radix `--radix-accordion-content-height`). Adds an Accordion test where none existed.
- **Checkbox** -- native `<input type="checkbox">` (appearance:none) with a CheckIcon overlay, preserving the `data-state` + primary/secondary class contract.
- **Autocomplete** -- a new owned `useCombobox` hook (filter-as-you-type listbox, arrow/enter/escape keys, WAI-ARIA combobox attributes) replaces downshift's `useCombobox`; the component body is otherwise unchanged.
- **Menu** -- an owned fixed-position portal positioned from the live anchor rect (the `useAnchorRect` issue-#710 logic is unchanged), with Escape + click-outside dismissal and close-on-select via context. Drops Radix dropdown-menu (and with it `@floating-ui`).
- **SpeedDial action tooltips** -- a CSS-only hover/focus tooltip replaces Radix tooltip.

Radix `dialog`/`tabs`/`toast` deliberately stay -- they carry focus-trap/ARIA correctness that is not worth re-owning. All 1195 diagram tests pass.

## Deliberately kept (audited, not worth touching)

- **Rust**: `ignore`, `calamine`, `notify-debouncer-full`, `jsonschema` -- big headline closures evaporate under inverse-dependency analysis (shared with `tracing-subscriber`/`salsa`/`loro`) or are already correctly feature-gated. `twox-hash`/`smallvec`/`rustc-hash`/`indexmap` add zero net crates.
- **JS**: `helmet`/`@iarna/toml` (zero deps), `cors` (one tiny pkg), `katex` (one call site, but deps only on `commander` -- weight is fonts not tree), `slate`, `@firebase/*`, `clsx`, `wouter` -- load-bearing or zero-closure.

## Verification

Every commit passed the full pre-commit battery (rustfmt, clippy, cargo test, eslint, build, tsc, JS tests, pysimlin). New/reimplemented components keep their existing component tests green; the firestore retarget and cookie-parser removal were validated against the server suite (111 tests) and tsc.

Closes #803

🤖 Generated with [Claude Code](https://claude.com/claude-code)