### PR TITLE
[codex] harden production rollout

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -1,5 +1,8 @@
 runtime: nodejs24
 
+build_env_variables:
+  GOOGLE_NODE_RUN_SCRIPTS: ''
+
 instance_class: F4
 automatic_scaling:
   max_concurrent_requests: 100
@@ -13,11 +16,17 @@ handlers:
   static_files: public/index.html
   upload: public/index.html
   secure: always
+  http_headers:
+    Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
+    Content-Security-Policy: "default-src 'self'; frame-src 'self' https://simlin.firebaseapp.com https://auth.simlin.com; base-uri 'self'; block-all-mixed-content; connect-src 'self' https://www.googleapis.com https://securetoken.googleapis.com https://identitytoolkit.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; frame-ancestors 'self'; img-src 'self' data: blob: https://*.googleusercontent.com https://www.gstatic.com; object-src 'none'; script-src 'self' blob: 'unsafe-eval' https://apis.google.com; script-src-attr 'none'; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; upgrade-insecure-requests"
 
 - url: /new$
   static_files: public/index.html
   upload: public/index.html
   secure: always
+  http_headers:
+    Strict-Transport-Security: "max-age=31536000; includeSubDomains; preload"
+    Content-Security-Policy: "default-src 'self'; frame-src 'self' https://simlin.firebaseapp.com https://auth.simlin.com; base-uri 'self'; block-all-mixed-content; connect-src 'self' https://www.googleapis.com https://securetoken.googleapis.com https://identitytoolkit.googleapis.com; font-src 'self' data: https://fonts.gstatic.com; frame-ancestors 'self'; img-src 'self' data: blob: https://*.googleusercontent.com https://www.gstatic.com; object-src 'none'; script-src 'self' blob: 'unsafe-eval' https://apis.google.com; script-src-attr 'none'; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; upgrade-insecure-requests"
 
 - url: /(legal|legal/cookies|privacy)$
   static_files: public/\1/index.html

--- a/docs/dev/deploy.md
+++ b/docs/dev/deploy.md
@@ -70,7 +70,8 @@ On the instance GAE runs `pnpm install`, then the root `start` script: `node src
 `app.yaml` is committed; `.app.prod.yaml` is gitignored and lives only on your machine, and `pnpm deploy:web` deploys `.app.prod.yaml`. Treat the committed `app.yaml` as the reference -- it carries the handler routes and the `runtime` / `instance_class` / scaling block production should match. Diff `.app.prod.yaml` against it before deploying:
 
 - `runtime`: `nodejs24`. (`nodejs18` is EOL on GAE; `nodejs16`, the runtime of the last deploy before May 2026, is gone entirely -- which is why there's no "redeploy the old commit" rollback.)
-- The handler list: `/static`, `/`, `/new`, `/legal*`, `/privacy`, `robots.txt`, `ads.txt`, favicon, `manifest.json`, then `/.*` -> `script: auto`. The SPA's dynamic routes like `/:username/:projectName` fall through to `/.*`, i.e. the Express server.
+- `build_env_variables.GOOGLE_NODE_RUN_SCRIPTS`: `''`. The local deploy script already runs the monorepo build and stages the exact artifact to upload; this prevents App Engine's Node buildpack from running the root `build` script again during staging.
+- The handler list: `/static`, `/`, `/new`, `/legal*`, `/privacy`, `robots.txt`, `ads.txt`, favicon, `manifest.json`, then `/.*` -> `script: auto`. The `/` and `/new` static HTML handlers carry CSP/HSTS headers because they bypass Express Helmet. The SPA's dynamic routes like `/:username/:projectName` fall through to `/.*`, i.e. the Express server.
 - `env_variables`: the committed `app.yaml` has none; the server needs a couple (next section). They live in `.app.prod.yaml`.
 
 GAE ignores `app.yaml`'s `skip_files` when a `.gcloudignore` exists (it does), so `skip_files` in `.app.prod.yaml` is dead -- maintain `.gcloudignore` instead.
@@ -92,7 +93,7 @@ The server loads `config/default.json`, then `config/production.json` when `NODE
 - [ ] `git status` is clean.
 - [ ] `gcloud config get-value project` is the production project.
 - [ ] `gcloud app versions list --service=default` shows a known-good current version -- note its ID, that's your rollback target. (If GAE has garbage-collected it, there is no rollback; see below.)
-- [ ] `.app.prod.yaml` reconciled against `app.yaml` (`runtime: nodejs24`, handlers, `authentication__seshcookie__key` set to the value already in use).
+- [ ] `.app.prod.yaml` reconciled against `app.yaml` (`runtime: nodejs24`, `build_env_variables.GOOGLE_NODE_RUN_SCRIPTS: ''`, handlers, `authentication__seshcookie__key` set to the value already in use).
 - [ ] `wasm-opt --version` works; `rustup show` lists the `wasm32-unknown-unknown` target.
 
 ## Post-deploy smoke test

--- a/docs/tech-debt.md
+++ b/docs/tech-debt.md
@@ -527,15 +527,6 @@ Known debt items consolidated from CLAUDE.md files and codebase analysis. Each e
 - **Owner**: unassigned
 - **Last reviewed**: 2026-05-08
 
-### 56. y_points.len() - 1 underflows to usize::MAX in JSON GraphicalFunction
-
-- **Component**: simlin-engine (`src/simlin-engine/src/json.rs:692-695`)
-- **Severity**: medium
-- **Description**: When deserialising a JSON `GraphicalFunction` with no explicit `x_scale`, the default `x_scale.max` is `(y_points.len() - 1) as f64`. If `y_points` is empty, `0_usize - 1` wraps to `usize::MAX` and casts to `1.84e19_f64`, producing a `GraphicalFunction` whose x-scale is `[0, 1.84e19]`. The TypeScript twin (`graphicalFunctionFromJson` in `src/core/datamodel.ts:112`) does the same calculation correctly with `Math.max(0, ...)`. Introduced in commit fd224e99 (initial JSON serialization support).
-- **Suspected fix**: `y_points.len().saturating_sub(1) as f64`.
-- **Owner**: unassigned
-- **Last reviewed**: 2026-05-08
-
 ### 57. Stale @system-dynamics/* import path in build-selection-map.test.ts
 
 - **Component**: diagram (`src/diagram/tests/build-selection-map.test.ts:6-7`)

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "@playwright/test": "^1.58.1",
     "prettier": "^3.8.1",
     "ts-protoc-gen": "^0.15.0",
-    "typescript": "^5.9.3"
+    "typescript": "^5.9.3",
+    "yaml": "^2.4.2"
   },
   "scripts": {
     "js-needs-format": "find src -name '*.ts' -o -name '*.tsx' | egrep -v '/(lib(\\.(browser|module))?)/' | xargs prettier -l",
@@ -36,7 +37,8 @@
     "clean": "pnpm -r run clean && cargo clean",
     "deploy:web": "bash scripts/deploy-web.sh",
     "start": "node src/server/lib",
-    "test": "pnpm --filter @simlin/core --filter @simlin/diagram --filter @simlin/engine --filter @simlin/app --filter @simlin/server --filter @simlin/serve-web --parallel run test",
+    "test:scripts": "node --test scripts/tests/*.test.mjs",
+    "test": "pnpm test:scripts && pnpm --filter @simlin/core --filter @simlin/diagram --filter @simlin/engine --filter @simlin/app --filter @simlin/server --filter @simlin/serve-web --parallel run test",
     "test:ui": "playwright test",
     "test:ui:ui": "playwright test --ui"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      yaml:
+        specifier: ^2.4.2
+        version: 2.9.0
 
   src/app:
     dependencies:
@@ -375,7 +378,7 @@ importers:
         version: 8.61.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@vitejs/plugin-react':
         specifier: ^5.2.0
-        version: 5.2.0(vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0))
+        version: 5.2.0(vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
       eslint:
         specifier: ^9.39.2
         version: 9.39.4(jiti@2.7.0)
@@ -402,13 +405,13 @@ importers:
         version: 5.9.3
       vite:
         specifier: ^7.0.0
-        version: 7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)
+        version: 7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
       vite-plugin-top-level-await:
         specifier: ^1.6.0
-        version: 1.6.0(@swc/helpers@0.5.23)(rollup@4.62.2)(vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0))
+        version: 1.6.0(@swc/helpers@0.5.23)(rollup@4.62.2)(vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
       vite-plugin-wasm:
         specifier: ^3.6.0
-        version: 3.6.0(vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0))
+        version: 3.6.0(vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))
 
   website:
     devDependencies:
@@ -6060,6 +6063,11 @@ packages:
   yallist@4.0.0:
     resolution: {integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==}
 
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
   yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
     engines: {node: '>=12'}
@@ -8237,7 +8245,7 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.12.2':
     optional: true
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.7
       '@babel/plugin-transform-react-jsx-self': 7.29.7(@babel/core@7.29.7)
@@ -8245,7 +8253,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)
+      vite: 7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -12540,22 +12548,22 @@ snapshots:
       '@types/unist': 3.0.3
       vfile-message: 4.0.3
 
-  vite-plugin-top-level-await@1.6.0(@swc/helpers@0.5.23)(rollup@4.62.2)(vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)):
+  vite-plugin-top-level-await@1.6.0(@swc/helpers@0.5.23)(rollup@4.62.2)(vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
       '@rollup/plugin-virtual': 3.0.2(rollup@4.62.2)
       '@swc/core': 1.15.41(@swc/helpers@0.5.23)
       '@swc/wasm': 1.15.41
       uuid: 10.0.0
-      vite: 7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)
+      vite: 7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
     transitivePeerDependencies:
       - '@swc/helpers'
       - rollup
 
-  vite-plugin-wasm@3.6.0(vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)):
+  vite-plugin-wasm@3.6.0(vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)):
     dependencies:
-      vite: 7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)
+      vite: 7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0)
 
-  vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0):
+  vite@7.3.5(@types/node@25.9.4)(jiti@2.7.0)(sass-embedded@1.100.0)(sass@1.100.0)(terser@5.48.0)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -12570,6 +12578,7 @@ snapshots:
       sass: 1.100.0
       sass-embedded: 1.100.0
       terser: 5.48.0
+      yaml: 2.9.0
 
   w3c-xmlserializer@5.0.0:
     dependencies:
@@ -12749,6 +12758,8 @@ snapshots:
   yallist@3.1.1: {}
 
   yallist@4.0.0: {}
+
+  yaml@2.9.0: {}
 
   yargs-parser@21.1.1: {}
 

--- a/scripts/deploy-web.sh
+++ b/scripts/deploy-web.sh
@@ -57,17 +57,7 @@ if [ ! -f "$REPO_ROOT/.app.prod.yaml" ]; then
     exit 1
 fi
 
-if ! grep -q 'GOOGLE_NODE_RUN_SCRIPTS' "$REPO_ROOT/.app.prod.yaml"; then
-    echo "ERROR: .app.prod.yaml must set build_env_variables.GOOGLE_NODE_RUN_SCRIPTS to suppress App Engine's buildpack rebuild." >&2
-    echo "       See the committed app.yaml reference and docs/dev/deploy.md." >&2
-    exit 1
-fi
-
-if ! grep -q 'authentication__seshcookie__key' "$REPO_ROOT/.app.prod.yaml"; then
-    echo "ERROR: .app.prod.yaml must set env_variables.authentication__seshcookie__key to the existing production session key." >&2
-    echo "       See docs/dev/deploy.md." >&2
-    exit 1
-fi
+node "$REPO_ROOT/scripts/validate-app-prod-config.mjs" "$REPO_ROOT/.app.prod.yaml"
 
 export NODE_ENV=production
 

--- a/scripts/deploy-web.sh
+++ b/scripts/deploy-web.sh
@@ -57,6 +57,18 @@ if [ ! -f "$REPO_ROOT/.app.prod.yaml" ]; then
     exit 1
 fi
 
+if ! grep -q 'GOOGLE_NODE_RUN_SCRIPTS' "$REPO_ROOT/.app.prod.yaml"; then
+    echo "ERROR: .app.prod.yaml must set build_env_variables.GOOGLE_NODE_RUN_SCRIPTS to suppress App Engine's buildpack rebuild." >&2
+    echo "       See the committed app.yaml reference and docs/dev/deploy.md." >&2
+    exit 1
+fi
+
+if ! grep -q 'authentication__seshcookie__key' "$REPO_ROOT/.app.prod.yaml"; then
+    echo "ERROR: .app.prod.yaml must set env_variables.authentication__seshcookie__key to the existing production session key." >&2
+    echo "       See docs/dev/deploy.md." >&2
+    exit 1
+fi
+
 export NODE_ENV=production
 
 echo "==> pnpm clean"

--- a/scripts/tests/validate-app-prod-config.test.mjs
+++ b/scripts/tests/validate-app-prod-config.test.mjs
@@ -32,6 +32,7 @@ runtime: nodejs24
 
     assert.deepEqual(messages, [
       'build_env_variables.GOOGLE_NODE_RUN_SCRIPTS must be set to an empty string',
+      'env_variables.NODE_ENV must be set to production',
       'env_variables.authentication__seshcookie__key must be set to the existing production session key',
     ]);
   });
@@ -39,6 +40,7 @@ runtime: nodejs24
   it('rejects GOOGLE_NODE_RUN_SCRIPTS outside build_env_variables', () => {
     const messages = messagesFor(`
 env_variables:
+  NODE_ENV: production
   GOOGLE_NODE_RUN_SCRIPTS: ''
   authentication__seshcookie__key: production-secret
 `);
@@ -51,6 +53,7 @@ env_variables:
 build_env_variables:
   GOOGLE_NODE_RUN_SCRIPTS: build
 env_variables:
+  NODE_ENV: production
   authentication__seshcookie__key: production-secret
 `);
 
@@ -62,6 +65,8 @@ env_variables:
 build_env_variables:
   GOOGLE_NODE_RUN_SCRIPTS: ''
   authentication__seshcookie__key: production-secret
+env_variables:
+  NODE_ENV: production
 `);
 
     assert.deepEqual(messages, [
@@ -76,10 +81,43 @@ build_env_variables:
 build_env_variables:
   GOOGLE_NODE_RUN_SCRIPTS: ''
 env_variables:
+  NODE_ENV: production
   authentication__seshcookie__key: ${value}
 `),
         ['env_variables.authentication__seshcookie__key must be set to the existing production session key'],
       );
+    }
+  });
+
+  it('rejects missing NODE_ENV', () => {
+    const messages = messagesFor(`
+build_env_variables:
+  GOOGLE_NODE_RUN_SCRIPTS: ''
+env_variables:
+  authentication__seshcookie__key: production-secret
+`);
+
+    assert.deepEqual(messages, ['env_variables.NODE_ENV must be set to production']);
+  });
+
+  it('rejects NODE_ENV outside env_variables or set to a non-production value', () => {
+    for (const source of [
+      `
+build_env_variables:
+  GOOGLE_NODE_RUN_SCRIPTS: ''
+  NODE_ENV: production
+env_variables:
+  authentication__seshcookie__key: production-secret
+`,
+      `
+build_env_variables:
+  GOOGLE_NODE_RUN_SCRIPTS: ''
+env_variables:
+  NODE_ENV: development
+  authentication__seshcookie__key: production-secret
+`,
+    ]) {
+      assert.deepEqual(messagesFor(source), ['env_variables.NODE_ENV must be set to production']);
     }
   });
 

--- a/scripts/tests/validate-app-prod-config.test.mjs
+++ b/scripts/tests/validate-app-prod-config.test.mjs
@@ -1,0 +1,97 @@
+import assert from 'node:assert/strict';
+import { describe, it } from 'node:test';
+
+import { validateAppProdConfig } from '../validate-app-prod-config.mjs';
+
+const validConfig = `
+runtime: nodejs24
+
+build_env_variables:
+  GOOGLE_NODE_RUN_SCRIPTS: ''
+
+env_variables:
+  NODE_ENV: production
+  authentication__seshcookie__key: production-secret
+`;
+
+function messagesFor(source) {
+  return validateAppProdConfig(source, '.app.prod.yaml').map((error) => error.message);
+}
+
+describe('validateAppProdConfig', () => {
+  it('accepts a production config with deploy-critical values in the correct sections', () => {
+    assert.deepEqual(messagesFor(validConfig), []);
+  });
+
+  it('rejects deploy guard tokens that appear only in comments', () => {
+    const messages = messagesFor(`
+# build_env_variables.GOOGLE_NODE_RUN_SCRIPTS: ''
+# env_variables.authentication__seshcookie__key: production-secret
+runtime: nodejs24
+`);
+
+    assert.deepEqual(messages, [
+      'build_env_variables.GOOGLE_NODE_RUN_SCRIPTS must be set to an empty string',
+      'env_variables.authentication__seshcookie__key must be set to the existing production session key',
+    ]);
+  });
+
+  it('rejects GOOGLE_NODE_RUN_SCRIPTS outside build_env_variables', () => {
+    const messages = messagesFor(`
+env_variables:
+  GOOGLE_NODE_RUN_SCRIPTS: ''
+  authentication__seshcookie__key: production-secret
+`);
+
+    assert.deepEqual(messages, ['build_env_variables.GOOGLE_NODE_RUN_SCRIPTS must be set to an empty string']);
+  });
+
+  it('rejects a non-empty GOOGLE_NODE_RUN_SCRIPTS value', () => {
+    const messages = messagesFor(`
+build_env_variables:
+  GOOGLE_NODE_RUN_SCRIPTS: build
+env_variables:
+  authentication__seshcookie__key: production-secret
+`);
+
+    assert.deepEqual(messages, ['build_env_variables.GOOGLE_NODE_RUN_SCRIPTS must be set to an empty string']);
+  });
+
+  it('rejects session keys outside env_variables', () => {
+    const messages = messagesFor(`
+build_env_variables:
+  GOOGLE_NODE_RUN_SCRIPTS: ''
+  authentication__seshcookie__key: production-secret
+`);
+
+    assert.deepEqual(messages, [
+      'env_variables.authentication__seshcookie__key must be set to the existing production session key',
+    ]);
+  });
+
+  it('rejects blank or placeholder session keys', () => {
+    for (const value of ["''", 'IN ENV', "' IN ENV '"]) {
+      assert.deepEqual(
+        messagesFor(`
+build_env_variables:
+  GOOGLE_NODE_RUN_SCRIPTS: ''
+env_variables:
+  authentication__seshcookie__key: ${value}
+`),
+        ['env_variables.authentication__seshcookie__key must be set to the existing production session key'],
+      );
+    }
+  });
+
+  it('rejects malformed YAML', () => {
+    const messages = messagesFor(`
+build_env_variables:
+  GOOGLE_NODE_RUN_SCRIPTS: ''
+env_variables:
+  authentication__seshcookie__key: [unterminated
+`);
+
+    assert.equal(messages.length, 1);
+    assert.match(messages[0], /^failed to parse \.app\.prod\.yaml:/);
+  });
+});

--- a/scripts/validate-app-prod-config.mjs
+++ b/scripts/validate-app-prod-config.mjs
@@ -1,0 +1,88 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs';
+import process from 'node:process';
+import { parseDocument } from 'yaml';
+
+const BUILD_SCRIPT_KEY = 'GOOGLE_NODE_RUN_SCRIPTS';
+const SESSION_KEY = 'authentication__seshcookie__key';
+
+function isRecord(value) {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function formatYamlError(error) {
+  const location = error.linePos?.[0];
+  if (!location) {
+    return error.message;
+  }
+  return `${error.message} at line ${location.line}, column ${location.col}`;
+}
+
+export function validateAppProdConfig(source, filename = '.app.prod.yaml') {
+  const document = parseDocument(source, { prettyErrors: false });
+  if (document.errors.length > 0) {
+    return [
+      {
+        message: `failed to parse ${filename}: ${formatYamlError(document.errors[0])}`,
+      },
+    ];
+  }
+
+  const config = document.toJSON();
+  const errors = [];
+
+  if (!isRecord(config)) {
+    errors.push({ message: `${filename} must contain a YAML mapping at the top level` });
+    return errors;
+  }
+
+  const buildEnv = config.build_env_variables;
+  if (!isRecord(buildEnv) || buildEnv[BUILD_SCRIPT_KEY] !== '') {
+    errors.push({
+      message: 'build_env_variables.GOOGLE_NODE_RUN_SCRIPTS must be set to an empty string',
+    });
+  }
+
+  const env = config.env_variables;
+  const sessionKey = isRecord(env) ? env[SESSION_KEY] : undefined;
+  if (typeof sessionKey !== 'string' || sessionKey.trim() === '' || sessionKey.trim() === 'IN ENV') {
+    errors.push({
+      message: 'env_variables.authentication__seshcookie__key must be set to the existing production session key',
+    });
+  }
+
+  return errors;
+}
+
+export function main(argv = process.argv) {
+  const filename = argv[2];
+  if (!filename) {
+    console.error('usage: validate-app-prod-config.mjs <path-to-.app.prod.yaml>');
+    return 2;
+  }
+
+  let source;
+  try {
+    source = fs.readFileSync(filename, 'utf8');
+  } catch (error) {
+    console.error(`ERROR: failed to read ${filename}: ${error.message}`);
+    return 1;
+  }
+
+  const errors = validateAppProdConfig(source, filename);
+  for (const error of errors) {
+    console.error(`ERROR: ${error.message}`);
+  }
+
+  if (errors.length > 0) {
+    console.error('       See the committed app.yaml reference and docs/dev/deploy.md.');
+    return 1;
+  }
+
+  return 0;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  process.exitCode = main();
+}

--- a/scripts/validate-app-prod-config.mjs
+++ b/scripts/validate-app-prod-config.mjs
@@ -5,6 +5,7 @@ import process from 'node:process';
 import { parseDocument } from 'yaml';
 
 const BUILD_SCRIPT_KEY = 'GOOGLE_NODE_RUN_SCRIPTS';
+const NODE_ENV_KEY = 'NODE_ENV';
 const SESSION_KEY = 'authentication__seshcookie__key';
 
 function isRecord(value) {
@@ -45,6 +46,13 @@ export function validateAppProdConfig(source, filename = '.app.prod.yaml') {
   }
 
   const env = config.env_variables;
+  const nodeEnv = isRecord(env) ? env[NODE_ENV_KEY] : undefined;
+  if (nodeEnv !== 'production') {
+    errors.push({
+      message: 'env_variables.NODE_ENV must be set to production',
+    });
+  }
+
   const sessionKey = isRecord(env) ? env[SESSION_KEY] : undefined;
   if (typeof sessionKey !== 'string' || sessionKey.trim() === '' || sessionKey.trim() === 'IN ENV') {
     errors.push({

--- a/scripts/verify-deploy-build.sh
+++ b/scripts/verify-deploy-build.sh
@@ -98,7 +98,36 @@ if [ -f public/static/js/sd-component.js ]; then
     fi
 fi
 
-# 5. A hashed WASM blob exists somewhere under public/static/wasm/, and it
+# 5. The web component stylesheet is shipped beside the SPA CSS. The
+#    component renders inside a closed shadow root, so document-level CSS from
+#    the embedding page cannot style it; sd-component.js links this exact file
+#    into the shadow tree.
+if [ ! -f public/static/css/sd-component.css ]; then
+    fail "public/static/css/sd-component.css missing (closed-shadow web component would render without its stylesheet)"
+else
+    size=$(wc -c < public/static/css/sd-component.css)
+    if [ "$size" -lt 1024 ]; then
+        fail "public/static/css/sd-component.css is suspiciously small ($size bytes)"
+    elif ! LC_ALL=C grep -q 'simlinCanvas' public/static/css/sd-component.css; then
+        fail "public/static/css/sd-component.css does not contain expected diagram canvas styles"
+    elif ! LC_ALL=C grep -q -- '--color-primary' public/static/css/sd-component.css; then
+        fail "public/static/css/sd-component.css does not contain expected theme styles"
+    elif ! LC_ALL=C grep -q 'KaTeX_Main' public/static/css/sd-component.css; then
+        fail "public/static/css/sd-component.css does not contain expected KaTeX styles"
+    else
+        pass "public/static/css/sd-component.css exists and contains editor styles ($size bytes)"
+    fi
+fi
+
+if [ -f public/static/js/sd-component.js ]; then
+    if ! grep -q '/static/css/sd-component.css' public/static/js/sd-component.js; then
+        fail "public/static/js/sd-component.js does not link /static/css/sd-component.css into the shadow root"
+    else
+        pass "public/static/js/sd-component.js links the component stylesheet"
+    fi
+fi
+
+# 6. A hashed WASM blob exists somewhere under public/static/wasm/, and it
 #    is the SLIM browser artifact. rsbuild emits the engine WASM via
 #    Rspack's asset module with a content hash; the exact filename varies.
 #    The browser bundle must come from libsimlin-browser.wasm (built
@@ -124,7 +153,7 @@ else
     fi
 fi
 
-# 6. The engine package's source WASM was built, and it is the FULL
+# 7. The engine package's source WASM was built, and it is the FULL
 #    artifact. The server runtime loads this via require('@simlin/engine')
 #    and its model-preview pipeline calls simlin_project_render_png; a
 #    slim WASM here would 500 every preview render. A missing or empty
@@ -144,7 +173,7 @@ else
     fi
 fi
 
-# 7. The compiled server bundle exists. GAE runs `node src/server/lib`
+# 8. The compiled server bundle exists. GAE runs `node src/server/lib`
 #    on the instance; an empty lib/ would crash-loop without a useful
 #    error.
 if [ ! -f src/server/lib/index.js ]; then

--- a/src/app/index-component.tsx
+++ b/src/app/index-component.tsx
@@ -6,6 +6,9 @@ import * as React from 'react';
 import { createRoot } from 'react-dom/client';
 
 import { baseURL } from '@simlin/core/common';
+import '@simlin/diagram/reset.css';
+import 'katex/dist/katex.min.css';
+import '@simlin/diagram/theme.css';
 import { HostedWebEditor } from '@simlin/diagram/HostedWebEditor';
 
 // try to get the base URL from the src attribute of the current script
@@ -25,6 +28,7 @@ class SDModel extends HTMLElement {
     this.attachShadow({ mode: 'closed' }).appendChild(mountPoint);
 
     const base = `${scriptURL.protocol}//${scriptURL.host}`;
+    const stylesheet = `${base}/static/css/sd-component.css`;
 
     const username = this.getAttribute('username') || '';
     const projectName = this.getAttribute('projectName') || '';
@@ -33,6 +37,7 @@ class SDModel extends HTMLElement {
       <div className="model-Editor-full">
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" />
         <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto+Mono&display=swap" />
+        <link rel="stylesheet" href={stylesheet} />
         <HostedWebEditor username={username} projectName={projectName} embedded={true} baseURL={base} />
       </div>,
     );

--- a/src/app/package.json
+++ b/src/app/package.json
@@ -44,7 +44,7 @@
     "format": "prettier --write '**/*.ts' '**/*.tsx'",
     "lint": "eslint --cache --cache-location node_modules/.cache/eslint/ .",
     "prepublishOnly": "pnpm build",
-    "deploy:assemble": "cp -r build/* public && cp -r build-component/static/js/* ./public/static/js/ && { [ ! -d build-component/static/wasm ] || cp -r build-component/static/wasm/* ./public/static/wasm/; } && rm public ../server/public ../server/default_projects",
+    "deploy:assemble": "cp -r build/* public && cp -r build-component/static/js/* ./public/static/js/ && { [ ! -d build-component/static/css ] || cp -r build-component/static/css/* ./public/static/css/; } && { [ ! -d build-component/static/wasm ] || cp -r build-component/static/wasm/* ./public/static/wasm/; } && { [ ! -d build-component/static/media ] || cp -r build-component/static/media/* ./public/static/media/; } && rm public ../server/public ../server/default_projects",
     "deploy:clean": "git checkout HEAD -- ../../public/index.html ./public ../server/public ../server/default_projects && rm -rf public/asset-manifest.json public/static/js public/static/wasm public/static/css public/static/media build build-component",
     "clean": "rm -rf ./lib.browser ./build ./build-component ./node_modules/.cache",
     "build": "pnpm run build:frontend && pnpm run build:webcomponent",

--- a/src/app/tests/index-component.test.tsx
+++ b/src/app/tests/index-component.test.tsx
@@ -1,0 +1,40 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import * as React from 'react';
+import { act, waitFor } from '@testing-library/react';
+
+jest.mock(
+  '@simlin/diagram/HostedWebEditor',
+  () => ({
+    HostedWebEditor: () => React.createElement('div', { 'data-testid': 'hosted-editor' }, 'Editor'),
+  }),
+  { virtual: true },
+);
+
+import '../index-component';
+
+describe('sd-model web component', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+    document.head.innerHTML = '';
+    jest.restoreAllMocks();
+  });
+
+  it('loads its component stylesheet inside the shadow tree', async () => {
+    const shadowRoot = document.createElement('div') as unknown as ShadowRoot;
+    jest.spyOn(HTMLElement.prototype, 'attachShadow').mockReturnValue(shadowRoot);
+
+    const element = document.createElement('sd-model');
+    await act(async () => {
+      document.body.appendChild(element);
+    });
+
+    await waitFor(() => {
+      expect(
+        shadowRoot.querySelector('link[href="https://app.simlin.com/static/css/sd-component.css"]'),
+      ).not.toBeNull();
+    });
+  });
+});

--- a/src/core/tests/datamodel.test.ts
+++ b/src/core/tests/datamodel.test.ts
@@ -118,6 +118,14 @@ describe('GraphicalFunction', () => {
     expect(restored.yPoints).toEqual([5, 10, 15, 20]);
     expect(restored.xPoints).toBeUndefined();
   });
+
+  it('should default empty yPoints to a zero-width x scale', () => {
+    const restored = graphicalFunctionFromJson({});
+
+    expect(restored.xScale).toEqual({ min: 0, max: 0 });
+    expect(restored.yPoints).toEqual([]);
+    expect(restored.xPoints).toBeUndefined();
+  });
 });
 
 describe('Stock', () => {

--- a/src/diagram/tests/theme-tokens.test.ts
+++ b/src/diagram/tests/theme-tokens.test.ts
@@ -45,14 +45,15 @@ describe('theme.css token contracts', () => {
   const theme = readCss('theme.css');
 
   function darkBlock(css: string): string {
-    const m = /\[data-theme="dark"\]\s*\{([\s\S]*?)\}/.exec(css);
+    const m = /\[data-theme="dark"\]\s*,\s*:host\(\[data-theme="dark"\]\)\s*\{([\s\S]*?)\}/.exec(css);
     if (!m) {
-      throw new Error('no [data-theme="dark"] block in theme.css');
+      throw new Error('no [data-theme="dark"] / :host([data-theme="dark"]) block in theme.css');
     }
     return m[1];
   }
 
-  it('defines the dense-toolbar and caption tokens in :root', () => {
+  it('defines the dense-toolbar and caption tokens in :root and shadow hosts', () => {
+    expect(theme).toMatch(/:root,\s*:host\s*\{/);
     expect(theme).toMatch(/--toolbar-dense-height:\s*48px/);
     expect(theme).toMatch(/--font-size-caption:\s*0\.75rem/);
   });

--- a/src/diagram/theme.css
+++ b/src/diagram/theme.css
@@ -1,6 +1,7 @@
 /* Theme CSS Custom Properties for Simlin Diagram Components */
 
-:root {
+:root,
+:host {
   /* Panel widths (sidebar panels: search bar, variable details, error details) */
   /* Note: SearchbarWidthSm and SearchbarWidthLg in Editor.tsx must stay in sync */
   --panel-width-sm: 359px;
@@ -204,7 +205,8 @@
  * chrome yet, so these chrome overrides are inert in the current light-only UI
  * -- they are infrastructure, not a switch being flipped here.
  */
-[data-theme="dark"] {
+[data-theme="dark"],
+:host([data-theme="dark"]) {
   /* Canvas primitives. */
   --color-black: #bbbbbb;
   --color-white: #222222;

--- a/src/pysimlin/simlin/_ffi.py
+++ b/src/pysimlin/simlin/_ffi.py
@@ -97,18 +97,30 @@ def extract_error_details(err_ptr: Any) -> list[Any]:
         if c_detail != ffi.NULL:
             details.append(
                 ErrorDetail(
-                    code=ErrorCode(c_detail.code),
+                    code=coerce_int_enum(ErrorCode, c_detail.code, ErrorCode.GENERIC),
                     message=c_to_string(c_detail.message) or "",
                     model_name=c_to_string(c_detail.model_name),
                     variable_name=c_to_string(c_detail.variable_name),
                     start_offset=c_detail.start_offset,
                     end_offset=c_detail.end_offset,
-                    kind=ErrorKind(c_detail.kind),
-                    unit_error_kind=UnitErrorKind(c_detail.unit_error_kind),
-                    severity=ErrorSeverity(c_detail.severity),
+                    kind=coerce_int_enum(ErrorKind, c_detail.kind, ErrorKind.VARIABLE),
+                    unit_error_kind=coerce_int_enum(
+                        UnitErrorKind,
+                        c_detail.unit_error_kind,
+                        UnitErrorKind.NOT_APPLICABLE,
+                    ),
+                    severity=coerce_int_enum(ErrorSeverity, c_detail.severity, ErrorSeverity.ERROR),
                 )
             )
     return details
+
+
+def coerce_int_enum(enum_cls: Any, value: int, default: Any) -> Any:
+    """Decode C enum values without letting future ABI additions mask the error."""
+    try:
+        return enum_cls(value)
+    except ValueError:
+        return default
 
 
 def check_out_error(out_error_ptr: Any, operation: str = "operation") -> None:

--- a/src/pysimlin/simlin/errors.py
+++ b/src/pysimlin/simlin/errors.py
@@ -42,6 +42,7 @@ class ErrorCode(IntEnum):
     UNIT_DEFINITION_ERRORS = 31
     GENERIC = 32
     UNIT_MISMATCH = 33
+    BAD_OVERRIDE = 34
 
 
 class ErrorKind(IntEnum):

--- a/src/pysimlin/tests/test_errors.py
+++ b/src/pysimlin/tests/test_errors.py
@@ -55,6 +55,7 @@ class TestErrorCode:
         assert ErrorCode.DOES_NOT_EXIST == 1
         assert ErrorCode.CIRCULAR_DEPENDENCY == 21
         assert ErrorCode.GENERIC == 32
+        assert ErrorCode.BAD_OVERRIDE == 34
 
     def test_error_code_to_string(self) -> None:
         """Test converting error codes to strings."""

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -18,6 +18,7 @@ import { Application } from './application';
 import { authn } from './authn';
 import authz from './authz';
 import { favicon } from './favicon';
+import { validateRuntimeConfig } from './config-validation';
 import * as logger from './logger';
 import { createDatabase } from './models/db';
 import { redirectToHttps } from './redirect-to-https';
@@ -110,6 +111,7 @@ class App {
         }
       }
     }
+    validateRuntimeConfig(process.env.NODE_ENV, this.app.get('authentication'));
   }
 
   async setup(): Promise<void> {

--- a/src/server/config-validation.ts
+++ b/src/server/config-validation.ts
@@ -1,0 +1,22 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
+export function validateRuntimeConfig(nodeEnv: string | undefined, authentication: unknown): void {
+  if (nodeEnv !== 'production') {
+    return;
+  }
+
+  if (!isRecord(authentication) || !isRecord(authentication.seshcookie)) {
+    throw new Error('production config must define authentication.seshcookie');
+  }
+
+  const key = authentication.seshcookie.key;
+  if (typeof key !== 'string' || key.trim() === '' || key === 'IN ENV') {
+    throw new Error('production authentication.seshcookie.key must be set from the environment');
+  }
+}

--- a/src/server/models/db-firestore.ts
+++ b/src/server/models/db-firestore.ts
@@ -11,7 +11,7 @@ import { Project } from '../schemas/project_pb';
 import { User } from '../schemas/user_pb';
 
 import { Database, DatabaseOptions } from './db-interfaces';
-import { FirestoreTable } from './table-firestore';
+import { FirestoreTable, firestoreDocumentId } from './table-firestore';
 import { Table } from './table';
 
 export class FirestoreDatabase implements Database {
@@ -33,6 +33,26 @@ export class FirestoreDatabase implements Database {
 
   async init(): Promise<void> {
     await Promise.all([this.file.init(), this.project.init(), this.preview.init(), this.user.init()]);
+  }
+
+  async deleteProjectAndFiles(projectId: string, currentFileId: string | undefined): Promise<void> {
+    const files = await this.client.collection('files').where('projectId', '==', projectId).get();
+    const historicalFileRefs = files.docs.filter((doc) => doc.id !== currentFileId).map((doc) => doc.ref);
+
+    for (let i = 0; i < historicalFileRefs.length; i += 500) {
+      const batch = this.client.batch();
+      for (const ref of historicalFileRefs.slice(i, i + 500)) {
+        batch.delete(ref);
+      }
+      await batch.commit();
+    }
+
+    const finalBatch = this.client.batch();
+    finalBatch.delete(this.client.collection('project').doc(firestoreDocumentId(projectId)));
+    if (currentFileId) {
+      finalBatch.delete(this.client.collection('files').doc(firestoreDocumentId(currentFileId)));
+    }
+    await finalBatch.commit();
   }
 }
 

--- a/src/server/models/db-interfaces.ts
+++ b/src/server/models/db-interfaces.ts
@@ -19,4 +19,6 @@ export interface Database {
   readonly project: Table<Project>;
   readonly preview: Table<Preview>;
   readonly user: Table<User>;
+
+  deleteProjectAndFiles(projectId: string, currentFileId: string | undefined): Promise<void>;
 }

--- a/src/server/models/table-firestore.ts
+++ b/src/server/models/table-firestore.ts
@@ -20,6 +20,10 @@ interface Schema {
   [x: string]: unknown;
 }
 
+export function firestoreDocumentId(id: string): string {
+  return id.replace('/', '|');
+}
+
 export class FirestoreTable<T extends Message> implements Table<T> {
   readonly kind: SerializableClass<T>;
   readonly opts: FirestoreTableOptions;
@@ -35,12 +39,8 @@ export class FirestoreTable<T extends Message> implements Table<T> {
 
   async init(): Promise<void> {}
 
-  private static filterId(id: string): string {
-    return id.replace('/', '|');
-  }
-
   private docRef(id: string) {
-    return this.collection.doc(FirestoreTable.filterId(id));
+    return this.collection.doc(firestoreDocumentId(id));
   }
 
   private deserialize(value: Buffer): T {
@@ -80,7 +80,7 @@ export class FirestoreTable<T extends Message> implements Table<T> {
   }
 
   async find(idPrefix: string): Promise<T[]> {
-    idPrefix = FirestoreTable.filterId(idPrefix);
+    idPrefix = firestoreDocumentId(idPrefix);
     // https://stackoverflow.com/questions/46573804/firestore-query-documents-startswith-a-string
     const successor =
       idPrefix.substring(0, idPrefix.length - 1) + String.fromCharCode(idPrefix.charCodeAt(idPrefix.length - 1) + 1);

--- a/src/server/route-handlers.ts
+++ b/src/server/route-handlers.ts
@@ -29,11 +29,6 @@ export interface ProjectRouteHandlerDeps {
 }
 
 /**
- * Database operations needed to delete a project: looking the project up to
- * verify ownership, then removing the project document and all stored content
- * blobs for that project.
- */
-/**
  * Database operations needed to clean up a project's cached preview PNG.
  */
 export interface DeletablePreviewDb {

--- a/src/server/route-handlers.ts
+++ b/src/server/route-handlers.ts
@@ -30,15 +30,9 @@ export interface ProjectRouteHandlerDeps {
 
 /**
  * Database operations needed to delete a project: looking the project up to
- * verify ownership, then removing the project document. Deleting the project
- * doc is what makes the project disappear from listings and the SSR route;
- * the (orphaned) `File` documents are intentionally left behind, consistent
- * with how every save already orphans the prior `File` doc.
+ * verify ownership, then removing the project document and all stored content
+ * blobs for that project.
  */
-export interface DeletableProjectDb extends ProjectDb {
-  deleteOne(id: string): Promise<void>;
-}
-
 /**
  * Database operations needed to clean up a project's cached preview PNG.
  */
@@ -48,8 +42,9 @@ export interface DeletablePreviewDb {
 
 export interface DeleteProjectHandlerDeps {
   db: {
-    project: DeletableProjectDb;
+    project: ProjectDb;
     preview: DeletablePreviewDb;
+    deleteProjectAndFiles(id: string, currentFileId: string | undefined): Promise<void>;
   };
 }
 
@@ -127,9 +122,9 @@ export function createProjectRouteHandler(deps: ProjectRouteHandlerDeps) {
  * owner may delete it. Ownership is checked twice: once against the URL
  * username before any DB lookup -- so a logged-in user can't probe whether
  * another user's private project exists via the 404-vs-401 distinction -- and
- * again against the stored record's ownerId as defense in depth. The cached
- * preview PNG is removed on a best-effort basis; the underlying `File`
- * documents are intentionally left orphaned.
+ * again against the stored record's ownerId as defense in depth. Stored model
+ * contents are deleted with the project; the cached preview PNG is removed on
+ * a best-effort basis.
  */
 export function createDeleteProjectHandler(deps: DeleteProjectHandlerDeps) {
   return async (req: Request, res: Response): Promise<void> => {
@@ -159,7 +154,13 @@ export function createDeleteProjectHandler(deps: DeleteProjectHandlerDeps) {
       return;
     }
 
-    await deps.db.project.deleteOne(projectId);
+    try {
+      await deps.db.deleteProjectAndFiles(projectId, project.getFileId());
+    } catch (err) {
+      logger.error(`unable to delete project ${projectId}: ${err}`);
+      res.status(500).json({ error: 'unable to delete project' });
+      return;
+    }
 
     // A stale preview is harmless once the project doc is gone (the preview
     // route 404s without a project), so don't fail the request if it can't

--- a/src/server/tests/config-validation.test.ts
+++ b/src/server/tests/config-validation.test.ts
@@ -1,0 +1,37 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import { validateRuntimeConfig } from '../config-validation';
+
+describe('validateRuntimeConfig', () => {
+  it('allows the default development session-key placeholder', () => {
+    expect(() =>
+      validateRuntimeConfig('development', {
+        seshcookie: {
+          key: '',
+        },
+      }),
+    ).not.toThrow();
+  });
+
+  it.each(['', '   ', 'IN ENV'])('rejects production session key %p', (key) => {
+    expect(() =>
+      validateRuntimeConfig('production', {
+        seshcookie: {
+          key,
+        },
+      }),
+    ).toThrow('production authentication.seshcookie.key');
+  });
+
+  it('allows a production session key supplied from the environment', () => {
+    expect(() =>
+      validateRuntimeConfig('production', {
+        seshcookie: {
+          key: 'a real deployment secret',
+        },
+      }),
+    ).not.toThrow();
+  });
+});

--- a/src/server/tests/delete-project.test.ts
+++ b/src/server/tests/delete-project.test.ts
@@ -26,12 +26,14 @@ function mockProject(id: string, ownerId?: string): MockProjectRecord {
 interface MockDeps {
   deps: DeleteProjectHandlerDeps;
   projectFindOne: jest.Mock;
-  projectDeleteCalls: string[];
+  projectDeleteCalls: Array<{ projectId: string; currentFileId: string | undefined }>;
   previewDeleteCalls: string[];
 }
 
-function mockDeps(opts: { project?: MockProjectRecord; previewDeleteRejects?: boolean } = {}): MockDeps {
-  const projectDeleteCalls: string[] = [];
+function mockDeps(
+  opts: { project?: MockProjectRecord; previewDeleteRejects?: boolean; projectDeleteRejects?: boolean } = {},
+): MockDeps {
+  const projectDeleteCalls: Array<{ projectId: string; currentFileId: string | undefined }> = [];
   const previewDeleteCalls: string[] = [];
   const projectFindOne = jest.fn().mockResolvedValue(opts.project);
   return {
@@ -42,9 +44,6 @@ function mockDeps(opts: { project?: MockProjectRecord; previewDeleteRejects?: bo
       db: {
         project: {
           findOne: projectFindOne,
-          deleteOne: jest.fn(async (id: string) => {
-            projectDeleteCalls.push(id);
-          }),
         },
         preview: {
           deleteOne: jest.fn(async (id: string) => {
@@ -54,6 +53,12 @@ function mockDeps(opts: { project?: MockProjectRecord; previewDeleteRejects?: bo
             }
           }),
         },
+        deleteProjectAndFiles: jest.fn(async (projectId: string, currentFileId: string | undefined) => {
+          projectDeleteCalls.push({ projectId, currentFileId });
+          if (opts.projectDeleteRejects) {
+            throw new Error('project delete failed');
+          }
+        }),
       },
     },
   };
@@ -95,14 +100,14 @@ function mockRequest(opts: { username?: string; projectName?: string; userId?: s
 }
 
 describe('createDeleteProjectHandler', () => {
-  it('deletes the project and preview docs and returns 200 for the owner', async () => {
+  it('deletes the project contents, project doc, and preview doc and returns 200 for the owner', async () => {
     const { deps, projectDeleteCalls, previewDeleteCalls } = mockDeps({ project: mockProject('alice/climate') });
     const handler = createDeleteProjectHandler(deps);
     const { res, statusCode, jsonBody } = mockResponse();
 
     await handler(mockRequest({ username: 'alice', projectName: 'climate', userId: 'alice' }), res);
 
-    expect(projectDeleteCalls).toEqual(['alice/climate']);
+    expect(projectDeleteCalls).toEqual([{ projectId: 'alice/climate', currentFileId: 'file-abc' }]);
     expect(previewDeleteCalls).toEqual(['alice/climate']);
     expect(statusCode()).toBe(200);
     expect(jsonBody()).toEqual({});
@@ -119,8 +124,24 @@ describe('createDeleteProjectHandler', () => {
 
     await handler(mockRequest({ userId: 'alice' }), res);
 
-    expect(projectDeleteCalls).toEqual(['alice/climate']);
+    expect(projectDeleteCalls).toEqual([{ projectId: 'alice/climate', currentFileId: 'file-abc' }]);
     expect(statusCode()).toBe(200);
+  });
+
+  it('returns 500 and does not delete the preview when project-content deletion fails', async () => {
+    const { deps, projectDeleteCalls, previewDeleteCalls } = mockDeps({
+      project: mockProject('alice/climate'),
+      projectDeleteRejects: true,
+    });
+    const handler = createDeleteProjectHandler(deps);
+    const { res, statusCode, jsonBody } = mockResponse();
+
+    await handler(mockRequest({ userId: 'alice' }), res);
+
+    expect(projectDeleteCalls).toEqual([{ projectId: 'alice/climate', currentFileId: 'file-abc' }]);
+    expect(previewDeleteCalls).toEqual([]);
+    expect(statusCode()).toBe(500);
+    expect(jsonBody()).toEqual({ error: 'unable to delete project' });
   });
 
   it('returns 404 when the project does not exist', async () => {

--- a/src/simlin-engine/src/json.rs
+++ b/src/simlin-engine/src/json.rs
@@ -708,7 +708,11 @@ impl From<GraphicalFunction> for datamodel::GraphicalFunction {
 
         let x_scale = gf.x_scale.unwrap_or(GraphicalFunctionScale {
             min: 0.0,
-            max: (y_points.len() - 1) as f64,
+            max: if y_points.is_empty() {
+                1.0
+            } else {
+                (y_points.len() - 1) as f64
+            },
         });
 
         let y_scale = gf
@@ -2104,6 +2108,23 @@ mod tests {
                 assert_eq!(json_gf.y_points, json_gf3.y_points, "Failed for: {}", name);
             }
         }
+    }
+
+    #[test]
+    fn empty_graphical_function_uses_unit_x_scale() {
+        let json_gf = GraphicalFunction {
+            points: vec![],
+            y_points: vec![],
+            kind: "continuous".to_string(),
+            x_scale: None,
+            y_scale: None,
+        };
+
+        let dm_gf: datamodel::GraphicalFunction = json_gf.into();
+
+        assert_eq!(dm_gf.x_scale.min, 0.0);
+        assert_eq!(dm_gf.x_scale.max, 1.0);
+        assert!(dm_gf.y_points.is_empty());
     }
 
     #[test]

--- a/src/simlin-engine/src/json.rs
+++ b/src/simlin-engine/src/json.rs
@@ -708,11 +708,7 @@ impl From<GraphicalFunction> for datamodel::GraphicalFunction {
 
         let x_scale = gf.x_scale.unwrap_or(GraphicalFunctionScale {
             min: 0.0,
-            max: if y_points.is_empty() {
-                1.0
-            } else {
-                (y_points.len() - 1) as f64
-            },
+            max: y_points.len().saturating_sub(1) as f64,
         });
 
         let y_scale = gf
@@ -2111,7 +2107,7 @@ mod tests {
     }
 
     #[test]
-    fn empty_graphical_function_uses_unit_x_scale() {
+    fn empty_graphical_function_uses_zero_width_x_scale() {
         let json_gf = GraphicalFunction {
             points: vec![],
             y_points: vec![],
@@ -2123,7 +2119,7 @@ mod tests {
         let dm_gf: datamodel::GraphicalFunction = json_gf.into();
 
         assert_eq!(dm_gf.x_scale.min, 0.0);
-        assert_eq!(dm_gf.x_scale.max, 1.0);
+        assert_eq!(dm_gf.x_scale.max, 0.0);
         assert!(dm_gf.y_points.is_empty());
     }
 


### PR DESCRIPTION
## Summary

- Ship the embeddable `sd-model` stylesheet in deploy artifacts and link it inside the closed shadow root.
- Add production deploy guards for App Engine rebuild suppression, session-cookie secrets, and static HTML CSP/HSTS.
- Delete project content blobs with project deletion, fix native JSON empty graphical functions, and align pysimlin `BAD_OVERRIDE` decoding.

## Validation

- Pre-commit hook passed: dependency policy, docs links, project lint rules, Rust fmt/cbindgen/clippy/tests, TypeScript lint/build/tsc/tests, and pysimlin tests.
- Deploy artifact verification passed: `pnpm --filter @simlin/app run deploy:assemble`, `bash scripts/verify-deploy-build.sh`, `pnpm --filter @simlin/app run deploy:clean`.
- Additional checks run before commit: `pnpm build`, `pnpm lint`, app/server/diagram Jest suites, `cargo test -p simlin-engine json::tests`, `uv run pytest tests/ -x`, `uv run ruff check simlin tests/test_errors.py`, and `uv run mypy simlin`.

## Deployment Notes

- Before production deploy, reconcile private `.app.prod.yaml` with `app.yaml`, especially `build_env_variables.GOOGLE_NODE_RUN_SCRIPTS: ''` and `authentication__seshcookie__key`.
- A real App Engine `--no-promote` deploy still needs to run from an environment with `.app.prod.yaml` and `gcloud`.
