### PR TITLE
Module editing: fix dangling/cyclic/mis-wired reference bugs found by adversarial audit

### DIFF
--- a/src/core/tests/datamodel.test.ts
+++ b/src/core/tests/datamodel.test.ts
@@ -305,6 +305,82 @@ describe('Module', () => {
     expect(restored.modelName).toBe('SectorModel');
     expect(restored.references.length).toBe(1);
   });
+
+  it('roundtrips a freshly-drawn module (empty modelName, no references)', () => {
+    // The editor creates a module with an EMPTY modelName until the user
+    // assigns a target model -- the exact state that panicked the engine in
+    // c1c4c954. The empty modelName must survive serialization (the Rust
+    // `model_name` is a required String, so a dropped field is an FFI hard
+    // error) and deserialize back to empty.
+    const mod: Module = {
+      type: 'module',
+      ident: 'new_module',
+      modelName: '',
+      documentation: '',
+      units: '',
+      references: [],
+      data: undefined,
+      errors: undefined,
+      unitErrors: undefined,
+      uid: undefined,
+    };
+
+    const json = moduleToJson(mod);
+    expect(json.modelName).toBe('');
+    expect(json.references ?? []).toEqual([]);
+
+    const restored = moduleFromJson(json);
+    expect(restored.modelName).toBe('');
+    expect(restored.references).toEqual([]);
+  });
+
+  it('preserves placeholder references with empty src/dst', () => {
+    // The wiring UI persists partially-filled rows (empty src or dst) as the
+    // user builds up inputs; these must round-trip verbatim, not be coalesced
+    // or dropped.
+    const mod: Module = {
+      type: 'module',
+      ident: 'sector',
+      modelName: 'SectorModel',
+      documentation: '',
+      units: '',
+      references: [
+        { src: '', dst: '' },
+        { src: 'food', dst: '' },
+      ],
+      data: undefined,
+      errors: undefined,
+      unitErrors: undefined,
+      uid: 5,
+    };
+
+    const restored = moduleFromJson(moduleToJson(mod));
+    expect(restored.references).toEqual([
+      { src: '', dst: '' },
+      { src: 'food', dst: '' },
+    ]);
+  });
+
+  it('roundtrips a module-qualified dst reference', () => {
+    // The canonical reference dst is the module-qualified `{moduleIdent}·{port}`
+    // form (the engine strips the prefix to wire the input); the middot must
+    // survive the JSON round trip intact.
+    const mod: Module = {
+      type: 'module',
+      ident: 'sector',
+      modelName: 'SectorModel',
+      documentation: '',
+      units: '',
+      references: [{ src: 'food', dst: 'sector·sector_input' }],
+      data: undefined,
+      errors: undefined,
+      unitErrors: undefined,
+      uid: 5,
+    };
+
+    const restored = moduleFromJson(moduleToJson(mod));
+    expect(restored.references[0].dst).toBe('sector·sector_input');
+  });
 });
 
 describe('View Elements', () => {

--- a/src/diagram/ModuleDetails.tsx
+++ b/src/diagram/ModuleDetails.tsx
@@ -18,7 +18,9 @@ import { STDLIB_PREFIX } from './module-navigation';
 import {
   addReference,
   getAvailableSrcVariables,
+  qualifyDst,
   removeReference,
+  unqualifyDst,
   updateReferenceDst,
   updateReferenceSrc,
 } from './module-wiring';
@@ -181,7 +183,9 @@ export function ModuleDetails(props: ModuleDetailsProps): React.ReactElement {
   };
 
   const handleDstChange = (index: number, newDst: string): void => {
-    const updated = updateReferenceDst(variable.references, index, newDst);
+    // The dropdown yields a bare child port; persist the canonical
+    // module-qualified `{moduleIdent}·{port}` form the engine wires against.
+    const updated = updateReferenceDst(variable.references, index, qualifyDst(variable.ident, newDst));
     onReferencesChange(variable.ident, updated);
   };
 
@@ -230,7 +234,7 @@ export function ModuleDetails(props: ModuleDetailsProps): React.ReactElement {
                   </td>
                   <td className={styles.wiringDropdown}>
                     <Autocomplete
-                      value={ref.dst || null}
+                      value={unqualifyDst(ref.dst) || null}
                       options={dstOptions}
                       onChange={(_: React.SyntheticEvent | null, newValue: string | null) => {
                         if (newValue) {

--- a/src/diagram/module-wiring.ts
+++ b/src/diagram/module-wiring.ts
@@ -6,6 +6,35 @@
 
 import type { ModuleReference } from '@simlin/core/datamodel';
 
+// A module reference `dst` is stored in the canonical module-qualified form
+// `{moduleIdent}·{port}`: the engine's `build_module_inputs` strips that prefix
+// to recover the child input port, and a BARE `dst` (just the port) silently
+// fails to wire -- the port reads its default and the simulation is quietly
+// wrong. The wiring UI works in bare port names, so persist the qualified form
+// and strip it for display. `·` (·) is the canonical separator the engine
+// canonicalizes to; a literal `.` is tolerated on read for a model imported
+// straight from XMILE that has not yet round-tripped through a patch.
+const MODULE_PORT_SEPARATOR = '·';
+
+/**
+ * Qualifies a bare child input-port name into the canonical `{moduleIdent}·{port}`
+ * reference `dst`. An empty port stays empty so new-row placeholders persist as
+ * empty (not a dangling `moduleIdent·`).
+ */
+export function qualifyDst(moduleIdent: string, port: string): string {
+  return port ? `${moduleIdent}${MODULE_PORT_SEPARATOR}${port}` : '';
+}
+
+/**
+ * Recovers the bare child input-port name from a reference `dst` for display:
+ * the segment after the final module separator (`·` or a legacy `.`), or the
+ * whole string when there is no separator (an already-bare or empty value).
+ */
+export function unqualifyDst(dst: string): string {
+  const sep = Math.max(dst.lastIndexOf(MODULE_PORT_SEPARATOR), dst.lastIndexOf('.'));
+  return sep >= 0 ? dst.slice(sep + 1) : dst;
+}
+
 /**
  * Returns true if a reference with the same src and dst already exists.
  */

--- a/src/diagram/tests/module-wiring-ui.test.tsx
+++ b/src/diagram/tests/module-wiring-ui.test.tsx
@@ -272,7 +272,36 @@ describe('ModuleDetails wiring editor', () => {
       const dstOption = screen.getByText('input_food');
       fireEvent.click(dstOption);
 
-      expect(callbacks.onReferencesChange).toHaveBeenCalledWith('hares_mod', [{ src: 'food', dst: 'input_food' }]);
+      // The bare dropdown port is persisted in the canonical module-qualified
+      // form the engine wires against ({moduleIdent}·{port}).
+      expect(callbacks.onReferencesChange).toHaveBeenCalledWith('hares_mod', [
+        { src: 'food', dst: 'hares_mod·input_food' },
+      ]);
+    });
+
+    test('a module-qualified dst is displayed as the bare port name', () => {
+      const variable = makeModule('hares_mod', 'hares', {
+        references: [{ src: 'food', dst: 'hares_mod·input_food' }],
+      });
+      const project = makeProject([
+        makeModel('main', [variable, makeAux('food')]),
+        makeModel('hares', [makeAux('input_food', { canBeModuleInput: true })]),
+      ]);
+      const callbacks = defaultCallbacks();
+
+      render(
+        <ModuleDetails
+          variable={variable}
+          viewElement={makeViewElement('hares_mod')}
+          project={project}
+          currentModelName="main"
+          {...callbacks}
+        />,
+      );
+
+      // The qualified dst renders as the bare port, not the raw `hares_mod·input_food`.
+      const dstInput = screen.getByPlaceholderText('Select input') as HTMLInputElement;
+      expect(dstInput.value).toBe('input_food');
     });
   });
 

--- a/src/diagram/tests/module-wiring.test.ts
+++ b/src/diagram/tests/module-wiring.test.ts
@@ -15,9 +15,43 @@ import {
   updateReferenceSrc,
   updateReferenceDst,
   getAvailableSrcVariables,
+  qualifyDst,
+  unqualifyDst,
 } from '../module-wiring';
 
 // -- Tests --
+
+describe('qualifyDst', () => {
+  it('prefixes a bare port with the module ident and the canonical separator', () => {
+    expect(qualifyDst('hares_mod', 'input_food')).toBe('hares_mod·input_food');
+  });
+
+  it('keeps an empty port empty (placeholder rows are not dangling prefixes)', () => {
+    expect(qualifyDst('hares_mod', '')).toBe('');
+  });
+});
+
+describe('unqualifyDst', () => {
+  it('recovers the bare port from a module-qualified dst', () => {
+    expect(unqualifyDst('hares_mod·input_food')).toBe('input_food');
+  });
+
+  it('tolerates a legacy period separator (XMILE-imported, pre-patch)', () => {
+    expect(unqualifyDst('hares_mod.input_food')).toBe('input_food');
+  });
+
+  it('returns an already-bare value unchanged', () => {
+    expect(unqualifyDst('input_food')).toBe('input_food');
+  });
+
+  it('returns empty for empty input', () => {
+    expect(unqualifyDst('')).toBe('');
+  });
+
+  it('round-trips with qualifyDst', () => {
+    expect(unqualifyDst(qualifyDst('m', 'port'))).toBe('port');
+  });
+});
 
 describe('isDuplicateReference', () => {
   it('returns false for empty references array', () => {

--- a/src/simlin-engine/src/analysis.rs
+++ b/src/simlin-engine/src/analysis.rs
@@ -143,18 +143,22 @@ pub fn analyze_model(
     let json_model = model_snapshot(project, model_name)
         .ok_or_else(|| format!("model '{model_name}' not found in project"))?;
 
-    // A cyclic / self-referential module graph would panic the recursive causal-
-    // graph / layout queries this analysis drives. Surface it as an actionable
-    // `analysis_error` (the model snapshot is intact, loops empty), matching the
-    // non-compilable-model degradation rather than aborting (GH #806).
-    if let Some((_code, msg)) = &crate::db::project_module_cycle(&*db, source_project).cycle_error {
+    // A cyclic / self-referential module graph reachable from the analyzed model
+    // would panic the recursive causal-graph / layout queries this analysis
+    // drives. Surface it as an actionable `analysis_error` (the model snapshot is
+    // intact, loops empty), matching the non-compilable-model degradation rather
+    // than aborting (GH #806). Scoped to reachability from `model_name` so an
+    // unrelated draft cycle elsewhere does not block analyzing a valid model.
+    if let Some((_code, msg)) =
+        crate::db::project_module_graph(&*db, source_project).cycle_error_from(model_name)
+    {
         return Ok(ModelAnalysis {
             model: json_model,
             time: vec![],
             loop_dominance: vec![],
             partitions: vec![],
             dominant_loops_by_period: vec![],
-            analysis_error: Some(msg.clone()),
+            analysis_error: Some(msg),
             truncated: false,
             agg_recovery_truncated: false,
         });

--- a/src/simlin-engine/src/analysis.rs
+++ b/src/simlin-engine/src/analysis.rs
@@ -143,6 +143,23 @@ pub fn analyze_model(
     let json_model = model_snapshot(project, model_name)
         .ok_or_else(|| format!("model '{model_name}' not found in project"))?;
 
+    // A cyclic / self-referential module graph would panic the recursive causal-
+    // graph / layout queries this analysis drives. Surface it as an actionable
+    // `analysis_error` (the model snapshot is intact, loops empty), matching the
+    // non-compilable-model degradation rather than aborting (GH #806).
+    if let Some((_code, msg)) = &crate::db::project_module_cycle(&*db, source_project).cycle_error {
+        return Ok(ModelAnalysis {
+            model: json_model,
+            time: vec![],
+            loop_dominance: vec![],
+            partitions: vec![],
+            dominant_loops_by_period: vec![],
+            analysis_error: Some(msg.clone()),
+            truncated: false,
+            agg_recovery_truncated: false,
+        });
+    }
+
     // Enable LTM discovery for this analysis; restore flags before returning
     // so the caller's db state stays clean.
     source_project.set_ltm_enabled(db).to(true);

--- a/src/simlin-engine/src/common.rs
+++ b/src/simlin-engine/src/common.rs
@@ -2651,20 +2651,32 @@ pub fn topo_sort<'out>(
             return;
         }
         used.insert(ident);
+        // An ident with no dependencies entry is a dangling reference -- skip it
+        // rather than panicking. A dangling module reference (an empty or missing
+        // `model_name`) on the legacy `from_salsa` path can leave such an ident
+        // in the dependency set; it is not a real variable to place in the
+        // runlist, so dropping it keeps this test-only path from crashing with an
+        // "internal compiler error" on user-controllable input (GH #806). The
+        // production salsa path uses `topo_sort_str` and rejects a
+        // dangling/cyclic module graph up front, so valid runlists -- where every
+        // ident has a deps entry -- are unaffected (result == runlist).
         if let Some(deps) = dependencies.get(ident) {
             for dep in deps.iter() {
                 add(dependencies, result, used, dep)
             }
-        } else {
-            panic!("internal compiler error: unknown ident {}", ident.as_str());
+            result.push(ident);
         }
-        result.push(ident);
     }
 
     for ident in runlist.into_iter() {
         add(dependencies, &mut result, &mut used, ident);
     }
 
-    assert_eq!(runlist_len, result.len());
+    // For a well-formed runlist every ident has a dependencies entry and every
+    // dependency is itself in the runlist, so `result` holds exactly the runlist
+    // idents (`result.len() == runlist_len`). A dangling reference (GH #806) is
+    // skipped above, so the result may be shorter; we no longer assert equality
+    // (it would re-introduce a panic on the bad input this guards against).
+    debug_assert!(result.len() <= runlist_len);
     result
 }

--- a/src/simlin-engine/src/db.rs
+++ b/src/simlin-engine/src/db.rs
@@ -63,9 +63,10 @@ pub use input::{
 mod query;
 pub(crate) use query::canonical_module_input_set;
 pub use query::{
-    ImplicitVarMeta, ParsedVariableResult, VariableDeps, model_implicit_var_info,
-    model_module_ident_context, model_module_map, parse_source_variable_with_module_context,
-    project_converted_dimensions, project_datamodel_dims, project_dimensions_context,
+    ImplicitVarMeta, ModuleCycleResult, ParsedVariableResult, VariableDeps,
+    model_implicit_var_info, model_module_ident_context, model_module_map,
+    parse_source_variable_with_module_context, project_converted_dimensions,
+    project_datamodel_dims, project_dimensions_context, project_module_cycle,
     project_units_context, variable_dimensions, variable_direct_dependencies,
     variable_relevant_dimensions, variable_size,
 };
@@ -1091,6 +1092,8 @@ mod incremental_compile_tests;
 mod ltm_module_tests;
 #[cfg(test)]
 mod ltm_unified_tests;
+#[cfg(test)]
+mod module_cycle_tests;
 #[cfg(test)]
 mod prev_init_tests;
 #[cfg(test)]

--- a/src/simlin-engine/src/db.rs
+++ b/src/simlin-engine/src/db.rs
@@ -63,10 +63,10 @@ pub use input::{
 mod query;
 pub(crate) use query::canonical_module_input_set;
 pub use query::{
-    ImplicitVarMeta, ModuleCycleResult, ParsedVariableResult, VariableDeps,
+    ImplicitVarMeta, ModuleReferenceGraph, ParsedVariableResult, VariableDeps,
     model_implicit_var_info, model_module_ident_context, model_module_map,
     parse_source_variable_with_module_context, project_converted_dimensions,
-    project_datamodel_dims, project_dimensions_context, project_module_cycle,
+    project_datamodel_dims, project_dimensions_context, project_module_graph,
     project_units_context, variable_dimensions, variable_direct_dependencies,
     variable_relevant_dimensions, variable_size,
 };

--- a/src/simlin-engine/src/db.rs
+++ b/src/simlin-engine/src/db.rs
@@ -1095,6 +1095,8 @@ mod ltm_unified_tests;
 #[cfg(test)]
 mod module_cycle_tests;
 #[cfg(test)]
+mod module_wiring_tests;
+#[cfg(test)]
 mod prev_init_tests;
 #[cfg(test)]
 mod tests;

--- a/src/simlin-engine/src/db/assemble.rs
+++ b/src/simlin-engine/src/db/assemble.rs
@@ -1921,6 +1921,13 @@ pub fn assemble_simulation(
         return Err(msg);
     }
 
+    // A cyclic / self-referential module graph would drive the recursive
+    // instance-enumeration, layout, and module-map queries into a salsa
+    // dependency-graph cycle panic. Reject it cleanly first (GH #806).
+    if let Some((_code, msg)) = &project_module_cycle(db, project).cycle_error {
+        return Err(msg.clone());
+    }
+
     // Enumerate module instances by walking module variables recursively.
     // Each unique (model_name, input_set) pair gets its own CompiledModule.
     let module_instances = enumerate_module_instances(db, project, &main_model_name)?;

--- a/src/simlin-engine/src/db/assemble.rs
+++ b/src/simlin-engine/src/db/assemble.rs
@@ -1921,11 +1921,16 @@ pub fn assemble_simulation(
         return Err(msg);
     }
 
-    // A cyclic / self-referential module graph would drive the recursive
-    // instance-enumeration, layout, and module-map queries into a salsa
-    // dependency-graph cycle panic. Reject it cleanly first (GH #806).
-    if let Some((_code, msg)) = &project_module_cycle(db, project).cycle_error {
-        return Err(msg.clone());
+    // A cyclic / self-referential module graph reachable FROM THE MAIN MODEL
+    // would drive the recursive instance-enumeration, layout, and module-map
+    // queries into a salsa dependency-graph cycle panic. Reject it cleanly first
+    // (GH #806). Scoped to reachability from `main`: assembly starts from main
+    // and only recurses into its instantiated modules, so an unrelated draft
+    // cycle elsewhere in the project must not block compiling a valid main.
+    if let Some((_code, msg)) =
+        project_module_graph(db, project).cycle_error_from(main_model_canonical.as_ref())
+    {
+        return Err(msg);
     }
 
     // Enumerate module instances by walking module variables recursively.

--- a/src/simlin-engine/src/db/diagnostic.rs
+++ b/src/simlin-engine/src/db/diagnostic.rs
@@ -158,6 +158,22 @@ pub fn collect_model_diagnostics(
 
 /// Collect all diagnostics for every model in a synced project.
 pub fn collect_all_diagnostics(db: &SimlinDb, project: SourceProject) -> Vec<Diagnostic> {
+    // A module-reference cycle would drive the per-model diagnostic passes into
+    // the recursive module queries' salsa cycle panic. Surface it as one
+    // project-level diagnostic and skip those passes entirely (GH #806).
+    if let Some((code, message)) = &project_module_cycle(db, project).cycle_error {
+        return vec![Diagnostic {
+            model: String::new(),
+            variable: None,
+            error: DiagnosticError::Model(Error::new(
+                crate::common::ErrorKind::Model,
+                *code,
+                Some(message.clone()),
+            )),
+            severity: DiagnosticSeverity::Error,
+        }];
+    }
+
     let mut all = Vec::new();
     for source_model in project.models(db).values() {
         let diags = collect_model_diagnostics(db, *source_model, project);

--- a/src/simlin-engine/src/db/diagnostic.rs
+++ b/src/simlin-engine/src/db/diagnostic.rs
@@ -125,6 +125,13 @@ pub fn model_all_diagnostics(db: &dyn Db, model: SourceModel, project: SourcePro
     // cap).
     crate::db::units::check_model_units(db, model, project);
 
+    // Validate each explicit module variable's input wiring (GH #806 sibling):
+    // a reference whose `dst` names no input of the target model, or whose bare
+    // `src` names no variable in this model, is silently dropped at assembly and
+    // the port reads its default -- a quietly-wrong simulation. The salsa path
+    // had lost the legacy `BadModuleInputDst`/`BadModuleInputSrc` check.
+    model_module_wiring_diagnostics(db, model, project);
+
     // When LTM is enabled, also trigger the LTM diagnostic pass so that
     // diagnostics accumulated by the LTM pipeline surface through
     // `collect_all_diagnostics`: the auto-flip-to-discovery warning from
@@ -140,6 +147,97 @@ pub fn model_all_diagnostics(db: &dyn Db, model: SourceModel, project: SourcePro
     // so these warnings reach `simlin-mcp`/`libsimlin`/pysimlin (GH #466).
     if project.ltm_enabled(db) {
         model_ltm_fragment_diagnostics(db, model, project);
+    }
+}
+
+/// Validate the input wiring of each explicit module variable in `model`.
+///
+/// A module reference is `{ src, dst }` where `dst` is the module-qualified
+/// `{module}·{port}` form naming an input of the target model and `src` is a
+/// variable in the enclosing model. `build_module_inputs` SILENTLY DROPS a
+/// reference whose `dst` does not match an existing child input -- the port then
+/// reads its default and the simulation is quietly wrong, with no error. The
+/// legacy monolithic path returned `BadModuleInputDst`/`BadModuleInputSrc` here;
+/// the salsa path dropped the check. Re-add it as a Warning (partial-result
+/// philosophy: a mis-wired input should not block the rest of the model).
+///
+/// Validated conservatively to avoid false positives:
+/// - empty placeholder endpoints (the new-row UI pattern) are skipped;
+/// - only an EXISTING target model is checked (an empty / dangling `model_name`
+///   is a separate concern and the empty name is the normal freshly-drawn state);
+/// - a `src` is checked only when it is a bare ident (no `·`) and not an engine
+///   synthetic (`$⁚…`) -- a qualified cross-module output or temporary is left
+///   to the equation checker.
+#[salsa::tracked]
+pub fn model_module_wiring_diagnostics(db: &dyn Db, model: SourceModel, project: SourceProject) {
+    use salsa::Accumulator;
+
+    let source_vars = model.variables(db);
+    let project_models = project.models(db);
+    let model_name = model.name(db);
+
+    let mut module_names: Vec<&String> = source_vars
+        .iter()
+        .filter(|(_, sv)| sv.kind(db) == SourceVariableKind::Module)
+        .map(|(name, _)| name)
+        .collect();
+    module_names.sort_unstable();
+
+    let emit = |code: crate::common::ErrorCode, message: String| {
+        CompilationDiagnostic(Diagnostic {
+            model: model_name.clone(),
+            variable: None,
+            error: DiagnosticError::Model(Error::new(
+                crate::common::ErrorKind::Model,
+                code,
+                Some(message),
+            )),
+            severity: DiagnosticSeverity::Warning,
+        })
+        .accumulate(db);
+    };
+
+    for module_name in module_names {
+        let svar = &source_vars[module_name];
+        let child_canonical = crate::canonicalize(svar.model_name(db));
+        let Some(child_model) = project_models.get(child_canonical.as_ref()) else {
+            continue;
+        };
+        let child_vars = child_model.variables(db);
+        let prefix = format!("{module_name}\u{00B7}");
+
+        for reference in svar.module_refs(db).iter() {
+            let dst = crate::canonicalize(&reference.dst);
+            if !dst.is_empty() {
+                let resolves = dst
+                    .strip_prefix(prefix.as_str())
+                    .is_some_and(|port| child_vars.contains_key(port));
+                if !resolves {
+                    emit(
+                        crate::common::ErrorCode::BadModuleInputDst,
+                        format!(
+                            "module '{module_name}' input wiring target '{}' does not name an input of model '{}'",
+                            reference.dst, child_canonical
+                        ),
+                    );
+                }
+            }
+
+            let src = crate::canonicalize(&reference.src);
+            if !src.is_empty()
+                && !src.contains('\u{00B7}')
+                && !src.starts_with("$\u{205A}")
+                && !source_vars.contains_key(src.as_ref())
+            {
+                emit(
+                    crate::common::ErrorCode::BadModuleInputSrc,
+                    format!(
+                        "module '{module_name}' input source '{}' does not name a variable in model '{model_name}'",
+                        reference.src
+                    ),
+                );
+            }
+        }
     }
 }
 

--- a/src/simlin-engine/src/db/diagnostic.rs
+++ b/src/simlin-engine/src/db/diagnostic.rs
@@ -256,26 +256,30 @@ pub fn collect_model_diagnostics(
 
 /// Collect all diagnostics for every model in a synced project.
 pub fn collect_all_diagnostics(db: &SimlinDb, project: SourceProject) -> Vec<Diagnostic> {
-    // A module-reference cycle would drive the per-model diagnostic passes into
-    // the recursive module queries' salsa cycle panic. Surface it as one
-    // project-level diagnostic and skip those passes entirely (GH #806).
-    if let Some((code, message)) = &project_module_cycle(db, project).cycle_error {
-        return vec![Diagnostic {
-            model: String::new(),
-            variable: None,
-            error: DiagnosticError::Model(Error::new(
-                crate::common::ErrorKind::Model,
-                *code,
-                Some(message.clone()),
-            )),
-            severity: DiagnosticSeverity::Error,
-        }];
-    }
+    let graph = project_module_graph(db, project);
 
     let mut all = Vec::new();
-    for source_model in project.models(db).values() {
-        let diags = collect_model_diagnostics(db, *source_model, project);
-        all.extend(diags);
+    for (name, source_model) in project.models(db) {
+        // A model that can REACH a module cycle would drive its per-model passes
+        // (compile_var_fragment recursing through the submodel) into the salsa
+        // cycle panic. Report the cycle for that model and skip its passes. A
+        // model that reaches no cycle is processed normally, so a valid model's
+        // diagnostics are not hidden by an unrelated draft cycle elsewhere
+        // (GH #806).
+        if let Some((code, message)) = graph.cycle_error_from(name) {
+            all.push(Diagnostic {
+                model: name.clone(),
+                variable: None,
+                error: DiagnosticError::Model(Error::new(
+                    crate::common::ErrorKind::Model,
+                    code,
+                    Some(message),
+                )),
+                severity: DiagnosticSeverity::Error,
+            });
+            continue;
+        }
+        all.extend(collect_model_diagnostics(db, *source_model, project));
     }
     all
 }

--- a/src/simlin-engine/src/db/module_cycle_tests.rs
+++ b/src/simlin-engine/src/db/module_cycle_tests.rs
@@ -1,0 +1,162 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+//! Regression tests for the module-reference cycle guard.
+//!
+//! A cyclic or self-referential module graph makes the recursive
+//! `model_module_map` / `compute_layout` salsa queries loop, which salsa turns
+//! into an unrecoverable dependency-graph panic. The empty-`model_name` sibling
+//! of this class was fixed in c1c4c954; this is the reachable cousin tracked as
+//! GH #806. Every production entry point -- compile, diagnostic collection, and
+//! analysis -- must surface the cycle as a clean `CircularDependency` error
+//! instead of aborting (a WASM panic plus the recursive-mutex cascade).
+
+use crate::analysis::analyze_model;
+use crate::common::ErrorCode;
+use crate::datamodel::{self, Equation, Variable};
+use crate::db::{
+    DiagnosticError, SimlinDb, collect_all_diagnostics, compile_project_incremental,
+    sync_from_datamodel,
+};
+use crate::test_common::TestProject;
+
+fn module_var(ident: &str, target_model: &str) -> Variable {
+    Variable::Module(datamodel::Module {
+        ident: ident.to_string(),
+        model_name: target_model.to_string(),
+        documentation: String::new(),
+        units: None,
+        references: vec![],
+        compat: datamodel::Compat::default(),
+        ai_state: None,
+        uid: None,
+    })
+}
+
+fn aux_var(ident: &str, equation: &str) -> Variable {
+    Variable::Aux(datamodel::Aux {
+        ident: ident.to_string(),
+        equation: Equation::Scalar(equation.to_string()),
+        documentation: String::new(),
+        units: None,
+        gf: None,
+        ai_state: None,
+        uid: None,
+        compat: datamodel::Compat::default(),
+    })
+}
+
+fn model(name: &str, variables: Vec<Variable>) -> datamodel::Model {
+    datamodel::Model {
+        name: name.to_string(),
+        sim_specs: None,
+        variables,
+        views: vec![],
+        loop_metadata: vec![],
+        groups: vec![],
+        macro_spec: None,
+    }
+}
+
+fn has_circular_diagnostic(diags: &[crate::db::Diagnostic]) -> bool {
+    diags.iter().any(|d| {
+        matches!(&d.error, DiagnosticError::Model(e) if e.code == ErrorCode::CircularDependency)
+    })
+}
+
+/// A module that instantiates its own enclosing model: `main` contains a module
+/// whose `model_name` is `main`.
+#[test]
+fn self_referential_module_errors_without_panicking() {
+    let mut project = TestProject::new("test").build_datamodel();
+    project.models[0].variables.push(module_var("m", "main"));
+    project.models[0].variables.push(aux_var("x", "1"));
+
+    let db = SimlinDb::default();
+    let sync = sync_from_datamodel(&db, &project);
+    let sp = sync.project;
+
+    // Compile must reject cleanly rather than panic.
+    assert!(
+        compile_project_incremental(&db, sp, "main").is_err(),
+        "a self-referential module must not compile"
+    );
+
+    // Diagnostic collection must surface the cycle, not panic.
+    let diags = collect_all_diagnostics(&db, sp);
+    assert!(
+        has_circular_diagnostic(&diags),
+        "expected a CircularDependency diagnostic, got {diags:?}"
+    );
+
+    // Analysis (the MCP read_model path) must degrade to an analysis_error.
+    let mut db = db;
+    let analysis = analyze_model(&project, &mut db, sp, "main", None)
+        .expect("analyze_model must not panic on a module cycle");
+    assert!(
+        analysis.analysis_error.is_some(),
+        "expected an analysis_error for a cyclic module graph"
+    );
+}
+
+/// Two models that instantiate each other: `a` contains a module targeting `b`
+/// and `b` contains a module targeting `a`.
+#[test]
+fn mutually_recursive_modules_error_without_panicking() {
+    let mut project = TestProject::new("test").build_datamodel();
+    project.models = vec![
+        model("a", vec![module_var("to_b", "b"), aux_var("x", "1")]),
+        model("b", vec![module_var("to_a", "a"), aux_var("y", "1")]),
+    ];
+
+    let db = SimlinDb::default();
+    let sync = sync_from_datamodel(&db, &project);
+    let sp = sync.project;
+
+    assert!(
+        compile_project_incremental(&db, sp, "a").is_err(),
+        "mutually recursive modules must not compile"
+    );
+
+    let diags = collect_all_diagnostics(&db, sp);
+    assert!(
+        has_circular_diagnostic(&diags),
+        "expected a CircularDependency diagnostic, got {diags:?}"
+    );
+
+    let mut db = db;
+    let analysis = analyze_model(&project, &mut db, sp, "a", None)
+        .expect("analyze_model must not panic on a module cycle");
+    assert!(analysis.analysis_error.is_some());
+}
+
+/// A valid nested-module project (no cycle) must still compile and produce no
+/// spurious cycle diagnostic -- the guard must not false-positive on legitimate
+/// acyclic nesting.
+#[test]
+fn acyclic_nested_modules_compile_clean() {
+    let mut project = TestProject::new("test").build_datamodel();
+    project.models = vec![
+        model("main", vec![module_var("mid", "middle"), aux_var("x", "1")]),
+        model(
+            "middle",
+            vec![module_var("leaf_mod", "leaf"), aux_var("y", "2")],
+        ),
+        model("leaf", vec![aux_var("z", "3")]),
+    ];
+
+    let db = SimlinDb::default();
+    let sync = sync_from_datamodel(&db, &project);
+    let sp = sync.project;
+
+    assert!(
+        compile_project_incremental(&db, sp, "main").is_ok(),
+        "an acyclic nested-module project must compile"
+    );
+    let diags = collect_all_diagnostics(&db, sp);
+    assert!(
+        !has_circular_diagnostic(&diags),
+        "acyclic nesting must not report a module cycle: {diags:?}"
+    );
+}

--- a/src/simlin-engine/src/db/module_cycle_tests.rs
+++ b/src/simlin-engine/src/db/module_cycle_tests.rs
@@ -131,6 +131,53 @@ fn mutually_recursive_modules_error_without_panicking() {
     assert!(analysis.analysis_error.is_some());
 }
 
+/// An unused draft cycle (`a <-> b`) that the requested `main` model does not
+/// reach must NOT block compiling or analyzing `main` -- the recursive queries
+/// only loop for modules under the requested root. The cycle is still surfaced
+/// as a diagnostic for the affected models. Regression for the Codex review
+/// finding on PR #807 (the project-wide guard over-rejected valid roots).
+#[test]
+fn unused_draft_cycle_does_not_block_valid_main() {
+    let mut project = TestProject::new("test").build_datamodel();
+    project.models = vec![
+        model("main", vec![aux_var("x", "1")]),
+        model("a", vec![module_var("to_b", "b")]),
+        model("b", vec![module_var("to_a", "a")]),
+    ];
+
+    let mut db = SimlinDb::default();
+    let sync = sync_from_datamodel(&db, &project);
+    let sp = sync.project;
+
+    // `main` cannot reach the a<->b cycle, so it compiles cleanly.
+    assert!(
+        compile_project_incremental(&db, sp, "main").is_ok(),
+        "a valid main must compile despite an unrelated draft cycle"
+    );
+
+    // Diagnostics still surface the draft cycle (for the affected models),
+    // without hiding main's own (empty) diagnostics.
+    let diags = collect_all_diagnostics(&db, sp);
+    assert!(
+        has_circular_diagnostic(&diags),
+        "the unrelated draft cycle should still be reported: {diags:?}"
+    );
+
+    // Analyzing main succeeds (no analysis_error); analyzing a cyclic model degrades.
+    let main_analysis =
+        analyze_model(&project, &mut db, sp, "main", None).expect("analyze_model must not panic");
+    assert!(
+        main_analysis.analysis_error.is_none(),
+        "analyzing a valid main must not error on an unrelated draft cycle"
+    );
+    let a_analysis =
+        analyze_model(&project, &mut db, sp, "a", None).expect("analyze_model must not panic");
+    assert!(
+        a_analysis.analysis_error.is_some(),
+        "analyzing a model that reaches a cycle must surface an analysis_error"
+    );
+}
+
 /// A valid nested-module project (no cycle) must still compile and produce no
 /// spurious cycle diagnostic -- the guard must not false-positive on legitimate
 /// acyclic nesting.

--- a/src/simlin-engine/src/db/module_wiring_tests.rs
+++ b/src/simlin-engine/src/db/module_wiring_tests.rs
@@ -1,0 +1,141 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+//! Regression tests for the module input-wiring diagnostic
+//! (`model_module_wiring_diagnostics`).
+//!
+//! `build_module_inputs` silently drops a module reference whose `dst` does not
+//! name an input of the target model, so the port reads its default and the
+//! simulation is quietly wrong. The salsa compile path had lost the legacy
+//! `BadModuleInputDst`/`BadModuleInputSrc` check; these tests pin that a
+//! mis-wired input now surfaces a Warning while a correct (module-qualified)
+//! wiring and empty placeholder rows stay clean.
+
+use crate::common::{Error, ErrorCode};
+use crate::datamodel::{self, Equation, Variable, Visibility};
+use crate::db::{
+    Diagnostic, DiagnosticError, DiagnosticSeverity, SimlinDb, collect_all_diagnostics,
+    sync_from_datamodel,
+};
+use crate::test_common::TestProject;
+
+/// `main` with `local_input`, a `submodel` exposing input port `input_var`, and
+/// a module `m` in `main` whose single reference is `{ src, dst }`.
+fn project_with_reference(src: &str, dst: &str) -> datamodel::Project {
+    let mut project = TestProject::new("test")
+        .aux("local_input", "10", None)
+        .build_datamodel();
+
+    project.models.push(datamodel::Model {
+        name: "submodel".to_string(),
+        sim_specs: None,
+        variables: vec![Variable::Aux(datamodel::Aux {
+            ident: "input_var".to_string(),
+            equation: Equation::Scalar("0".to_string()),
+            documentation: String::new(),
+            units: None,
+            gf: None,
+            ai_state: None,
+            uid: None,
+            compat: datamodel::Compat {
+                can_be_module_input: true,
+                visibility: Visibility::Public,
+                ..datamodel::Compat::default()
+            },
+        })],
+        views: vec![],
+        loop_metadata: vec![],
+        groups: vec![],
+        macro_spec: None,
+    });
+
+    project.models[0]
+        .variables
+        .push(Variable::Module(datamodel::Module {
+            ident: "m".to_string(),
+            model_name: "submodel".to_string(),
+            documentation: String::new(),
+            units: None,
+            references: vec![datamodel::ModuleReference {
+                src: src.to_string(),
+                dst: dst.to_string(),
+            }],
+            compat: datamodel::Compat::default(),
+            ai_state: None,
+            uid: None,
+        }));
+
+    project
+}
+
+fn diagnostics(project: &datamodel::Project) -> Vec<Diagnostic> {
+    let db = SimlinDb::default();
+    let sync = sync_from_datamodel(&db, project);
+    collect_all_diagnostics(&db, sync.project)
+}
+
+fn has_warning(diags: &[Diagnostic], code: ErrorCode) -> bool {
+    diags.iter().any(|d| {
+        d.severity == DiagnosticSeverity::Warning
+            && matches!(&d.error, DiagnosticError::Model(Error { code: c, .. }) if *c == code)
+    })
+}
+
+/// A correctly module-qualified `dst` (`m·input_var`) wiring a real input port
+/// resolves cleanly -- no wiring diagnostic.
+#[test]
+fn qualified_dst_to_real_port_is_clean() {
+    let diags = diagnostics(&project_with_reference("local_input", "m·input_var"));
+    assert!(
+        !has_warning(&diags, ErrorCode::BadModuleInputDst),
+        "a correct module-qualified dst must not warn: {diags:?}"
+    );
+    assert!(!has_warning(&diags, ErrorCode::BadModuleInputSrc));
+}
+
+/// A BARE `dst` (the editor-bug shape: just the port name, missing the
+/// `module·` qualifier) never matches an input and is silently dropped at
+/// assembly -- it must warn.
+#[test]
+fn bare_dst_warns() {
+    let diags = diagnostics(&project_with_reference("local_input", "input_var"));
+    assert!(
+        has_warning(&diags, ErrorCode::BadModuleInputDst),
+        "a bare (unqualified) dst must surface a BadModuleInputDst warning: {diags:?}"
+    );
+}
+
+/// A qualified `dst` naming a port that does not exist in the child model warns.
+#[test]
+fn dangling_dst_port_warns() {
+    let diags = diagnostics(&project_with_reference("local_input", "m·nonexistent"));
+    assert!(
+        has_warning(&diags, ErrorCode::BadModuleInputDst),
+        "a dst naming a non-existent child input must warn: {diags:?}"
+    );
+}
+
+/// A bare `src` naming no variable in the enclosing model warns.
+#[test]
+fn dangling_src_warns() {
+    let diags = diagnostics(&project_with_reference("missing_var", "m·input_var"));
+    assert!(
+        has_warning(&diags, ErrorCode::BadModuleInputSrc),
+        "a src naming no parent variable must warn: {diags:?}"
+    );
+}
+
+/// Empty placeholder endpoints (the new-row UI pattern) are not wiring errors.
+#[test]
+fn empty_placeholder_reference_is_clean() {
+    let diags = diagnostics(&project_with_reference("", ""));
+    assert!(
+        !has_warning(&diags, ErrorCode::BadModuleInputDst),
+        "{diags:?}"
+    );
+    assert!(
+        !has_warning(&diags, ErrorCode::BadModuleInputSrc),
+        "{diags:?}"
+    );
+}

--- a/src/simlin-engine/src/db/query.rs
+++ b/src/simlin-engine/src/db/query.rs
@@ -16,7 +16,7 @@
 //! queries (`variable_relevant_dimensions`/`variable_dimensions`/
 //! `variable_size`).
 
-use std::collections::{BTreeSet, HashMap, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
 
 use super::*;
 use crate::common::{Canonical, Ident};
@@ -595,4 +595,132 @@ pub fn variable_size(db: &dyn Db, var: SourceVariable, project: SourceProject) -
     } else {
         dims.iter().map(|d| d.len()).product()
     }
+}
+
+/// Result of the project-wide module-reference cycle check.
+///
+/// `cycle_error` is `Some((code, message))` when the explicit module-instance
+/// graph -- each model's `Variable::Module` -> the model named by its
+/// `model_name` -- contains a cycle (a self-referential or mutually-recursive
+/// module). Such a graph makes the recursive `model_module_map` /
+/// `compute_layout` salsa queries loop, which salsa turns into an unrecoverable
+/// dependency-graph panic (the empty-`model_name` sibling of this class was
+/// fixed in c1c4c954; GH #806). Every production compile / diagnostic / analysis
+/// entry point consults this FIRST so a cycle surfaces as a clean
+/// `CircularDependency` error rather than aborting WASM.
+#[derive(Debug, Clone, PartialEq, Eq, salsa::Update)]
+pub struct ModuleCycleResult {
+    pub cycle_error: Option<(crate::common::ErrorCode, String)>,
+}
+
+/// Detect a cycle in the project's explicit module-instance graph.
+///
+/// Reads each model's module variables and their target `model_name`s (the same
+/// edges the recursive queries follow), then runs an iterative DFS. Implicit
+/// (SMOOTH/DELAY/TREND/stdlib) modules can only reference leaf stdlib models, so
+/// they can never close a user cycle and are intentionally omitted.
+#[salsa::tracked(returns(ref))]
+pub fn project_module_cycle(db: &dyn Db, project: SourceProject) -> ModuleCycleResult {
+    let models = project.models(db);
+
+    // Build the adjacency deterministically (sorted models, sorted vars) so the
+    // reported cycle is stable across processes and salsa invalidations.
+    let mut sorted_models: Vec<(&String, &SourceModel)> = models.iter().collect();
+    sorted_models.sort_by(|a, b| a.0.cmp(b.0));
+
+    let mut adjacency: BTreeMap<Ident<Canonical>, Vec<Ident<Canonical>>> = BTreeMap::new();
+    for (name, model) in sorted_models {
+        let model_ident: Ident<Canonical> = Ident::new(name);
+        let source_vars = model.variables(db);
+        let mut sorted_var_names: Vec<&String> = source_vars.keys().collect();
+        sorted_var_names.sort_unstable();
+
+        let mut targets = Vec::new();
+        for var_name in sorted_var_names {
+            let svar = &source_vars[var_name];
+            if svar.kind(db) == SourceVariableKind::Module {
+                let target = canonicalize(svar.model_name(db));
+                // Only follow targets that exist -- a dangling / empty
+                // `model_name` is not a cycle (and is handled elsewhere).
+                if models.contains_key(target.as_ref()) {
+                    targets.push(Ident::new(target.as_ref()));
+                }
+            }
+        }
+        adjacency.insert(model_ident, targets);
+    }
+
+    let cycle_error = find_module_reference_cycle(&adjacency).map(|cycle| {
+        let path = cycle
+            .iter()
+            .map(|m| m.as_str().to_string())
+            .collect::<Vec<_>>()
+            .join(" → ");
+        (
+            crate::common::ErrorCode::CircularDependency,
+            format!("circular module reference: {path}"),
+        )
+    });
+
+    ModuleCycleResult { cycle_error }
+}
+
+/// Pure 3-color DFS over the module-instance graph. Returns the first cycle as a
+/// closed path of model names (start repeated at the end), or `None` if acyclic.
+/// Iterative so a pathologically deep chain cannot overflow the stack.
+/// Deterministic given a sorted adjacency.
+fn find_module_reference_cycle(
+    adjacency: &BTreeMap<Ident<Canonical>, Vec<Ident<Canonical>>>,
+) -> Option<Vec<Ident<Canonical>>> {
+    #[derive(Clone, Copy, PartialEq)]
+    enum Color {
+        White,
+        Gray,
+        Black,
+    }
+
+    let mut color: BTreeMap<&Ident<Canonical>, Color> =
+        adjacency.keys().map(|k| (k, Color::White)).collect();
+
+    for root in adjacency.keys() {
+        if color[root] != Color::White {
+            continue;
+        }
+        // Each frame is (node, index of the next child to visit). `path` mirrors
+        // the Gray frames on the stack so a back-edge yields the exact cycle.
+        let mut stack: Vec<(&Ident<Canonical>, usize)> = vec![(root, 0)];
+        let mut path: Vec<&Ident<Canonical>> = vec![root];
+        color.insert(root, Color::Gray);
+
+        while let Some(&(node, child_idx)) = stack.last() {
+            let children = &adjacency[node];
+            if child_idx >= children.len() {
+                color.insert(node, Color::Black);
+                stack.pop();
+                path.pop();
+                continue;
+            }
+            stack.last_mut().unwrap().1 += 1;
+            let child = &children[child_idx];
+            match color.get(child).copied().unwrap_or(Color::Black) {
+                Color::White => {
+                    color.insert(child, Color::Gray);
+                    stack.push((child, 0));
+                    path.push(child);
+                }
+                Color::Gray => {
+                    // Back-edge: the cycle runs from `child`'s position in the
+                    // current path back to `node`, closed by `child` again.
+                    let start = path.iter().position(|n| *n == child).unwrap();
+                    let mut cycle: Vec<Ident<Canonical>> =
+                        path[start..].iter().map(|n| (*n).clone()).collect();
+                    cycle.push(child.clone());
+                    return Some(cycle);
+                }
+                Color::Black => {}
+            }
+        }
+    }
+
+    None
 }

--- a/src/simlin-engine/src/db/query.rs
+++ b/src/simlin-engine/src/db/query.rs
@@ -597,30 +597,110 @@ pub fn variable_size(db: &dyn Db, var: SourceVariable, project: SourceProject) -
     }
 }
 
-/// Result of the project-wide module-reference cycle check.
+/// The project's explicit module-instance graph: each model maps to the models
+/// its `Variable::Module`s instantiate (only existing targets -- the same edges
+/// the recursive `model_module_map` / `compute_layout` queries follow). Built
+/// with flat reads so cycle detection never recurses through salsa.
 ///
-/// `cycle_error` is `Some((code, message))` when the explicit module-instance
-/// graph -- each model's `Variable::Module` -> the model named by its
-/// `model_name` -- contains a cycle (a self-referential or mutually-recursive
-/// module). Such a graph makes the recursive `model_module_map` /
-/// `compute_layout` salsa queries loop, which salsa turns into an unrecoverable
-/// dependency-graph panic (the empty-`model_name` sibling of this class was
-/// fixed in c1c4c954; GH #806). Every production compile / diagnostic / analysis
-/// entry point consults this FIRST so a cycle surfaces as a clean
-/// `CircularDependency` error rather than aborting WASM.
+/// A cycle in this graph makes those recursive queries loop, which salsa turns
+/// into an unrecoverable dependency-graph panic (the empty-`model_name` sibling
+/// of this class was fixed in c1c4c954; GH #806). Every production compile /
+/// diagnostic / analysis entry point consults this FIRST -- scoped to the models
+/// reachable from the requested root -- so a cycle surfaces as a clean
+/// `CircularDependency` error rather than aborting WASM, WITHOUT rejecting a
+/// valid root just because an unrelated draft elsewhere in the project is cyclic.
 #[derive(Debug, Clone, PartialEq, Eq, salsa::Update)]
-pub struct ModuleCycleResult {
-    pub cycle_error: Option<(crate::common::ErrorCode, String)>,
+pub struct ModuleReferenceGraph {
+    edges: BTreeMap<Ident<Canonical>, Vec<Ident<Canonical>>>,
 }
 
-/// Detect a cycle in the project's explicit module-instance graph.
-///
-/// Reads each model's module variables and their target `model_name`s (the same
-/// edges the recursive queries follow), then runs an iterative DFS. Implicit
+impl ModuleReferenceGraph {
+    /// The first module cycle REACHABLE FROM `root` as a closed path of model
+    /// names (start repeated at the end), or `None` if `root`'s reachable
+    /// subgraph is acyclic (or `root` names no model). Iterative 3-color DFS so a
+    /// pathologically deep chain cannot overflow the stack; deterministic given
+    /// the sorted adjacency. Scoping to reachability is what keeps an unrelated
+    /// draft cycle from rejecting a compile of `root` -- the recursive queries
+    /// only loop for modules under the requested root.
+    pub fn cycle_reachable_from(&self, root: &str) -> Option<Vec<Ident<Canonical>>> {
+        let root_ident: Ident<Canonical> = Ident::new(root);
+        if !self.edges.contains_key(&root_ident) {
+            return None;
+        }
+
+        #[derive(Clone, Copy, PartialEq)]
+        enum Color {
+            Gray,
+            Black,
+        }
+
+        // `path` mirrors the Gray frames currently on the stack, so a back-edge
+        // yields the exact cycle. Owned idents keep the borrow simple; the graph
+        // is model-sized, so the clones are cheap.
+        let mut color: BTreeMap<Ident<Canonical>, Color> = BTreeMap::new();
+        let mut stack: Vec<(Ident<Canonical>, usize)> = vec![(root_ident.clone(), 0)];
+        let mut path: Vec<Ident<Canonical>> = vec![root_ident.clone()];
+        color.insert(root_ident, Color::Gray);
+
+        while let Some((node, child_idx)) = stack.last().cloned() {
+            let Some(children) = self.edges.get(&node) else {
+                stack.pop();
+                path.pop();
+                continue;
+            };
+            if child_idx >= children.len() {
+                color.insert(node, Color::Black);
+                stack.pop();
+                path.pop();
+                continue;
+            }
+            stack.last_mut().unwrap().1 += 1;
+            let child = children[child_idx].clone();
+            match color.get(&child).copied() {
+                Some(Color::Gray) => {
+                    // Back-edge: the cycle runs from `child`'s position in the
+                    // current path, closed by `child` again.
+                    let start = path.iter().position(|n| *n == child).unwrap();
+                    let mut cycle = path[start..].to_vec();
+                    cycle.push(child);
+                    return Some(cycle);
+                }
+                Some(Color::Black) => {}
+                None => {
+                    color.insert(child.clone(), Color::Gray);
+                    stack.push((child.clone(), 0));
+                    path.push(child);
+                }
+            }
+        }
+
+        None
+    }
+
+    /// Formats a cycle reachable from `root` as a `(CircularDependency, message)`
+    /// diagnostic pair, or `None` if `root` reaches no cycle.
+    pub fn cycle_error_from(&self, root: &str) -> Option<(crate::common::ErrorCode, String)> {
+        self.cycle_reachable_from(root).map(|cycle| {
+            let path = cycle
+                .iter()
+                .map(|m| m.as_str().to_string())
+                .collect::<Vec<_>>()
+                .join(" → ");
+            (
+                crate::common::ErrorCode::CircularDependency,
+                format!("circular module reference: {path}"),
+            )
+        })
+    }
+}
+
+/// Build the project's explicit module-instance graph (see
+/// [`ModuleReferenceGraph`]). Reads each model's module variables and their
+/// target `model_name`s with flat salsa reads (no recursion). Implicit
 /// (SMOOTH/DELAY/TREND/stdlib) modules can only reference leaf stdlib models, so
 /// they can never close a user cycle and are intentionally omitted.
 #[salsa::tracked(returns(ref))]
-pub fn project_module_cycle(db: &dyn Db, project: SourceProject) -> ModuleCycleResult {
+pub fn project_module_graph(db: &dyn Db, project: SourceProject) -> ModuleReferenceGraph {
     let models = project.models(db);
 
     // Build the adjacency deterministically (sorted models, sorted vars) so the
@@ -628,7 +708,7 @@ pub fn project_module_cycle(db: &dyn Db, project: SourceProject) -> ModuleCycleR
     let mut sorted_models: Vec<(&String, &SourceModel)> = models.iter().collect();
     sorted_models.sort_by(|a, b| a.0.cmp(b.0));
 
-    let mut adjacency: BTreeMap<Ident<Canonical>, Vec<Ident<Canonical>>> = BTreeMap::new();
+    let mut edges: BTreeMap<Ident<Canonical>, Vec<Ident<Canonical>>> = BTreeMap::new();
     for (name, model) in sorted_models {
         let model_ident: Ident<Canonical> = Ident::new(name);
         let source_vars = model.variables(db);
@@ -647,80 +727,8 @@ pub fn project_module_cycle(db: &dyn Db, project: SourceProject) -> ModuleCycleR
                 }
             }
         }
-        adjacency.insert(model_ident, targets);
+        edges.insert(model_ident, targets);
     }
 
-    let cycle_error = find_module_reference_cycle(&adjacency).map(|cycle| {
-        let path = cycle
-            .iter()
-            .map(|m| m.as_str().to_string())
-            .collect::<Vec<_>>()
-            .join(" → ");
-        (
-            crate::common::ErrorCode::CircularDependency,
-            format!("circular module reference: {path}"),
-        )
-    });
-
-    ModuleCycleResult { cycle_error }
-}
-
-/// Pure 3-color DFS over the module-instance graph. Returns the first cycle as a
-/// closed path of model names (start repeated at the end), or `None` if acyclic.
-/// Iterative so a pathologically deep chain cannot overflow the stack.
-/// Deterministic given a sorted adjacency.
-fn find_module_reference_cycle(
-    adjacency: &BTreeMap<Ident<Canonical>, Vec<Ident<Canonical>>>,
-) -> Option<Vec<Ident<Canonical>>> {
-    #[derive(Clone, Copy, PartialEq)]
-    enum Color {
-        White,
-        Gray,
-        Black,
-    }
-
-    let mut color: BTreeMap<&Ident<Canonical>, Color> =
-        adjacency.keys().map(|k| (k, Color::White)).collect();
-
-    for root in adjacency.keys() {
-        if color[root] != Color::White {
-            continue;
-        }
-        // Each frame is (node, index of the next child to visit). `path` mirrors
-        // the Gray frames on the stack so a back-edge yields the exact cycle.
-        let mut stack: Vec<(&Ident<Canonical>, usize)> = vec![(root, 0)];
-        let mut path: Vec<&Ident<Canonical>> = vec![root];
-        color.insert(root, Color::Gray);
-
-        while let Some(&(node, child_idx)) = stack.last() {
-            let children = &adjacency[node];
-            if child_idx >= children.len() {
-                color.insert(node, Color::Black);
-                stack.pop();
-                path.pop();
-                continue;
-            }
-            stack.last_mut().unwrap().1 += 1;
-            let child = &children[child_idx];
-            match color.get(child).copied().unwrap_or(Color::Black) {
-                Color::White => {
-                    color.insert(child, Color::Gray);
-                    stack.push((child, 0));
-                    path.push(child);
-                }
-                Color::Gray => {
-                    // Back-edge: the cycle runs from `child`'s position in the
-                    // current path back to `node`, closed by `child` again.
-                    let start = path.iter().position(|n| *n == child).unwrap();
-                    let mut cycle: Vec<Ident<Canonical>> =
-                        path[start..].iter().map(|n| (*n).clone()).collect();
-                    cycle.push(child.clone());
-                    return Some(cycle);
-                }
-                Color::Black => {}
-            }
-        }
-    }
-
-    None
+    ModuleReferenceGraph { edges }
 }

--- a/src/simlin-engine/src/model.rs
+++ b/src/simlin-engine/src/model.rs
@@ -170,7 +170,14 @@ fn module_deps(
     } = var
     {
         if ctx.is_initial {
-            let model = ctx.models[model_name];
+            // A module may reference a model that is not present (an empty or
+            // dangling `model_name`: a freshly-drawn module or a reference to a
+            // deleted model). Skip its submodel deps gracefully rather than
+            // indexing `ctx.models` and panicking -- mirroring the guarded twin
+            // in `module_output_deps` (GH #806).
+            let Some(model) = ctx.models.get(model_name).copied() else {
+                return vec![];
+            };
             // FIXME: do this higher up
             let module_inputs = &inputs.iter().map(|mi| mi.dst.clone()).collect();
             if let Some(initial_deps) = model.initial_deps(module_inputs) {

--- a/src/simlin-engine/src/patch.rs
+++ b/src/simlin-engine/src/patch.rs
@@ -189,6 +189,17 @@ fn canonicalize_aux(aux: &mut datamodel::Aux) {
 
 fn canonicalize_module(module: &mut datamodel::Module) {
     canonicalize_ident(&mut module.ident);
+    // Canonicalize the reference endpoints too, mirroring `canonicalize_stock`'s
+    // inflow/outflow canonicalization. `src`/`dst` are variable idents (`dst` is
+    // the module-qualified `module·port` form); leaving them verbatim lets a
+    // non-canonical `src`/`dst` arriving via the FFI `apply_patch`
+    // (pysimlin `upsert_module`) disagree with the canonical idents every
+    // UI/engine consumer compares against. Empty placeholder endpoints
+    // canonicalize to empty and are preserved.
+    for reference in module.references.iter_mut() {
+        canonicalize_ident(&mut reference.src);
+        canonicalize_ident(&mut reference.dst);
+    }
 }
 
 fn get_uid(var: &Variable) -> Option<i32> {
@@ -436,6 +447,20 @@ fn apply_delete_variable(model: &mut datamodel::Model, ident_str: &str) -> Resul
         }
     }
 
+    // Drop any module input wiring whose `src` named the deleted variable.
+    // Mirrors the stock-flow and group-member cleanup above: a left-behind
+    // `src` becomes a dependency on a non-existent variable, making the whole
+    // project fail to compile with a confusing "missing variable" message. The
+    // rename path already rewrites module references; the delete path was the
+    // asymmetric gap.
+    for var in model.variables.iter_mut() {
+        if let Variable::Module(module) = var {
+            module
+                .references
+                .retain(|reference| canonicalize(reference.src.as_str()) != ident);
+        }
+    }
+
     for group in model.groups.iter_mut() {
         group
             .members
@@ -505,7 +530,52 @@ fn apply_rename_variable(
         var.set_ident(new_ident.as_str().to_string());
     }
 
+    // Cross-model fix-up: the variable just renamed may be a module INPUT PORT.
+    // Every PARENT module that instantiates this model wires into the OLD port
+    // name via its `dst` (the module-qualified `module·port` form), and those
+    // references live in OTHER models that the single-model rename above never
+    // visits. Without retargeting them the parent silently feeds the renamed
+    // port its default value -- wrong numbers, no error.
+    retarget_parent_module_dst(project, model_name, &old_ident, &new_ident);
+
     Ok(())
+}
+
+/// Retarget the `dst` of every parent module reference that wires into the
+/// just-renamed input port of `target_model_name`.
+///
+/// A module reference `dst` is the canonical `{module_ident}·{port}` form (see
+/// `build_module_inputs`). For each module instance pointing at
+/// `target_model_name`, rewrite a reference whose port suffix names `old_ident`
+/// to name `new_ident`. Gated on the module's target model so an unrelated model
+/// with a like-named variable is untouched.
+fn retarget_parent_module_dst(
+    project: &mut datamodel::Project,
+    target_model_name: &str,
+    old_ident: &Ident<Canonical>,
+    new_ident: &Ident<Canonical>,
+) {
+    let target_canonical = canonicalize(target_model_name);
+    for model in project.models.iter_mut() {
+        for var in model.variables.iter_mut() {
+            let Variable::Module(module) = var else {
+                continue;
+            };
+            if canonicalize(module.model_name.as_str()) != target_canonical {
+                continue;
+            }
+            let prefix = format!("{}\u{00B7}", canonicalize(module.ident.as_str()));
+            for reference in module.references.iter_mut() {
+                let dst_canonical = canonicalize(reference.dst.as_str());
+                let Some(port) = dst_canonical.strip_prefix(prefix.as_str()) else {
+                    continue;
+                };
+                if canonicalize(port).as_ref() == old_ident.as_str() {
+                    reference.dst = format!("{prefix}{}", new_ident.as_str());
+                }
+            }
+        }
+    }
 }
 
 fn rename_model_equations(
@@ -2315,6 +2385,244 @@ mod tests {
                 assert_eq!(m.references.len(), 1);
                 assert_eq!(m.references[0].src, "local_input");
                 assert_eq!(m.references[0].dst, "input_var");
+            }
+            _ => panic!("expected module"),
+        }
+    }
+
+    /// A parent `main` with `local_input`, a `submodel` exposing an input port
+    /// (`input_var`) and a public `output = input_var * 2`, and `main` holding
+    /// `my_module` wired `local_input -> input_var` plus a `reader` of the
+    /// module output. With the wiring intact `reader` simulates to 20.
+    fn project_with_wired_module() -> datamodel::Project {
+        let mut project = TestProject::new("test")
+            .aux("local_input", "10", None)
+            .build_datamodel();
+
+        project.models[0]
+            .variables
+            .push(Variable::Aux(datamodel::Aux {
+                ident: "reader".to_string(),
+                equation: Equation::Scalar("my_module·output".to_string()),
+                documentation: String::new(),
+                units: None,
+                gf: None,
+                ai_state: None,
+                uid: None,
+                compat: datamodel::Compat::default(),
+            }));
+
+        project.models.push(datamodel::Model {
+            name: "submodel".to_string(),
+            sim_specs: None,
+            variables: vec![
+                Variable::Aux(datamodel::Aux {
+                    ident: "input_var".to_string(),
+                    equation: Equation::Scalar("0".to_string()),
+                    documentation: String::new(),
+                    units: None,
+                    gf: None,
+                    ai_state: None,
+                    uid: None,
+                    compat: datamodel::Compat {
+                        can_be_module_input: true,
+                        visibility: Visibility::Public,
+                        ..datamodel::Compat::default()
+                    },
+                }),
+                Variable::Aux(datamodel::Aux {
+                    ident: "output".to_string(),
+                    equation: Equation::Scalar("input_var * 2".to_string()),
+                    documentation: String::new(),
+                    units: None,
+                    gf: None,
+                    ai_state: None,
+                    uid: None,
+                    compat: datamodel::Compat {
+                        visibility: Visibility::Public,
+                        ..datamodel::Compat::default()
+                    },
+                }),
+            ],
+            views: vec![],
+            loop_metadata: vec![],
+            groups: vec![],
+            macro_spec: None,
+        });
+
+        let module = datamodel::Module {
+            ident: "my_module".to_string(),
+            model_name: "submodel".to_string(),
+            documentation: String::new(),
+            units: None,
+            references: vec![datamodel::ModuleReference {
+                src: "local_input".to_string(),
+                dst: "my_module·input_var".to_string(),
+            }],
+            compat: datamodel::Compat::default(),
+            ai_state: None,
+            uid: None,
+        };
+        apply_patch(
+            &mut project,
+            ProjectPatch {
+                project_ops: vec![],
+                models: vec![ModelPatch {
+                    name: "main".to_string(),
+                    ops: vec![ModelOperation::UpsertModule(module)],
+                }],
+            },
+        )
+        .unwrap();
+        project
+    }
+
+    fn reader_value(project: &datamodel::Project) -> f64 {
+        let series = TestProject::from_datamodel(project.clone()).vm_result("reader");
+        *series.last().expect("reader produced no samples")
+    }
+
+    /// Regression for the asymmetric delete cleanup: `apply_delete_variable`
+    /// pruned deleted flows from stock in/outflows and group members, but left
+    /// module references whose `src` named the deleted variable -- a dangling
+    /// dependency on a non-existent variable that made the whole project fail to
+    /// compile with a confusing "missing variable" message.
+    #[test]
+    fn delete_variable_prunes_dangling_module_src() {
+        let mut project = project_with_wired_module();
+        assert!((reader_value(&project) - 20.0).abs() < 1e-6);
+
+        apply_patch(
+            &mut project,
+            ProjectPatch {
+                project_ops: vec![],
+                models: vec![ModelPatch {
+                    name: "main".to_string(),
+                    ops: vec![ModelOperation::DeleteVariable {
+                        ident: "local_input".to_string(),
+                    }],
+                }],
+            },
+        )
+        .unwrap();
+
+        match project
+            .get_model("main")
+            .unwrap()
+            .get_variable("my_module")
+            .unwrap()
+        {
+            Variable::Module(m) => assert!(
+                m.references.is_empty(),
+                "deleted variable still wired as a module src: {:?}",
+                m.references
+            ),
+            _ => panic!("expected module"),
+        }
+
+        // The project must still compile and simulate (the module is now
+        // unwired, so its input falls back to the port default of 0).
+        TestProject::from_datamodel(project.clone()).assert_compiles_incremental();
+        assert!((reader_value(&project) - 0.0).abs() < 1e-6);
+    }
+
+    /// Regression for the cross-model rename gap: renaming a child model's input
+    /// port left every parent module's `dst` pointing at the old name, so the
+    /// parent silently fed the renamed port its default value (wrong numbers, no
+    /// error). The rename must retarget parent module references too.
+    #[test]
+    fn rename_child_input_port_retargets_parent_module_dst() {
+        let mut project = project_with_wired_module();
+        assert!((reader_value(&project) - 20.0).abs() < 1e-6);
+
+        apply_patch(
+            &mut project,
+            ProjectPatch {
+                project_ops: vec![],
+                models: vec![ModelPatch {
+                    name: "submodel".to_string(),
+                    ops: vec![ModelOperation::RenameVariable {
+                        from: "input_var".to_string(),
+                        to: "renamed_port".to_string(),
+                    }],
+                }],
+            },
+        )
+        .unwrap();
+
+        match project
+            .get_model("main")
+            .unwrap()
+            .get_variable("my_module")
+            .unwrap()
+        {
+            Variable::Module(m) => {
+                assert_eq!(m.references.len(), 1);
+                assert_eq!(
+                    m.references[0].dst, "my_module·renamed_port",
+                    "parent module dst did not follow the child input-port rename"
+                );
+            }
+            _ => panic!("expected module"),
+        }
+
+        // The wiring must still carry local_input(10) -> renamed_port -> 20.
+        assert!((reader_value(&project) - 20.0).abs() < 1e-6);
+    }
+
+    /// `canonicalize_module` canonicalized only the module ident, leaving the
+    /// reference endpoints verbatim -- so a non-canonical `src`/`dst` arriving
+    /// via the FFI `apply_patch` (pysimlin `upsert_module`) disagreed with the
+    /// canonical idents every UI/engine consumer compares against. Mirror
+    /// `canonicalize_stock`'s inflow/outflow canonicalization.
+    #[test]
+    fn upsert_module_canonicalizes_references() {
+        let mut project = TestProject::new("test").build_datamodel();
+        project.models.push(datamodel::Model {
+            name: "submodel".to_string(),
+            sim_specs: None,
+            variables: vec![],
+            views: vec![],
+            loop_metadata: vec![],
+            groups: vec![],
+            macro_spec: None,
+        });
+
+        let module = datamodel::Module {
+            ident: "My Module".to_string(),
+            model_name: "submodel".to_string(),
+            documentation: String::new(),
+            units: None,
+            references: vec![datamodel::ModuleReference {
+                src: "Local Input".to_string(),
+                dst: "My Module·Input Var".to_string(),
+            }],
+            compat: datamodel::Compat::default(),
+            ai_state: None,
+            uid: None,
+        };
+
+        apply_patch(
+            &mut project,
+            ProjectPatch {
+                project_ops: vec![],
+                models: vec![ModelPatch {
+                    name: "main".to_string(),
+                    ops: vec![ModelOperation::UpsertModule(module)],
+                }],
+            },
+        )
+        .unwrap();
+
+        match project
+            .get_model("main")
+            .unwrap()
+            .get_variable("my_module")
+            .unwrap()
+        {
+            Variable::Module(m) => {
+                assert_eq!(m.references[0].src, "local_input");
+                assert_eq!(m.references[0].dst, "my_module·input_var");
             }
             _ => panic!("expected module"),
         }

--- a/src/simlin-engine/src/patch.rs
+++ b/src/simlin-engine/src/patch.rs
@@ -528,6 +528,22 @@ fn apply_rename_variable(
 
     if let Some(var) = model.variables.get_mut(target_index) {
         var.set_ident(new_ident.as_str().to_string());
+
+        // If the renamed variable is itself a module instance, its OWN input
+        // references carry the module-qualified `{old}·{port}` dst prefix. The
+        // engine rebuilds inputs under the new `{new}·` prefix and would drop a
+        // stale `{old}·port` reference, silently unwiring every input. Reprefix
+        // them so the wiring survives renaming the module variable.
+        if let Variable::Module(module) = var {
+            let old_prefix = format!("{}\u{00B7}", old_ident.as_str());
+            let new_prefix = format!("{}\u{00B7}", new_ident.as_str());
+            for reference in module.references.iter_mut() {
+                let dst_canonical = canonicalize(reference.dst.as_str());
+                if let Some(port) = dst_canonical.strip_prefix(old_prefix.as_str()) {
+                    reference.dst = format!("{new_prefix}{port}");
+                }
+            }
+        }
     }
 
     // Cross-model fix-up: the variable just renamed may be a module INPUT PORT.
@@ -2568,6 +2584,101 @@ mod tests {
 
         // The wiring must still carry local_input(10) -> renamed_port -> 20.
         assert!((reader_value(&project) - 20.0).abs() < 1e-6);
+    }
+
+    /// Renaming the MODULE VARIABLE itself must reprefix its own input
+    /// references: `dst` is the module-qualified `{moduleIdent}·{port}` form, so
+    /// after `my_module` -> `renamed_module` the engine rebuilds inputs under the
+    /// `renamed_module·` prefix and would drop a stale `my_module·input_var`
+    /// reference, silently unwiring the input. Regression for the Codex review
+    /// finding on PR #807.
+    #[test]
+    fn rename_module_variable_retargets_its_own_dst_prefix() {
+        // A minimal module-with-input fixture (no output reader, so the test is
+        // not entangled with module-output reference renaming).
+        let mut project = TestProject::new("test")
+            .aux("local_input", "10", None)
+            .build_datamodel();
+        project.models.push(datamodel::Model {
+            name: "submodel".to_string(),
+            sim_specs: None,
+            variables: vec![Variable::Aux(datamodel::Aux {
+                ident: "input_var".to_string(),
+                equation: Equation::Scalar("0".to_string()),
+                documentation: String::new(),
+                units: None,
+                gf: None,
+                ai_state: None,
+                uid: None,
+                compat: datamodel::Compat {
+                    can_be_module_input: true,
+                    visibility: Visibility::Public,
+                    ..datamodel::Compat::default()
+                },
+            })],
+            views: vec![],
+            loop_metadata: vec![],
+            groups: vec![],
+            macro_spec: None,
+        });
+        apply_patch(
+            &mut project,
+            ProjectPatch {
+                project_ops: vec![],
+                models: vec![ModelPatch {
+                    name: "main".to_string(),
+                    ops: vec![ModelOperation::UpsertModule(datamodel::Module {
+                        ident: "my_module".to_string(),
+                        model_name: "submodel".to_string(),
+                        documentation: String::new(),
+                        units: None,
+                        references: vec![datamodel::ModuleReference {
+                            src: "local_input".to_string(),
+                            dst: "my_module·input_var".to_string(),
+                        }],
+                        compat: datamodel::Compat::default(),
+                        ai_state: None,
+                        uid: None,
+                    })],
+                }],
+            },
+        )
+        .unwrap();
+
+        apply_patch(
+            &mut project,
+            ProjectPatch {
+                project_ops: vec![],
+                models: vec![ModelPatch {
+                    name: "main".to_string(),
+                    ops: vec![ModelOperation::RenameVariable {
+                        from: "my_module".to_string(),
+                        to: "renamed_module".to_string(),
+                    }],
+                }],
+            },
+        )
+        .unwrap();
+
+        match project
+            .get_model("main")
+            .unwrap()
+            .get_variable("renamed_module")
+            .unwrap()
+        {
+            Variable::Module(m) => {
+                assert_eq!(m.references.len(), 1);
+                assert_eq!(
+                    m.references[0].dst, "renamed_module·input_var",
+                    "the module's own dst prefix did not follow the module-variable rename"
+                );
+            }
+            _ => panic!("expected module"),
+        }
+
+        // The input must still resolve (the engine strips the new prefix and
+        // wires local_input into the child port), so the project still compiles.
+        TestProject::from_datamodel(project).assert_compiles_incremental();
     }
 
     /// `canonicalize_module` canonicalized only the module ident, leaving the

--- a/src/simlin-engine/src/project.rs
+++ b/src/simlin-engine/src/project.rs
@@ -304,4 +304,34 @@ mod tests {
             unit_errs,
         );
     }
+
+    /// A module referencing a model that does not exist must not panic the
+    /// legacy `from_salsa` construction path (GH #806): `module_deps`'
+    /// initial-branch HashMap index and `topo_sort`'s unknown-ident assertion
+    /// both degrade gracefully instead of crashing with an "internal compiler
+    /// error" on this user-controllable input (a freshly-drawn module, or a
+    /// reference to a deleted model). The production salsa path already rejects
+    /// such a project cleanly; this guards the test-only oracle path too.
+    #[test]
+    fn from_salsa_module_with_missing_model_does_not_panic() {
+        use crate::testutils::{sim_specs_with_units, x_aux, x_model, x_project};
+
+        let module = datamodel::Variable::Module(datamodel::Module {
+            ident: "m".to_string(),
+            model_name: "nonexistent".to_string(),
+            documentation: String::new(),
+            units: None,
+            references: vec![],
+            compat: datamodel::Compat::default(),
+            ai_state: None,
+            uid: None,
+        });
+        let model = x_model("main", vec![x_aux("x", "1", None), module]);
+        let dm = x_project(sim_specs_with_units("years"), &[model]);
+
+        // Drives Project::from_datamodel -> from_salsa -> set_dependencies ->
+        // module_deps / topo_sort. Before the guards these panicked on the
+        // dangling model_name; now construction returns without crashing.
+        let _project = Project::from(dm);
+    }
 }


### PR DESCRIPTION
## Why

Commit c1c4c954 fixed a WASM panic where a freshly-drawn module (empty `model_name`) crashed unit inference. That was one instance of a broader **dangling / empty / cyclic / mis-wired module-reference** bug class. An adversarial audit of the module-editing feature (engine patch/compile pipeline, the JSON/FFI boundary, MCP, and the diagram controller) surfaced five more production-reachable issues plus one severe lurking bug; this PR fixes all of them, each with tests that reproduce the failure end to end.

## Fixes

**`engine: keep module references consistent under edits`** — module wiring stores a parent `src` and a module-qualified `module·port` `dst`, which the patch layer was not keeping consistent across structural edits:
- `apply_delete_variable` pruned deleted flows from stocks and groups but left module references whose `src` named the deleted variable, so deleting a wired-in parent variable left a dangling dependency and the whole project failed to compile with a confusing "missing variable" error. It now prunes those references too.
- `apply_rename_variable` rewrote module references only within the renamed variable's own model. Renaming a *child* model's input port left every parent module's `dst` pointing at the old name, silently feeding the renamed port its default value (wrong numbers, no error). The rename now retargets the qualified `dst` suffix of every module instance that targets the renamed model.
- `canonicalize_module` canonicalized only the module ident, so a non-canonical `src`/`dst` arriving via the FFI `apply_patch` (pysimlin `upsert_module`) disagreed with the canonical idents every consumer compares against. It now canonicalizes the endpoints, mirroring `canonicalize_stock`.

**`engine: reject cyclic module graphs instead of panicking`** — nothing checked that the module-instance graph is acyclic, so a self-referential or mutually-recursive module drove the recursive salsa queries (`model_module_map`, `compute_layout`) into a dependency-graph cycle, which salsa turns into an unrecoverable panic — reached from MCP `edit_model`/`read_model` and from importing a hand-authored recursive model, aborting WASM. A new `project_module_cycle` query detects the cycle with flat reads + an iterative DFS (no recursive salsa) and the three compile / diagnostic / analysis entry points fail cleanly with a `CircularDependency` error instead. This is the **production-reachable cousin** of the `from_salsa` panic class tracked in #806 — #806's own dead legacy sites are not reachable from production and are left as tracked; the live path is what this guards.

**`engine: warn on unresolved module input wiring`** — `build_module_inputs` silently drops a reference whose `dst` does not match an existing child input, so the port reads its default and the simulation is quietly wrong with no error. The legacy compile path returned `BadModuleInputDst`/`BadModuleInputSrc`; the salsa path had dropped the check. A new diagnostic pass re-adds it as a **Warning** (partial-result philosophy — a mis-wired input should not block the rest of the model), deliberately conservative to avoid false positives (empty placeholder rows skipped, only existing target models checked, qualified/synthetic `src`s left alone).

**`diagram: persist module input dst in the engine-qualified form`** (the lurking bug) — the wiring UI dropdown yields a *bare* child port name, and `ModuleDetails` persisted that bare value straight into the reference `dst`. But the engine wires inputs by the canonical `module·port` form and silently drops a `dst` that lacks the prefix, so **every module input wired through the editor failed to connect**. XMILE import already produces the qualified form, so this was an editor-only divergence from the datamodel contract. The fix qualifies the port on persist and strips it on display (pure `qualifyDst`/`unqualifyDst` helpers), tolerating a legacy `.` separator on read.

**`core: cover module serialization edge cases`** — the only Module round-trip test exercised a fully-populated module. Added cases for the empty-`modelName` freshly-drawn state (the c1c4c954 panic shape; the empty name is a required Rust `String`), placeholder references with empty `src`/`dst`, and a module-qualified `dst` whose middot must survive the JSON round trip.

## Non-obvious decisions

- **Cycle detection lives in the engine, not the frontend.** The diagram's `wouldCreateCycle` only filters the model-reference dropdown and is bypassed by MCP and file-import, so the engine must own the guard for every entry point.
- **The wiring check is a Warning, not a hard error**, matching the engine's partial-result philosophy and avoiding breaking existing models with benign dangling references; the structural fixes (delete-prune, rename-retarget, editor qualification) close the ways these arise in the first place.
- **`dst` is qualified in the editor, not bare.** The canonical datamodel/XMILE representation is `module·port`; making the editor conform (rather than making the engine accept bare `dst`) keeps a single representation across import/export/edit.

## Testing

Every fix ships with a test that reproduces the original failure: the engine patch tests compile and simulate a wired module (asserting the value flows, or cleanly drops to the port default); the cycle tests assert a clean error across compile, diagnostics, and analysis (and that valid nesting does not false-positive); the wiring-diagnostic tests pin bare/dangling `dst` and `src` warnings while a correct wiring and empty rows stay clean; the diagram tests cover the qualify/unqualify helpers and the UI persist/display round trip; and the core tests cover the serialization edge cases. Each commit was gated by the full pre-commit suite (Rust fmt/clippy/test, TypeScript lint/build/tsc/test, pysimlin).

Related: #806 (the production-reachable cousin of that dangling-reference panic class is fixed here; #806's specific dead `from_salsa` sites remain tracked).