### PR TITLE
diagram: interactive-editing burndown (Cancel, cloud drags, offscreen open, sim specs, selection state)

### DIFF
--- a/src/diagram/Editor.tsx
+++ b/src/diagram/Editor.tsx
@@ -48,6 +48,7 @@ import { FlowIcon } from './FlowIcon';
 import { LinkIcon } from './LinkIcon';
 import { ModuleIcon } from './ModuleIcon';
 import { ModelPropertiesDrawer } from './ModelPropertiesDrawer';
+import type { SimSpecField } from './sim-spec-draft';
 import { renderSvgToString } from './render-common';
 import { Status } from './Status';
 import { StockIcon } from './StockIcon';
@@ -1197,24 +1198,26 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
     await applyPatchAndRefresh(patch, 'sim specs');
   };
 
-  const handleStartTimeChange = React.useCallback(async (event: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
-    const value = Number(event.target.value);
-    await applySimSpecChange({ startTime: value });
-  }, []);
-
-  const handleStopTimeChange = React.useCallback(async (event: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
-    const value = Number(event.target.value);
-    await applySimSpecChange({ endTime: value });
-  }, []);
-
-  const handleDtChange = React.useCallback(async (event: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
-    const value = Number(event.target.value);
-    await applySimSpecChange({ dt: `${value}` });
-  }, []);
-
-  const handleTimeUnitsChange = React.useCallback(async (event: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
-    const value = event.target.value;
-    await applySimSpecChange({ timeUnits: value });
+  // The drawer holds a draft while a sim-specs field is focused and calls this
+  // exactly once when the field settles (blur/Enter) with a validated, changed
+  // value -- so a single edit is one engine patch and one undo entry, instead
+  // of one per keystroke (issue #55). The drawer already rejected garbage/empty
+  // input, so we only route the field to its `applySimSpecChange` update.
+  const handleSimSpecCommit = React.useCallback((field: SimSpecField, value: number | string): void => {
+    switch (field) {
+      case 'startTime':
+        void applySimSpecChange({ startTime: value as number });
+        break;
+      case 'stopTime':
+        void applySimSpecChange({ endTime: value as number });
+        break;
+      case 'dt':
+        void applySimSpecChange({ dt: `${value as number}` });
+        break;
+      case 'timeUnits':
+        void applySimSpecChange({ timeUnits: value as string });
+        break;
+    }
   }, []);
 
   const handleDownloadXmile = React.useCallback(async (): Promise<void> => {
@@ -1276,10 +1279,7 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
         stopTime={simSpec.stop}
         dt={dt}
         timeUnits={simSpec.timeUnits || ''}
-        onStartTimeChange={handleStartTimeChange}
-        onStopTimeChange={handleStopTimeChange}
-        onDtChange={handleDtChange}
-        onTimeUnitsChange={handleTimeUnitsChange}
+        onSimSpecCommit={handleSimSpecCommit}
         onDownloadXmile={handleDownloadXmile}
         onDelete={onDelete}
       />

--- a/src/diagram/Editor.tsx
+++ b/src/diagram/Editor.tsx
@@ -167,6 +167,52 @@ interface EditorState {
   variableDetailsActiveTab: number;
 }
 
+// Enforces the Editor's selection invariant for the element-mutation paths
+// (delete, create, flow/link attach): when such a path leaves the selection
+// EMPTY, the selection-tied variable-details panel must close and the
+// variable-details tab must reset. Every one of those setState sites composes
+// this (spread into its patch) so the rule holds uniformly instead of each call
+// site re-deriving it and drifting apart.
+//
+// The errors panel is EXEMPT. showDetails is a single field that is either
+// 'variable' (a panel bound to the selected variable), 'errors' (the
+// model-level error list, independent of any selection), or undefined. Only the
+// 'variable' case is tied to the selection, so an emptied selection clears
+// showDetails ONLY when it is currently 'variable' -- deleting a variable while
+// triaging the error list must not dismiss that list. currentShowDetails is
+// therefore an input.
+//
+// A non-empty selection is returned unchanged: the caller keeps ownership of
+// showDetails for the paths that intentionally open a panel. handleSelection's
+// empty-click/Escape dismiss and the navigation handlers deliberately close
+// EVERYTHING (variable AND errors), so they do NOT route through here.
+//
+// The bug this closes: the delete/create/attach handlers mutated `selection`
+// directly and skipped the variable-panel reset, leaving showDetails at
+// 'variable' with nothing selected -- masked only because getDetails() also
+// guards on a named selected element, but fragile (a later single-select would
+// pop the stale panel open, and any change to that render guard would surface a
+// broken panel over an empty selection).
+export function selectionStatePatch(
+  selection: ReadonlySet<UID>,
+  currentShowDetails: 'variable' | 'errors' | undefined,
+): {
+  selection: ReadonlySet<UID>;
+  showDetails?: 'variable' | 'errors' | undefined;
+  variableDetailsActiveTab?: number;
+} {
+  if (selection.size === 0) {
+    // Close the variable panel only if it is the one showing; leave an open
+    // errors panel (or an already-closed panel) untouched. Reset the tab
+    // regardless so the next variable panel opens on its first tab.
+    if (currentShowDetails === 'variable') {
+      return { selection, showDetails: undefined, variableDetailsActiveTab: 0 };
+    }
+    return { selection, variableDetailsActiveTab: 0 };
+  }
+  return { selection };
+}
+
 // Discriminated union types for project data formats
 export type ProtobufProjectData = {
   format: 'protobuf';
@@ -541,6 +587,10 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
   React.useEffect(() => {
     if (navResetSeq !== r.lastNavResetSeq) {
       r.lastNavResetSeq = navResetSeq;
+      // An undo-driven navigation reset (the viewed model vanished) is a
+      // full reset, not an element mutation: close EVERYTHING explicitly rather
+      // than routing through selectionStatePatch (which would preserve an open
+      // errors panel).
       setState({
         selection: new Set<UID>(),
         showDetails: undefined,
@@ -770,6 +820,12 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
       flowStillBeingCreated: false,
       variableDetailsActiveTab: 0,
     });
+    // An empty selection here is a deliberate dismiss gesture (clicking empty
+    // canvas, Escape, clearing the search box), so close EVERYTHING -- the
+    // variable panel AND the model-level errors panel. This is intentionally
+    // broader than selectionStatePatch (which the element-mutation paths use so
+    // an emptied selection preserves an open errors panel); the two behaviors
+    // are deliberately distinct, so this path does NOT route through the helper.
     if (selection.size === 0) {
       setState({ showDetails: undefined });
     }
@@ -861,10 +917,10 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
     // dropped the deleted element but props.selection still pointed at it --
     // Canvas's buildSelectionMap now tolerates that, but the state transition
     // should still be atomic.) The deleteOps above were computed from the
-    // pre-clear selection.
-    setState({
-      selection: new Set<number>(),
-    });
+    // pre-clear selection. selectionStatePatch also closes the variable panel
+    // (but not an open errors panel) and resets the tab in this same block so
+    // the emptied selection can't strand a variable panel over nothing.
+    setState(selectionStatePatch(new Set<number>(), latest.current.state.showDetails));
 
     if (deleteOps.length > 0) {
       const patch: JsonProjectPatch = {
@@ -948,8 +1004,12 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
       }
 
       await updateView({ ...view, nextUid: result.nextUid, elements: [...result.elements] }, { recordHistory: true });
+      // Creation assigns the new flow (non-empty) and arms flowStillBeingCreated
+      // (which suppresses the panel until the flow is named); a reattach
+      // preserves the prior selection. selectionStatePatch keeps the
+      // empty-selection invariant should either ever resolve to no selection.
       setState({
-        selection,
+        ...selectionStatePatch(selection, latest.current.state.showDetails),
         flowStillBeingCreated: inCreation,
       });
       scheduleSimRun();
@@ -995,7 +1055,7 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
     view = { ...view, nextUid, elements };
 
     await updateView(view, { recordHistory: true });
-    setState({ selection });
+    setState(selectionStatePatch(selection, latest.current.state.showDetails));
   }, []);
 
   const handleCreateVariable = React.useCallback(async (element: ViewElement): Promise<void> => {
@@ -1071,9 +1131,7 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
     await applyPatchOrReportError(patch, 'variable creation');
 
     await updateView({ ...view, nextUid, elements }, { recordHistory: true });
-    setState({
-      selection: new Set<number>(),
-    });
+    setState(selectionStatePatch(new Set<number>(), latest.current.state.showDetails));
   }, []);
 
   const handleSelectionMove = React.useCallback(
@@ -1453,6 +1511,8 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
       return;
     }
     const newModelName = controller.getModelName();
+    // Navigation is a full context switch: close EVERYTHING (variable AND
+    // errors) explicitly rather than routing through selectionStatePatch.
     setState({
       selection: outcome.restoredSelection,
       showDetails: undefined,
@@ -1474,6 +1534,8 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
     if (!outcome.restoredSelection) {
       return;
     }
+    // Navigation is a full context switch: close EVERYTHING explicitly (the
+    // restored parent selection may be non-empty), not via selectionStatePatch.
     setState({
       selection: outcome.restoredSelection,
       showDetails: undefined,
@@ -1489,6 +1551,8 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
     if (!outcome.restoredSelection) {
       return;
     }
+    // Same as navigateBack: a full context switch that closes EVERYTHING
+    // explicitly, not via selectionStatePatch.
     setState({
       selection: outcome.restoredSelection,
       showDetails: undefined,
@@ -1503,14 +1567,19 @@ export const Editor = React.memo(function Editor(props: EditorProps): React.Reac
       }
       const element = getNamedElement(canonicalize(newValue));
       handleSelection(element ? new Set([element.uid]) : new Set());
-      // Don't open the mutation-capable details panel for read-only
-      // models (stdlib models, embedded mode). The Canvas-level guard
-      // at line ~1480 handles double-click, but search bypasses it.
-      const readOnly = latest.current.props.embedded || isStdlibModel(modelName());
-      setState({
-        showDetails: readOnly ? undefined : 'variable',
-      });
       if (element) {
+        // Don't open the mutation-capable details panel for read-only
+        // models (stdlib models, embedded mode). The Canvas-level guard
+        // at line ~1480 handles double-click, but search bypasses it.
+        //
+        // Only open the panel when the search resolved to an element. When it
+        // did not, handleSelection already cleared the selection (and, via its
+        // own empty-selection close-all, showDetails); setting showDetails here
+        // would strand a 'variable' panel over an empty selection.
+        const readOnly = latest.current.props.embedded || isStdlibModel(modelName());
+        setState({
+          showDetails: readOnly ? undefined : 'variable',
+        });
         await centerVariable(element);
       }
     },

--- a/src/diagram/ModelPropertiesDrawer.tsx
+++ b/src/diagram/ModelPropertiesDrawer.tsx
@@ -13,6 +13,7 @@ import { ArrowBackIcon, ClearIcon, CloudDownloadIcon } from './components/icons'
 
 import { DeleteProjectButton } from './DeleteProjectButton';
 import { ModelIcon } from './ModelIcon';
+import { formatSimSpecValue, resolveSimSpecDraft, type SimSpecField } from './sim-spec-draft';
 
 import styles from './ModelPropertiesDrawer.module.css';
 
@@ -24,15 +25,137 @@ interface ModelPropertiesDrawerProps {
   stopTime: number;
   dt: number;
   timeUnits: string;
-  onStartTimeChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  onStopTimeChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  onDtChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  onTimeUnitsChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  // Fired once when a sim-specs field settles (blur/Enter) with a value that
+  // actually changed and passed validation -- NOT per keystroke. Each call is
+  // one engine patch / one undo entry. Replaces the old per-`onChange`
+  // handlers, which recorded an undo entry and scheduled a save on every
+  // character typed (issue #55).
+  onSimSpecCommit: (field: SimSpecField, value: number | string) => void;
   onDownloadXmile: () => void;
   // When provided, a destructive "Delete project" action is shown. Hosts that
   // can't (or shouldn't) delete -- read-only viewers, embeds, the local
   // file-backed viewer -- simply leave this undefined.
   onDelete?: () => Promise<void>;
+}
+
+interface SimSpecDraftFieldProps {
+  field: SimSpecField;
+  label: string;
+  value: number | string;
+  type?: string;
+  onCommit: (field: SimSpecField, value: number | string) => void;
+}
+
+// A single sim-specs field: controlled from `value` (the model) when idle, but
+// holding a local draft string while focused so typing does not touch the
+// model. It commits ONCE on settle (blur/Enter, via the pure
+// `resolveSimSpecDraft`), reverts on Escape, and never clobbers an in-progress
+// draft when new props arrive mid-edit. Keeping the draft state per-field (one
+// component instance each) makes those semantics fall out structurally: an
+// engine refresh only releases the drafts of fields that are not focused.
+function SimSpecDraftField(props: SimSpecDraftFieldProps): React.ReactElement {
+  const { field, label, value, type, onCommit } = props;
+
+  // `undefined` means "not editing -- show the model value". A string means an
+  // edit is in flight (or a just-committed value awaiting the model catching up).
+  const [draft, setDraft] = React.useState<string | undefined>(undefined);
+  const focusedRef = React.useRef(false);
+  // Set synchronously by Escape so the blur it triggers skips the commit. A ref
+  // (not state) because the blur handler runs in the same tick, before a state
+  // update would be visible.
+  const skipNextCommitRef = React.useRef(false);
+  // The exact draft text of the most recent commit, held until the model prop
+  // catches up. It makes commit idempotent under prop lag: a second blur of the
+  // same retained draft (e.g. focus moving to a sibling field re-blurs this
+  // one) must not fire a duplicate patch/undo entry, because `value` is still
+  // the stale pre-commit model value the decision compares against. Cleared on
+  // any fresh keystroke and when the draft releases.
+  const committedDraftRef = React.useRef<string | undefined>(undefined);
+
+  // While unfocused, the model value is the source of truth: a new prop (engine
+  // refresh, undo, external edit) releases any lingering draft so the field
+  // shows the model. Guarded on focus so a refresh mid-edit never clobbers what
+  // the user is typing. This also clears the "committed, awaiting model" draft
+  // once the model reflects the commit -- so a valid commit shows the typed
+  // value continuously, with no flash of the pre-edit value.
+  React.useEffect(() => {
+    if (!focusedRef.current) {
+      setDraft(undefined);
+      committedDraftRef.current = undefined;
+    }
+  }, [value]);
+
+  const display = draft ?? formatSimSpecValue(value);
+
+  const commit = (): void => {
+    // `draft` is read from the current render's closure. Every keystroke
+    // re-renders (onChange -> setDraft), so by the time a blur/Enter fires this
+    // closure has the latest text.
+    if (draft === undefined || committedDraftRef.current === draft) {
+      return;
+    }
+    const decision = resolveSimSpecDraft(field, draft, value);
+    if (decision.shouldCommit && decision.value !== undefined) {
+      committedDraftRef.current = draft;
+      onCommit(field, decision.value);
+      // Keep the committed text visible; the [value] effect releases the draft
+      // when the model prop catches up.
+    } else {
+      // Unchanged / invalid / empty: discard the draft and show the model.
+      setDraft(undefined);
+    }
+  };
+
+  return (
+    <TextField
+      label={label}
+      value={display}
+      type={type}
+      margin="normal"
+      fullWidth
+      onChange={(e) => {
+        // A fresh keystroke supersedes any retained committed text.
+        committedDraftRef.current = undefined;
+        setDraft(e.target.value);
+      }}
+      inputProps={{
+        onFocus: () => {
+          focusedRef.current = true;
+          // Seed from the current display so refocusing before the model
+          // catches up preserves a just-committed value.
+          setDraft((d) => d ?? formatSimSpecValue(value));
+        },
+        onBlur: () => {
+          focusedRef.current = false;
+          if (skipNextCommitRef.current) {
+            skipNextCommitRef.current = false;
+            setDraft(undefined);
+            return;
+          }
+          commit();
+        },
+        onKeyDown: (e) => {
+          if (e.key === 'Enter') {
+            // Blur drives the single commit (avoids a double commit from
+            // committing here and again on the ensuing blur).
+            e.preventDefault();
+            e.currentTarget.blur();
+          } else if (e.key === 'Escape') {
+            e.preventDefault();
+            // Escape here means "revert this field", not "dismiss the drawer":
+            // stop propagation so the Drawer's own document-level Escape-close
+            // listener doesn't also fire and yank the whole panel away.
+            e.stopPropagation();
+            // Discard the draft (revert to the model) and skip the commit the
+            // ensuing blur would otherwise run against the pre-Escape draft.
+            skipNextCommitRef.current = true;
+            setDraft(undefined);
+            e.currentTarget.blur();
+          }
+        },
+      }}
+    />
+  );
 }
 
 export function ModelPropertiesDrawer(props: ModelPropertiesDrawerProps): React.ReactElement {
@@ -44,10 +167,7 @@ export function ModelPropertiesDrawer(props: ModelPropertiesDrawerProps): React.
     stopTime,
     dt,
     timeUnits,
-    onStartTimeChange,
-    onStopTimeChange,
-    onDtChange,
-    onTimeUnitsChange,
+    onSimSpecCommit,
     onDownloadXmile,
     onDelete,
   } = props;
@@ -82,24 +202,22 @@ export function ModelPropertiesDrawer(props: ModelPropertiesDrawerProps): React.
 
         <div className={styles.propsForm}>
           <h2>{modelName}</h2>
-          <TextField
+          <SimSpecDraftField
+            field="startTime"
             label="Start Time"
             value={startTime}
-            onChange={onStartTimeChange}
             type="number"
-            margin="normal"
-            fullWidth
+            onCommit={onSimSpecCommit}
           />
-          <TextField
+          <SimSpecDraftField
+            field="stopTime"
             label="Stop Time"
             value={stopTime}
-            onChange={onStopTimeChange}
             type="number"
-            margin="normal"
-            fullWidth
+            onCommit={onSimSpecCommit}
           />
-          <TextField label="dt" value={dt} onChange={onDtChange} type="number" margin="normal" fullWidth />
-          <TextField label="Time Units" value={timeUnits} onChange={onTimeUnitsChange} margin="normal" fullWidth />
+          <SimSpecDraftField field="dt" label="dt" value={dt} type="number" onCommit={onSimSpecCommit} />
+          <SimSpecDraftField field="timeUnits" label="Time Units" value={timeUnits} onCommit={onSimSpecCommit} />
           <br />
           <br />
           <Button

--- a/src/diagram/VariableDetails.tsx
+++ b/src/diagram/VariableDetails.tsx
@@ -64,6 +64,33 @@ function descendantsFromString(equation: string): CustomElement[] {
   return plainDeserialize('equation', equation);
 }
 
+// Replace a Slate editor's entire document. `<Slate initialValue>` is
+// uncontrolled after mount, so resetting the React state that seeded it does
+// NOT revert the visible content -- the editor must be mutated directly. Used
+// by the discard (Cancel/Escape) path so the on-screen text snaps back to the
+// original. Deselect first so a caret sitting at a now-out-of-range path cannot
+// throw while the old nodes are removed, then swap the document wholesale inside
+// a single non-normalizing batch.
+//
+// Then clear the undo/redo history. The editors are `withHistory`, so the
+// discard's own transforms -- and the keystrokes they undo -- are otherwise
+// recorded as ordinary history; a single Cmd+Z would invert the revert and
+// resurrect the abandoned text (which a later blur would then commit).
+// `withoutSaving` is not enough: it would keep the discard out of history but
+// leave the original keystrokes in `undos`, so undo would still bring the text
+// partway back. Resetting `history` wholesale is safe -- after a discard the
+// document equals the original, so there is nothing meaningful left to undo.
+function resetEditorDocument(editor: CustomEditor, nodes: CustomElement[]): void {
+  Editor.withoutNormalizing(editor, () => {
+    Transforms.deselect(editor);
+    for (let i = editor.children.length - 1; i >= 0; i--) {
+      Transforms.removeNodes(editor, { at: [i] });
+    }
+    Transforms.insertNodes(editor, nodes, { at: [0] });
+  });
+  editor.history = { undos: [], redos: [] };
+}
+
 function scalarEquationFor(variable: Variable): string {
   if (variable.type === 'module') return '';
   if (variable.equation.type === 'scalar') {
@@ -239,6 +266,16 @@ function caretOffsetForPreviewClick(host: HTMLElement, clientX: number, clientY:
 export function VariableDetails(props: VariableDetailsProps): React.ReactElement {
   const { variable, viewElement, getLatexEquation, onDelete, onEquationChange, onTableChange, activeTab } = props;
 
+  // The original (props-derived) document for each field. These seed the editors
+  // on mount and are what the discard path (Cancel/Escape) restores, so the
+  // seeding and the revert stay in lockstep -- including the error/warning
+  // highlight the equation and units fields carry.
+  const initialEquationContents = (): CustomElement[] =>
+    highlightErrors(scalarEquationFor(variable), variable.errors, variable.unitErrors, false);
+  const initialUnitsContents = (): CustomElement[] =>
+    highlightErrors(variable.units, variable.errors, variable.unitErrors, true);
+  const initialNotesContents = (): CustomElement[] => descendantsFromString(variable.documentation);
+
   // Seed the Slate editors and their contents from props exactly once per mount
   // (lazy useState initializers), mirroring the old constructor. The Editor keys
   // this panel on projectGeneration, so a content change remounts the panel and
@@ -250,21 +287,15 @@ export function VariableDetails(props: VariableDetailsProps): React.ReactElement
   const [equationEditor] = React.useState<CustomEditor>(
     () => withHistory(withReact(createEditor())) as unknown as CustomEditor,
   );
-  const [equationContents, setEquationContents] = React.useState<Descendant[]>(() =>
-    highlightErrors(scalarEquationFor(variable), variable.errors, variable.unitErrors, false),
-  );
+  const [equationContents, setEquationContents] = React.useState<Descendant[]>(initialEquationContents);
   const [unitsEditor] = React.useState<CustomEditor>(
     () => withHistory(withReact(createEditor())) as unknown as CustomEditor,
   );
-  const [unitsContents, setUnitsContents] = React.useState<Descendant[]>(() =>
-    highlightErrors(variable.units, variable.errors, variable.unitErrors, true),
-  );
+  const [unitsContents, setUnitsContents] = React.useState<Descendant[]>(initialUnitsContents);
   const [notesEditor] = React.useState<CustomEditor>(
     () => withHistory(withReact(createEditor())) as unknown as CustomEditor,
   );
-  const [notesContents, setNotesContents] = React.useState<Descendant[]>(() =>
-    descendantsFromString(variable.documentation),
-  );
+  const [notesContents, setNotesContents] = React.useState<Descendant[]>(initialNotesContents);
   const [editingEquation, setEditingEquation] = React.useState<boolean>(
     () => !!(variable.errors && variable.errors.length > 0),
   );
@@ -275,6 +306,11 @@ export function VariableDetails(props: VariableDetailsProps): React.ReactElement
   // because they gate async continuations and must never themselves re-render.
   const latexRequestId = React.useRef(0);
   const mounted = React.useRef(false);
+
+  // The outer panel element, used to tell an intra-panel focus move (tabbing to
+  // another field or to the Cancel/Save buttons) from focus genuinely leaving
+  // the panel. Only the latter commits the in-progress edit on blur.
+  const cardRef = React.useRef<HTMLDivElement>(null);
 
   // Stable references for the load effect so it depends only on viewElement.ident
   // (the class's componentDidMount + componentDidUpdate prev-ident comparison),
@@ -335,11 +371,43 @@ export function VariableDetails(props: VariableDetailsProps): React.ReactElement
     setNotesContents(equation);
   };
 
+  // Discard every in-progress edit and restore the original documents. Both the
+  // React state (which drives the preview and the Save/Cancel enabled state) and
+  // the live Slate documents (uncontrolled after mount) must be reset, or the
+  // visible editors would keep showing the abandoned text. Shared by the Cancel
+  // button and the Escape key.
   const handleEquationCancel = (): void => {
-    setEquationContents(descendantsFromString(scalarEquationFor(variable)));
-    setUnitsContents(descendantsFromString(variable.units));
-    setNotesContents(descendantsFromString(variable.documentation));
+    const equation = initialEquationContents();
+    const units = initialUnitsContents();
+    const notes = initialNotesContents();
+    resetEditorDocument(equationEditor, equation);
+    resetEditorDocument(unitsEditor, units);
+    resetEditorDocument(notesEditor, notes);
+    setEquationContents(equation);
+    setUnitsContents(units);
+    setNotesContents(notes);
     setEditingEquation(false);
+  };
+
+  // Blur commits the in-progress edit only when focus actually leaves the panel
+  // (to the canvas, another variable, or nowhere). This is load-bearing: a
+  // canvas-driven edit first blurs the side-panel editor, and that blur must
+  // commit the pending text (see diagram/CLAUDE.md, "Details panels are keyed by
+  // projectGeneration"). But a blur toward the panel's own Cancel/Save buttons
+  // or another field must NOT commit -- otherwise clicking or tabbing to Cancel
+  // would save the very edit the user is discarding, and the button's own
+  // pointerdown-preventDefault (which keeps focus on the editor for mouse/touch)
+  // is not available on the keyboard path.
+  const focusLeftPanel = (e: React.FocusEvent): boolean => {
+    const next = e.relatedTarget as Node | null;
+    const card = cardRef.current;
+    return !next || !card || !card.contains(next);
+  };
+
+  const handleFieldBlur = (e: React.FocusEvent): void => {
+    if (focusLeftPanel(e)) {
+      handleEquationSave();
+    }
   };
 
   const handleEquationSave = (): void => {
@@ -517,18 +585,31 @@ export function VariableDetails(props: VariableDetailsProps): React.ReactElement
               placeholder="Enter an equation..."
               spellCheck={false}
               autoFocus
-              onBlur={() => {
+              onBlur={(e) => {
+                // An intra-panel focus move (to another field or the action
+                // buttons) neither commits nor collapses the raw editor: the
+                // edit is still pending, so leaving the editor mounted keeps it
+                // visible instead of snapping back to the last-committed preview.
+                if (!focusLeftPanel(e)) {
+                  return;
+                }
                 handleEquationSave();
-                // Stay in editing mode only for genuine equation errors --
-                // the same gating as showPreview; unit warnings render under
-                // the chart and shouldn't pin the raw editor open.
+                // Collapse back to the preview on the way out, except when a
+                // genuine equation error pins the raw editor open (same gating
+                // as showPreview; unit warnings render under the chart and
+                // shouldn't pin it open).
                 if (!variable.errors || variable.errors.length === 0) {
                   setEditingEquation(false);
                 }
               }}
               onKeyDown={(e) => {
                 if (e.key === 'Escape') {
-                  setEditingEquation(false);
+                  // Escape discards the in-progress edit (revert + exit), the
+                  // same as the Cancel button. Without this the field would only
+                  // exit editing and the ensuing blur would commit the abandoned
+                  // text.
+                  e.preventDefault();
+                  handleEquationCancel();
                   return;
                 }
                 // Cmd/Ctrl+Enter inserts a line break, matching Shift+Enter
@@ -553,7 +634,15 @@ export function VariableDetails(props: VariableDetailsProps): React.ReactElement
             renderLeaf={renderLeaf}
             placeholder="Enter units..."
             spellCheck={false}
-            onBlur={handleEquationSave}
+            onBlur={handleFieldBlur}
+            onKeyDown={(e) => {
+              // Escape discards, matching the equation field and the Cancel
+              // button. (Still no newline chord here -- units are single-line.)
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                handleEquationCancel();
+              }
+            }}
           />
         </Slate>
 
@@ -563,8 +652,15 @@ export function VariableDetails(props: VariableDetailsProps): React.ReactElement
             renderLeaf={renderLeaf}
             placeholder="Documentation"
             spellCheck={false}
-            onBlur={handleEquationSave}
+            onBlur={handleFieldBlur}
             onKeyDown={(e) => {
+              // Escape discards, matching the equation field and the Cancel
+              // button.
+              if (e.key === 'Escape') {
+                e.preventDefault();
+                handleEquationCancel();
+                return;
+              }
               // Documentation is multi-line like the equation; accept the same
               // Cmd/Ctrl+Enter line-break chord Shift+Enter already provides.
               if (isNewlineChord(e)) {
@@ -576,14 +672,38 @@ export function VariableDetails(props: VariableDetailsProps): React.ReactElement
         </Slate>
 
         <div className={styles.cardActions}>
-          <Button size="small" color="error" onClick={handleVariableDelete} className={styles.buttonLeft}>
+          {/* preventDefault on pointer-down keeps focus on the editor for
+              mouse/touch, so pressing an action button does not blur-commit the
+              field before the click runs (macOS in particular does not focus a
+              button on click, so a plain blur would otherwise fire). The keyboard
+              path is handled by focusLeftPanel above. Delete gets it too so a
+              pending edit is not committed on the way to deleting the variable. */}
+          <Button
+            size="small"
+            color="error"
+            onMouseDown={(e) => e.preventDefault()}
+            onClick={handleVariableDelete}
+            className={styles.buttonLeft}
+          >
             Delete
           </Button>
           <div className={styles.buttonRight}>
-            <Button size="small" color="primary" disabled={!equationActionsEnabled} onClick={handleEquationCancel}>
+            <Button
+              size="small"
+              color="primary"
+              disabled={!equationActionsEnabled}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={handleEquationCancel}
+            >
               Cancel
             </Button>
-            <Button size="small" color="primary" disabled={!equationActionsEnabled} onClick={handleEquationSave}>
+            <Button
+              size="small"
+              color="primary"
+              disabled={!equationActionsEnabled}
+              onMouseDown={(e) => e.preventDefault()}
+              onClick={handleEquationSave}
+            >
               Save
             </Button>
           </div>
@@ -658,7 +778,7 @@ export function VariableDetails(props: VariableDetailsProps): React.ReactElement
   const lookupTab = viewElement.type === 'stock' ? undefined : <Tab label="Lookup Function" />;
 
   return (
-    <div className={styles.card}>
+    <div className={styles.card} ref={cardRef}>
       <Tabs
         className={styles.inner}
         variant="fullWidth"

--- a/src/diagram/VariableDetails.tsx
+++ b/src/diagram/VariableDetails.tsx
@@ -431,6 +431,17 @@ export function VariableDetails(props: VariableDetailsProps): React.ReactElement
   };
 
   const handleTabChange = (_event: React.SyntheticEvent, newValue: number): void => {
+    // Switching tabs is a leave-the-editing-context action and must commit any
+    // pending equation/units/notes edit, exactly like blur-away. The blur that
+    // precedes this click is intra-panel (the tab strip is inside the card), so
+    // the focusLeftPanel gate deliberately skipped it -- but the tab switch
+    // unmounts the editors and the Lookup tab renders no Save/Cancel, so
+    // without a commit here the pending edit would sit stranded and invisible
+    // until the next keyed remount silently dropped it.
+    handleEquationSave();
+    if (!variable.errors || variable.errors.length === 0) {
+      setEditingEquation(false);
+    }
     props.onActiveTabChange(newValue);
   };
 

--- a/src/diagram/components/Button.tsx
+++ b/src/diagram/components/Button.tsx
@@ -14,6 +14,7 @@ interface ButtonProps {
   size?: 'small' | 'medium' | 'large';
   disabled?: boolean;
   onClick?: (event: React.MouseEvent<HTMLButtonElement>) => void;
+  onMouseDown?: (event: React.MouseEvent<HTMLButtonElement>) => void;
   className?: string;
   style?: React.CSSProperties;
   startIcon?: React.ReactNode;
@@ -32,6 +33,7 @@ export default function Button(props: ButtonProps): React.ReactElement {
     size = 'medium',
     disabled,
     onClick,
+    onMouseDown,
     className,
     style,
     startIcon,
@@ -94,6 +96,7 @@ export default function Button(props: ButtonProps): React.ReactElement {
       style={style}
       disabled={disabled}
       onClick={onClick}
+      onMouseDown={onMouseDown}
       type={type}
       aria-label={ariaLabel}
       aria-owns={ariaOwns}

--- a/src/diagram/drawing/Canvas.tsx
+++ b/src/diagram/drawing/Canvas.tsx
@@ -64,6 +64,8 @@ import { isDragMovement, shouldShowVariableDetails } from './pointer-utils';
 import {
   VELOCITY_THRESHOLD,
   calculateVelocity as computeVelocity,
+  centerOffsetForBounds,
+  isDiagramOffscreen,
   isMomentumDone,
   momentumOffsetAt,
   pinchOffset,
@@ -336,6 +338,14 @@ interface CanvasRefs {
   momentumStartTime: number | undefined;
   momentumInitialVelocity: Point | undefined;
   momentumStartOffset: Point | undefined;
+
+  // One-shot latch for the mount-time offscreen re-center (issue #52). Set the
+  // first time we can evaluate the check (real svgSize, idle, non-embedded) so
+  // it runs at most once per Canvas instance and never re-triggers on later
+  // prop churn. Because the Editor renders Canvas without a `key`, module
+  // navigation reuses the same instance and the latch persists across drill-in
+  // -- intentional: navigation restores/seeds its own viewport.
+  offscreenChecked: boolean;
 }
 
 // The local "live viewport" the canvas owns DURING a gesture (pan, momentum,
@@ -421,6 +431,7 @@ export const Canvas = React.memo(function Canvas(props: CanvasProps): React.Reac
       momentumStartTime: undefined,
       momentumInitialVelocity: undefined,
       momentumStartOffset: undefined,
+      offscreenChecked: false,
     };
     // Seed the empty derivation's elementsByUid to the same map instance, as the
     // class constructor did (derived.elementsByUid === this.elements).
@@ -2663,6 +2674,65 @@ export const Canvas = React.memo(function Canvas(props: CanvasProps): React.Reac
     // closes over stale values. (The repo lint config does not enable
     // react-hooks/exhaustive-deps, so no disable directive is needed.)
   }, []);
+
+  // ---- Offscreen re-center on mount (issue #52) ---------------------------
+  // A saved viewBox/zoom can leave the whole diagram outside the visible canvas
+  // (e.g. it was panned far away, or the window is a very different size than
+  // when it was saved and the mount-time proportional refit preserved the
+  // offscreen framing). The user then opens the model to a blank surface with
+  // no idea where it went. Once we know both the element bounds and the real
+  // svg size, check the visible fraction and, if the diagram is (mostly)
+  // offscreen, center it at the current zoom.
+  //
+  // This runs at most once per mount (the `offscreenChecked` latch): it must not
+  // fight a later user pan or an external viewport change, and module drill-in
+  // (same Canvas instance -- see the latch's comment) manages its own viewport.
+  // "Idle" here matches the resize handler's convention (`!liveViewport`): while
+  // a gesture owns the live viewport the check waits, so it never yanks the view
+  // out from under an in-flight pan/pinch/coast. The commit goes through
+  // `onViewBoxChange` directly -- the same view-only, non-undo path the idle
+  // resize uses -- so the host persists it once with no history entry. Zoom is
+  // deliberately left unchanged (scope kept tight to re-centering).
+  React.useEffect(() => {
+    if (r.offscreenChecked || props.embedded || liveViewport) {
+      return;
+    }
+    if (!svgSize || svgSize.width <= 0 || svgSize.height <= 0) {
+      // No real measurement yet: wait for the first ResizeObserver delivery
+      // (or the mount effect's initial fit) without burning our one shot.
+      return;
+    }
+    // This is the one measured, idle, non-embedded opportunity.
+    r.offscreenChecked = true;
+
+    // Bounds come from the derivation the just-committed render produced (same
+    // pure pass the mount effect uses), so this reflects what is actually drawn.
+    const derived = r.derived;
+    const bounds = calcViewBox(computeElementBounds(derived.displayElements, derived.selectionUpdates));
+    if (!bounds) {
+      // Empty model: nothing to center against.
+      return;
+    }
+
+    const offset = props.view.viewBox;
+    const zoom = props.view.zoom;
+    if (!isDiagramOffscreen(bounds, offset, zoom, svgSize)) {
+      return;
+    }
+
+    const centered = centerOffsetForBounds(bounds, zoom, svgSize);
+    const newViewBox: ViewRect = {
+      x: centered.x,
+      y: centered.y,
+      width: svgSize.width,
+      height: svgSize.height,
+    };
+    props.onViewBoxChange(newViewBox, zoom);
+    // Deps: svgSize (the gating first measurement), props.view (re-evaluate if
+    // the view changes before we get a measured shot), and liveViewport (defer
+    // while a gesture is live, re-check when it settles). The latch makes the
+    // effect a no-op after its single run, so extra runs are harmless.
+  }, [svgSize, props.view, liveViewport]);
 
   // ---- Render -------------------------------------------------------------
 

--- a/src/diagram/drawing/Flow.tsx
+++ b/src/diagram/drawing/Flow.tsx
@@ -694,31 +694,40 @@ function adjustFlows(
       };
     }
 
-    // Re-place the valve by mirroring it around the segment: base =
-    // min(otherEnd, moved end) plus the ABSOLUTE scaled offset, so an off-center
-    // valve stays between the two ends even when the drag flips the segment
-    // orientation (the moved end crossing past otherEnd).
+    // Re-place the valve by preserving its FRACTIONAL position along the segment,
+    // anchored to the fixed `otherEnd`. The earlier form -- base = min(otherEnd,
+    // moved end) plus the ABSOLUTE scaled offset -- happened to be idempotent only
+    // when otherEnd was the SMALLER coordinate (a sink cloud on the right). When
+    // the dragged end was the smaller coordinate (a SOURCE cloud on the left),
+    // `base` landed on the moved end and the offset-from-otherEnd was applied from
+    // the wrong reference, reflecting an off-center valve across the segment
+    // midpoint on the very first drag frame (#832). Anchoring to otherEnd with a
+    // SIGNED new length keeps the valve between the two ends even when the moved
+    // end crosses past otherEnd (the flip case the mirror form was chasing), and
+    // clamping the fraction to [0, 1] keeps it on the segment. This mirrors what
+    // `preserveValveFraction` already does for multi-segment flows.
     //
-    // Guard the denominators against zero: for a vertical flow origStock.x ===
-    // otherEnd.x (and likewise y for a horizontal flow), which without the `|| 1`
-    // divides by zero and yields a NaN/Infinity valve -- serialized to JSON null,
-    // that bricks the model (#818).
-    const fraction = {
-      x: flow.x === otherEnd.x ? 0.5 : (stock.x - otherEnd.x) / (origStock.x - otherEnd.x || 1),
-      y: flow.y === otherEnd.y ? 0.5 : (stock.y - otherEnd.y) / (origStock.y - otherEnd.y || 1),
-    };
-    const d = {
-      x: flow.x === otherEnd.x ? stock.x - otherEnd.x : flow.x - otherEnd.x,
-      y: flow.y === otherEnd.y ? stock.y - otherEnd.y : flow.y - otherEnd.y,
-    };
-    const base = {
-      x: Math.min(otherEnd.x, stock.x),
-      y: Math.min(otherEnd.y, stock.y),
+    // The `oldLen === 0` branch preserves the #818 divide-by-zero guard and has
+    // two sub-cases distinguished by the NEW length:
+    //   - newLen === 0: the axis is perpendicular to the flow (x for a vertical
+    //     flow, y for a horizontal one) -- origStock and otherEnd share a
+    //     coordinate and still do, so there is no length to take a fraction of and
+    //     the valve stays on otherEnd's coordinate (frac 0).
+    //   - newLen !== 0: the OLD flow was DEGENERATE (a creation flow whose points
+    //     all coincided at the press point) and this end has now expanded out;
+    //     center the valve on the freshly-created segment (frac 0.5), matching the
+    //     prior formula's degenerate fallback so creation keeps its mid-segment
+    //     valve.
+    const preserveAxis = (valve: number, other: number, origMoved: number, newMoved: number): number => {
+      const oldLen = origMoved - other;
+      const newLen = newMoved - other;
+      const frac = oldLen === 0 ? (newLen === 0 ? 0 : 0.5) : Math.max(0, Math.min(1, (valve - other) / oldLen));
+      return other + frac * newLen;
     };
     flow = {
       ...flow,
-      x: base.x + Math.abs(fraction.x * d.x),
-      y: base.y + Math.abs(fraction.y * d.y),
+      x: preserveAxis(flow.x, otherEnd.x, origStock.x, stock.x),
+      y: preserveAxis(flow.y, otherEnd.y, origStock.y, stock.y),
     };
 
     return { ...flow, points };

--- a/src/diagram/drawing/Flow.tsx
+++ b/src/diagram/drawing/Flow.tsx
@@ -857,49 +857,40 @@ export function UpdateCloudAndFlow(
     const shouldReroute = !isDegenerate && perpAbs >= PERP_THRESHOLD && perpAbs > parAbs;
 
     if (shouldReroute) {
-      // Create L-shape by adding a corner point
-      let newCloudPoint: Point;
-      let newOtherPoint: Point;
-      let corner: Point;
+      // Bend the straight flow into an L by inserting a corner. The dragged cloud
+      // moves by the FULL accumulated delta -- BOTH the perpendicular component
+      // (which forms the bend) AND the parallel component. An earlier version
+      // applied only the perpendicular delta and kept the cloud's ORIGINAL
+      // parallel coordinate; because the live drag re-routes from the original
+      // 2-point flow each pointermove, a drag that had already traveled
+      // along-axis snapped the cloud back to its starting parallel position the
+      // instant it crossed the perpendicular threshold (a one-frame teleport).
+      const base = cloudIsFirst ? firstPoint : lastPoint;
+      const otherPoint = cloudIsFirst ? lastPoint : firstPoint;
+      const newCloudPoint: Point = { ...base, x: base.x - moveDelta.x, y: base.y - moveDelta.y };
 
-      if (treatAsHorizontal) {
-        // Horizontal segment: perpendicular movement is vertical (Y changes)
-        if (cloudIsFirst) {
-          newCloudPoint = { ...firstPoint, y: firstPoint.y - moveDelta.y };
-          newOtherPoint = lastPoint;
-          // Corner at (otherEnd.x, newCloud.y)
-          corner = { x: lastPoint.x, y: newCloudPoint.y, attachedToUid: undefined };
-          points = [newCloudPoint, corner, newOtherPoint];
-        } else {
-          newOtherPoint = firstPoint;
-          newCloudPoint = { ...lastPoint, y: lastPoint.y - moveDelta.y };
-          // Corner at (otherEnd.x, newCloud.y)
-          corner = { x: firstPoint.x, y: newCloudPoint.y, attachedToUid: undefined };
-          points = [newOtherPoint, corner, newCloudPoint];
-        }
-      } else {
-        // Vertical segment: perpendicular movement is horizontal (X changes)
-        if (cloudIsFirst) {
-          newCloudPoint = { ...firstPoint, x: firstPoint.x - moveDelta.x };
-          newOtherPoint = lastPoint;
-          // Corner at (newCloud.x, otherEnd.y)
-          corner = { x: newCloudPoint.x, y: lastPoint.y, attachedToUid: undefined };
-          points = [newCloudPoint, corner, newOtherPoint];
-        } else {
-          newOtherPoint = firstPoint;
-          newCloudPoint = { ...lastPoint, x: lastPoint.x - moveDelta.x };
-          // Corner at (newCloud.x, otherEnd.y)
-          corner = { x: newCloudPoint.x, y: firstPoint.y, attachedToUid: undefined };
-          points = [newOtherPoint, corner, newCloudPoint];
-        }
-      }
+      // The corner keeps the two segments orthogonal: a riser on the FIXED end's
+      // coordinate, then a run out to the cloud. For a (dominantly) horizontal
+      // flow the riser is vertical at otherPoint.x; for a vertical flow it is
+      // horizontal at otherPoint.y.
+      const corner: Point = treatAsHorizontal
+        ? { x: otherPoint.x, y: newCloudPoint.y, attachedToUid: undefined }
+        : { x: newCloudPoint.x, y: otherPoint.y, attachedToUid: undefined };
 
-      // Update cloud position
+      points = cloudIsFirst ? [newCloudPoint, corner, otherPoint] : [otherPoint, corner, newCloudPoint];
+
+      // Update cloud position to the full dragged position.
       cloud = {
         ...cloud,
         x: newCloudPoint.x,
         y: newCloudPoint.y,
       };
+
+      // Normalize before placing the valve: if the cloud was dragged onto the
+      // fixed end's axis the run collapses to zero length and the L degenerates
+      // to a straight flow -- normalizeFlowPoints drops the redundant corner so
+      // the valve lands on a real segment.
+      points = normalizeFlowPoints(points);
 
       // Land the valve on the segment adjacent to the dragged cloud -- the bent
       // segment the drag is actively growing -- at an interior position. Picking
@@ -907,11 +898,8 @@ export function UpdateCloudAndFlow(
       // valve's closest segment flip from this bent segment onto the
       // perpendicular riser as the L deepened, teleporting the valve (and its
       // label) to the riser's stock-adjacent end, flush against the stock body
-      // (#53). Because the live drag re-routes from the original 2-point flow
-      // each pointermove, that flip recurred every frame past a threshold; the
-      // committed reroute inherited the same degenerate position. Anchoring to
-      // the cloud-adjacent segment tracks the cursor continuously, and
-      // clampToSegment keeps the valve off the segment ends.
+      // (#53). Anchoring to the cloud-adjacent segment tracks the cursor
+      // continuously, and clampToSegment keeps the valve off the segment ends.
       const rerouteSegments = getSegments(points);
       const cloudAdjacentSegment = cloudIsFirst ? rerouteSegments[0] : rerouteSegments[rerouteSegments.length - 1];
       const newValve = clampToSegment(currentValve, cloudAdjacentSegment);

--- a/src/diagram/drawing/Flow.tsx
+++ b/src/diagram/drawing/Flow.tsx
@@ -892,8 +892,20 @@ export function UpdateCloudAndFlow(
         y: newCloudPoint.y,
       };
 
-      // Clamp valve to closest segment of new shape
-      const newValve = clampValveToClosestSegment(currentValve, points);
+      // Land the valve on the segment adjacent to the dragged cloud -- the bent
+      // segment the drag is actively growing -- at an interior position. Picking
+      // the merely-CLOSEST segment here (clampValveToClosestSegment) let the
+      // valve's closest segment flip from this bent segment onto the
+      // perpendicular riser as the L deepened, teleporting the valve (and its
+      // label) to the riser's stock-adjacent end, flush against the stock body
+      // (#53). Because the live drag re-routes from the original 2-point flow
+      // each pointermove, that flip recurred every frame past a threshold; the
+      // committed reroute inherited the same degenerate position. Anchoring to
+      // the cloud-adjacent segment tracks the cursor continuously, and
+      // clampToSegment keeps the valve off the segment ends.
+      const rerouteSegments = getSegments(points);
+      const cloudAdjacentSegment = cloudIsFirst ? rerouteSegments[0] : rerouteSegments[rerouteSegments.length - 1];
+      const newValve = clampToSegment(currentValve, cloudAdjacentSegment);
 
       flow = {
         ...flow,

--- a/src/diagram/drawing/viewport.ts
+++ b/src/diagram/drawing/viewport.ts
@@ -15,7 +15,7 @@
  * testable without jsdom and keeps the shell focused on wiring and lifecycle.
  */
 
-import type { Point } from './common';
+import type { Point, Rect } from './common';
 import type { Rect as ViewRect } from '@simlin/core/datamodel';
 
 // --- physics / interaction constants -------------------------------------
@@ -234,5 +234,108 @@ export function resizeViewBox(offset: Point, dWidth: number, dHeight: number, wi
     y: offset.y + dHeight / 4,
     width,
     height,
+  };
+}
+
+// --- offscreen detection / recenter (issue #52) --------------------------
+
+// A diagram whose visible fraction falls below this on mount is treated as
+// "offscreen(ish)" and re-centered, so a saved viewBox/zoom that stranded the
+// model outside the canvas doesn't greet the user with a blank surface.
+export const OFFSCREEN_VISIBLE_FRACTION = 0.1;
+
+/**
+ * The fraction (0..1) of the diagram's bounding box that is currently visible
+ * on the canvas, given the model-space `bounds`, the current `offset`/`zoom`,
+ * and the measured `svgSize`. The render transform maps a model point (mx,my)
+ * to screen ((mx+offset.x)*zoom, (my+offset.y)*zoom) and the visible region is
+ * [0,width] x [0,height], so this intersects the box's screen rect with the
+ * viewport. It is intentionally computed in screen space (not model space): the
+ * viewport is a fixed pixel rectangle, so how much of the box is clipped depends
+ * on zoom -- a model box occupies more of the screen when zoomed in and is more
+ * likely to fall (partly) out of view.
+ *
+ * The intersection is normalized by the SMALLER of the box's screen area and
+ * the viewport area, not by the box area alone. That distinction is the whole
+ * point of the metric: the question is "does the user see enough diagram?", not
+ * "what fraction of the diagram is on screen?". For a box smaller than the
+ * viewport the two coincide (min = box area -> "fraction of the diagram
+ * visible"). For a box LARGER than the viewport, box-area normalization would
+ * report a large-but-well-framed model as mostly hidden -- a 3500x3000 model
+ * perfectly centered in a 1200x800 viewport shows the entire viewport full of
+ * diagram yet only ~9% of its own bbox, and would be needlessly yanked to
+ * bbox-center on every open. Normalizing by the viewport area instead makes a
+ * viewport full of diagram read 1.0 regardless of bbox size (min = viewport
+ * area -> "fraction of the viewport filled by diagram").
+ *
+ * A degenerate box (zero or negative area -- e.g. an empty model) has no
+ * meaningful "visible fraction", so this returns 1 (fully visible) to signal
+ * "nothing to re-center"; `isDiagramOffscreen` relies on that to never trigger
+ * on empty models.
+ */
+export function visibleDiagramFraction(
+  bounds: Rect,
+  offset: Point,
+  zoom: number,
+  svgSize: { width: number; height: number },
+): number {
+  const boxWidth = bounds.right - bounds.left;
+  const boxHeight = bounds.bottom - bounds.top;
+  if (boxWidth <= 0 || boxHeight <= 0) {
+    return 1;
+  }
+
+  const screenLeft = (bounds.left + offset.x) * zoom;
+  const screenTop = (bounds.top + offset.y) * zoom;
+  const screenRight = (bounds.right + offset.x) * zoom;
+  const screenBottom = (bounds.bottom + offset.y) * zoom;
+
+  const interWidth = Math.min(screenRight, svgSize.width) - Math.max(screenLeft, 0);
+  const interHeight = Math.min(screenBottom, svgSize.height) - Math.max(screenTop, 0);
+  if (interWidth <= 0 || interHeight <= 0) {
+    return 0;
+  }
+
+  const boxScreenArea = (screenRight - screenLeft) * (screenBottom - screenTop);
+  const viewportArea = svgSize.width * svgSize.height;
+  return (interWidth * interHeight) / Math.min(boxScreenArea, viewportArea);
+}
+
+/**
+ * True when the diagram is (mostly) offscreen and should be re-centered:
+ * either it does not intersect the viewport at all or its visible fraction is
+ * below `threshold`. Empty models (zero-area bounds) and an unmeasured canvas
+ * (zero-size viewport) never qualify -- there is nothing to center against.
+ */
+export function isDiagramOffscreen(
+  bounds: Rect,
+  offset: Point,
+  zoom: number,
+  svgSize: { width: number; height: number },
+  threshold: number = OFFSCREEN_VISIBLE_FRACTION,
+): boolean {
+  const boxWidth = bounds.right - bounds.left;
+  const boxHeight = bounds.bottom - bounds.top;
+  if (boxWidth <= 0 || boxHeight <= 0) {
+    return false;
+  }
+  if (svgSize.width <= 0 || svgSize.height <= 0) {
+    return false;
+  }
+  return visibleDiagramFraction(bounds, offset, zoom, svgSize) < threshold;
+}
+
+/**
+ * The offset that centers the diagram bounding box in the canvas at the CURRENT
+ * zoom (zoom is intentionally left unchanged -- centering keeps the scope
+ * tight). Solves (boxCenter + offset) * zoom = svgSize / 2 for `offset`, so the
+ * box center lands at the middle of the viewport.
+ */
+export function centerOffsetForBounds(bounds: Rect, zoom: number, svgSize: { width: number; height: number }): Point {
+  const centerX = (bounds.left + bounds.right) / 2;
+  const centerY = (bounds.top + bounds.bottom) / 2;
+  return {
+    x: svgSize.width / (2 * zoom) - centerX,
+    y: svgSize.height / (2 * zoom) - centerY,
   };
 }

--- a/src/diagram/sim-spec-draft.ts
+++ b/src/diagram/sim-spec-draft.ts
@@ -1,0 +1,59 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+// Functional core for the sim-specs drawer fields (start/stop/dt/time units).
+// The drawer holds a per-field draft string while focused and commits ONCE on
+// settle (blur/Enter); these pure helpers decide what the display text is and
+// whether a settled draft is worth committing. Keeping the parse/validation
+// here (separate from the React shell) makes the rules exhaustively testable.
+
+export type SimSpecField = 'startTime' | 'stopTime' | 'dt' | 'timeUnits';
+
+export interface SimSpecCommit {
+  readonly shouldCommit: boolean;
+  // Present iff shouldCommit is true. A number for the three numeric fields, a
+  // string for timeUnits.
+  readonly value?: number | string;
+}
+
+// Renders a model value for display in a field. Numbers use the JS default
+// string form, matching the previously plain controlled `<input value={n}>`.
+export function formatSimSpecValue(value: number | string): string {
+  return `${value}`;
+}
+
+// Decides what to do when a field edit settles. It rejects input that would
+// patch garbage into the model -- empty / non-numeric / non-finite numbers, and
+// a non-positive dt -- and never commits a value equal to the model's current
+// one (so a focus-and-blur with no real change is a no-op). Deliberately does
+// NOT enforce start < stop: the engine reports that as a model error, and the
+// drawer must not invent new validation semantics beyond rejecting garbage.
+// timeUnits is a free string; the empty string is a valid (units are optional).
+export function resolveSimSpecDraft(field: SimSpecField, raw: string, current: number | string): SimSpecCommit {
+  if (field === 'timeUnits') {
+    if (raw === current) {
+      return { shouldCommit: false };
+    }
+    return { shouldCommit: true, value: raw };
+  }
+
+  // Number('') and Number('  ') are 0, so an empty field must be rejected
+  // explicitly rather than trusting Number()/isFinite alone.
+  const trimmed = raw.trim();
+  if (trimmed === '') {
+    return { shouldCommit: false };
+  }
+
+  const value = Number(trimmed);
+  if (!Number.isFinite(value)) {
+    return { shouldCommit: false };
+  }
+  if (field === 'dt' && value <= 0) {
+    return { shouldCommit: false };
+  }
+  if (value === current) {
+    return { shouldCommit: false };
+  }
+  return { shouldCommit: true, value };
+}

--- a/src/diagram/tests/canvas-gestures-offscreen.test.tsx
+++ b/src/diagram/tests/canvas-gestures-offscreen.test.tsx
@@ -1,0 +1,142 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+// Shell wiring for the mount-time offscreen re-center (issue #52). A saved
+// viewBox/zoom can strand the whole diagram outside the visible canvas; once
+// the Canvas knows both the element bounds and the real svg size, it should
+// center the diagram exactly once. These tests drive a real <Canvas> through
+// the gesture harness and assert on the onViewBoxChange callback, never on
+// Canvas internals. The pure predicate + centering math are covered in
+// viewport.test.ts.
+
+import { renderCanvas, makeAux, makeStock } from './canvas-gesture-harness';
+
+// The harness mounts with a jsdom canvas whose clientWidth/Height is 0, so the
+// first real size arrives via a synthesized ResizeObserver delivery (resize()).
+// A resize from a known old size also runs the pre-existing quarter-delta
+// resize recenter (handleSvgResize), so onViewBoxChange can fire once for that
+// BEFORE our offscreen effect fires; our commit is always the LAST call.
+function lastViewBoxCall(onViewBoxChange: jest.Mock): {
+  viewBox: { x: number; y: number; width: number; height: number };
+  zoom: number;
+} {
+  const calls = onViewBoxChange.mock.calls;
+  const [viewBox, zoom] = calls[calls.length - 1];
+  return { viewBox, zoom };
+}
+
+describe('mount offscreen re-center (issue #52)', () => {
+  it('centers a diagram whose saved viewBox leaves it (mostly) offscreen', () => {
+    // Elements clustered near the model origin.
+    const elements = [makeAux(1, 'a', 0, 0), makeStock(2, 'b', 120, 60)];
+    const h = renderCanvas({ elements });
+
+    // Model loads with a viewBox panned far away: the diagram is entirely
+    // outside the visible canvas.
+    h.setViewport({ x: -5000, y: -5000 });
+    h.clearMountCalls();
+
+    // The real size arrives -> the offscreen effect gets its one measured,
+    // idle, non-embedded shot and re-centers.
+    h.resize(1000, 1000);
+
+    expect(h.callbacks.onViewBoxChange).toHaveBeenCalled();
+    const { viewBox, zoom } = lastViewBoxCall(h.callbacks.onViewBoxChange);
+
+    // Zoom is left unchanged; the viewBox adopts the measured size.
+    expect(zoom).toBe(1);
+    expect(viewBox.width).toBe(1000);
+    expect(viewBox.height).toBe(1000);
+
+    // Every element now maps into the visible [0,1000] x [0,1000] region.
+    for (const el of elements) {
+      const screenX = (el.x + viewBox.x) * zoom;
+      const screenY = (el.y + viewBox.y) * zoom;
+      expect(screenX).toBeGreaterThanOrEqual(0);
+      expect(screenX).toBeLessThanOrEqual(1000);
+      expect(screenY).toBeGreaterThanOrEqual(0);
+      expect(screenY).toBeLessThanOrEqual(1000);
+    }
+
+    // The diagram's bounding-box center lands near the viewport center. The
+    // exact center depends on element radii/label extent (auxBounds/stockBounds
+    // pad past the raw x/y), so allow a modest tolerance around the element-
+    // position midpoint rather than pinning the padded-bbox center exactly.
+    const cx = (0 + 120) / 2;
+    const cy = (0 + 60) / 2;
+    expect(Math.abs((cx + viewBox.x) * zoom - 500)).toBeLessThan(40);
+    expect(Math.abs((cy + viewBox.y) * zoom - 500)).toBeLessThan(40);
+  });
+
+  it('does not re-center a diagram that mounts (mostly) visible', () => {
+    const elements = [makeAux(1, 'a', 400, 400), makeStock(2, 'b', 520, 460)];
+    const h = renderCanvas({ elements });
+
+    // Default viewBox offset (0,0): the elements near (400..520) are well inside
+    // a 1000x1000 canvas, so the offscreen check must NOT fire.
+    h.clearMountCalls();
+    h.resize(1000, 1000);
+
+    // The ONLY onViewBoxChange here is the pre-existing quarter-delta resize
+    // recenter (handleSvgResize): from offset (0,0) with a +1000/+1000 size delta
+    // it shifts by a quarter -> (250,250). Our offscreen effect adds nothing, so
+    // the single commit is exactly that resize value, not a centering update.
+    expect(h.callbacks.onViewBoxChange).toHaveBeenCalledTimes(1);
+    const { viewBox, zoom } = lastViewBoxCall(h.callbacks.onViewBoxChange);
+    expect(viewBox).toEqual({ x: 250, y: 250, width: 1000, height: 1000 });
+    expect(zoom).toBe(1);
+    // Cross-check: a centering commit would have placed the bbox center at
+    // screen 500; the resize-only offset leaves it far from center.
+    const cx = (400 + 520) / 2;
+    expect(Math.abs(cx + viewBox.x - 500)).toBeGreaterThan(50);
+  });
+
+  it('runs at most once per mount: a later external offscreen pan is not auto-centered', () => {
+    const elements = [makeAux(1, 'a', 400, 400)];
+    const h = renderCanvas({ elements });
+
+    // First measured shot happens while visible -> latch consumed, no center.
+    h.clearMountCalls();
+    h.resize(1000, 1000);
+    h.callbacks.onViewBoxChange.mockClear();
+
+    // A later external viewport change strands the diagram offscreen. The
+    // mount-only check has already run, so nothing auto-centers it.
+    h.setViewport({ x: -5000, y: -5000 });
+    // Nudge svgSize again to give any (incorrectly re-armed) effect a chance.
+    h.resize(1000, 1000);
+
+    // Any onViewBoxChange here is at most the resize handler's quarter shift,
+    // never a re-center that brings the element to screen 500.
+    for (const [viewBox] of h.callbacks.onViewBoxChange.mock.calls) {
+      const screenX = 400 + viewBox.x;
+      expect(Math.abs(screenX - 500)).toBeGreaterThan(50);
+    }
+  });
+
+  it('ignores an empty model (no centering commit)', () => {
+    const h = renderCanvas({ elements: [] });
+    h.clearMountCalls();
+    h.resize(1000, 1000);
+    // No elements -> calcViewBox is undefined -> the offscreen effect returns
+    // without committing. The ONLY onViewBoxChange is the pre-existing quarter-
+    // delta resize handler (from offset (0,0) -> (250,250)); the offscreen effect
+    // adds no second call. If it had (wrongly) committed a center, this would be
+    // two calls. That single resize-only commit is the direct proof no centering
+    // occurred.
+    expect(h.callbacks.onViewBoxChange).toHaveBeenCalledTimes(1);
+    const { viewBox } = lastViewBoxCall(h.callbacks.onViewBoxChange);
+    expect(viewBox).toEqual({ x: 250, y: 250, width: 1000, height: 1000 });
+  });
+
+  it('does nothing in embedded mode (viewport-inert)', () => {
+    const elements = [makeAux(1, 'a', 0, 0)];
+    const h = renderCanvas({ elements, embedded: true });
+    h.clearMountCalls();
+    h.resize(1000, 1000);
+    // Embedded canvases draw to tight element bounds and ignore viewBox/zoom;
+    // the offscreen effect early-returns, so it never notifies the host.
+    expect(h.callbacks.onViewBoxChange).not.toHaveBeenCalled();
+  });
+});

--- a/src/diagram/tests/editor-selection-invariant.test.ts
+++ b/src/diagram/tests/editor-selection-invariant.test.ts
@@ -1,0 +1,277 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Copyright 2026 The Simlin Authors. All rights reserved.
+ * Use of this source code is governed by the Apache License,
+ * Version 2.0, that can be found in the LICENSE file.
+ */
+
+// Issue #529 (rescoped): the Editor handlers that mutate `selection` directly
+// (delete, create, flow/link attach, navigation) must honor the same
+// empty-selection invariant handleSelection always enforced -- when the
+// committed selection empties, the details panel must close (showDetails ->
+// undefined) and the variable-details tab must reset. Previously the delete and
+// create handlers cleared `selection` but left showDetails at 'variable'. That
+// was masked because getDetails() also guards on a named selected element, but
+// the stale state was observable: after such a clear, a *plain single-select*
+// of another (or the same) element pops the details panel open on mere
+// selection -- even though selection alone should never open the panel.
+//
+// selectionStatePatch is the pure funnel; every selection-assigning setState
+// composes it. This test pins both the pure logic and the observable render
+// consequence in the real Editor (Canvas + VariableDetails mocked; a real
+// ProjectController whose engine-touching methods are stubbed).
+
+import { TextEncoder, TextDecoder } from 'util';
+Object.assign(globalThis, { TextEncoder, TextDecoder });
+
+import * as React from 'react';
+import { act, fireEvent, render, screen } from '@testing-library/react';
+
+import { projectFromJson, type JsonProject } from '@simlin/core/datamodel';
+import { ProjectController, type ProjectSnapshot } from '../project-controller';
+
+// A project with a single aux 'x' (uid 1) drawn in the main view, so the
+// Editor's details flow resolves to a VariableDetails panel when 'x' is
+// selected and showDetails is 'variable'.
+const projectJson = JSON.stringify({
+  name: 'test',
+  simSpecs: { startTime: 0, endTime: 10, dt: '1' },
+  models: [
+    {
+      name: 'main',
+      stocks: [],
+      flows: [],
+      auxiliaries: [{ name: 'x', equation: '1' }],
+      views: [{ elements: [{ type: 'aux', uid: 1, name: 'x', x: 0, y: 0 }] }],
+    },
+  ],
+});
+
+// Render queryable markers for the two side panels so a test can assert which
+// (if either) is showing without depending on their internals. The errors panel
+// (ErrorDetails) is model-level and independent of the selection; the variable
+// panel (VariableDetails) is selection-tied.
+jest.mock('../VariableDetails', () => ({
+  __esModule: true,
+  VariableDetails: () => React.createElement('div', { 'data-testid': 'var-details' }),
+}));
+jest.mock('../ErrorDetails', () => ({
+  __esModule: true,
+  ErrorDetails: () => React.createElement('div', { 'data-testid': 'error-details' }),
+}));
+
+// A clickable stand-in for the Status dot so a test can open the errors panel
+// (its onClick is the Editor's handleStatusClick, which toggles showDetails to
+// 'errors'). The real Status renders an <svg><circle> that is awkward to target.
+jest.mock('../Status', () => ({
+  __esModule: true,
+  Status: ({ onClick }: { onClick: () => void }) =>
+    React.createElement('button', { 'data-testid': 'status-toggle', onClick }),
+}));
+
+// Capture the props the Editor hands the Canvas so we can drive the real
+// selection/show-details/delete/create handlers (the documented Canvas ->
+// Editor contract) without WASM, jsdom SVG geometry, or a ResizeObserver.
+interface CapturedCanvasProps {
+  onSetSelection: (sel: ReadonlySet<number>) => void;
+  onShowVariableDetails: () => void;
+  onDeleteSelection: () => Promise<void> | void;
+  onCreateVariable: (element: unknown) => Promise<void> | void;
+}
+let capturedCanvasProps: CapturedCanvasProps | undefined;
+jest.mock('../drawing/Canvas', () => ({
+  __esModule: true,
+  Canvas: (p: CapturedCanvasProps) => {
+    capturedCanvasProps = p;
+    return null;
+  },
+  inCreationUid: -2,
+}));
+
+import { Editor, selectionStatePatch, type EditorProps } from '../Editor';
+
+function makeSnapshot(): ProjectSnapshot {
+  const project = projectFromJson(JSON.parse(projectJson) as JsonProject);
+  return {
+    project,
+    projectVersion: 1,
+    projectGeneration: 0,
+    status: 'ok',
+    cachedErrors: { simError: undefined, modelErrors: [], varErrors: new Map(), unitErrors: new Map() },
+    data: new Map(),
+    modelName: 'main',
+    modelStack: [],
+    canUndo: false,
+    canRedo: false,
+    navResetSeq: 0,
+  } as unknown as ProjectSnapshot;
+}
+
+function makeProps(): EditorProps {
+  return {
+    inputFormat: 'json',
+    initialProjectJson: projectJson,
+    initialProjectVersion: 1,
+    name: 'test',
+    onSave: async () => 1,
+  } as EditorProps;
+}
+
+describe('selectionStatePatch (pure funnel)', () => {
+  it('closes the variable panel and resets the tab when an empty selection had a variable panel open', () => {
+    const patch = selectionStatePatch(new Set<number>(), 'variable');
+    expect(patch.selection.size).toBe(0);
+    // showDetails is present-and-undefined (spread must overwrite the stale
+    // 'variable'), not merely absent.
+    expect('showDetails' in patch).toBe(true);
+    expect(patch.showDetails).toBeUndefined();
+    expect(patch.variableDetailsActiveTab).toBe(0);
+  });
+
+  it('leaves an open errors panel alone when the selection empties', () => {
+    const patch = selectionStatePatch(new Set<number>(), 'errors');
+    expect(patch.selection.size).toBe(0);
+    // showDetails is absent -> the merge preserves the current 'errors': the
+    // model-level error list must survive deleting a selected variable.
+    expect('showDetails' in patch).toBe(false);
+    // The tab still resets (harmless prep for the next variable panel).
+    expect(patch.variableDetailsActiveTab).toBe(0);
+  });
+
+  it('does not reopen a panel when an empty selection had none open', () => {
+    const patch = selectionStatePatch(new Set<number>(), undefined);
+    expect('showDetails' in patch).toBe(false);
+    expect(patch.variableDetailsActiveTab).toBe(0);
+  });
+
+  it('leaves showDetails and the tab untouched for a non-empty selection', () => {
+    const patch = selectionStatePatch(new Set<number>([1, 2]), 'variable');
+    expect([...patch.selection].sort()).toEqual([1, 2]);
+    // Absent (not present-undefined): a non-empty select must not disturb an
+    // intentionally-open panel or the tab the caller chose.
+    expect('showDetails' in patch).toBe(false);
+    expect('variableDetailsActiveTab' in patch).toBe(false);
+  });
+});
+
+describe('Editor empty-selection invariant (issue #529)', () => {
+  let snapshot: ProjectSnapshot;
+
+  beforeEach(() => {
+    capturedCanvasProps = undefined;
+    snapshot = makeSnapshot();
+    jest.spyOn(ProjectController.prototype, 'getSnapshot').mockImplementation(() => snapshot);
+    // The Editor drives everything here through the captured Canvas handlers,
+    // so the controller subscription is never fired; return a no-op unsubscribe.
+    jest.spyOn(ProjectController.prototype, 'subscribe').mockImplementation(() => () => {});
+    jest.spyOn(ProjectController.prototype, 'openInitialProject').mockResolvedValue(undefined);
+    jest.spyOn(ProjectController.prototype, 'dispose').mockResolvedValue(undefined);
+    jest.spyOn(ProjectController.prototype, 'scheduleSimRun').mockImplementation(() => {});
+    // The delete/create handlers bail if the engine hasn't opened; the mocked
+    // openInitialProject never opens one, so stub getEngine truthy and stub the
+    // patch/view methods the handlers await so they proceed to their setState.
+    jest.spyOn(ProjectController.prototype, 'getEngine').mockReturnValue({} as never);
+    jest.spyOn(ProjectController.prototype, 'applyPatchOrReportError').mockResolvedValue(true);
+    jest.spyOn(ProjectController.prototype, 'updateView').mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function openVariableDetails(): void {
+    act(() => {
+      capturedCanvasProps!.onSetSelection(new Set([1]));
+      capturedCanvasProps!.onShowVariableDetails();
+    });
+  }
+
+  it('deleting the selection closes the panel so a later single-select does not reopen it', async () => {
+    act(() => {
+      render(React.createElement(Editor, makeProps()));
+    });
+    openVariableDetails();
+    expect(screen.queryByTestId('var-details')).not.toBeNull();
+
+    // Delete the selection: this empties it (and, via selectionStatePatch,
+    // resets showDetails). The mocked snapshot is fixed, so 'x' remains
+    // selectable afterward -- exactly what makes the stale showDetails
+    // observable.
+    await act(async () => {
+      await capturedCanvasProps!.onDeleteSelection();
+    });
+    // With the selection empty the panel is gone regardless (guarded by the
+    // named-selected-element check).
+    expect(screen.queryByTestId('var-details')).toBeNull();
+
+    // A plain single-select must NOT reopen the panel: only the show-details
+    // affordance does. Before the fix, showDetails was still 'variable', so
+    // this selection popped the panel open.
+    act(() => {
+      capturedCanvasProps!.onSetSelection(new Set([1]));
+    });
+    expect(screen.queryByTestId('var-details')).toBeNull();
+  });
+
+  it('deleting a variable while the errors panel is open leaves the errors panel open', async () => {
+    act(() => {
+      render(React.createElement(Editor, makeProps()));
+    });
+
+    // Select a variable, then open the model-level errors panel (Status click).
+    // The variable panel is NOT shown here (we never invoked show-details), so
+    // showDetails is 'errors' with a non-empty selection.
+    act(() => {
+      capturedCanvasProps!.onSetSelection(new Set([1]));
+    });
+    act(() => {
+      fireEvent.click(screen.getByTestId('status-toggle'));
+    });
+    expect(screen.queryByTestId('error-details')).not.toBeNull();
+    expect(screen.queryByTestId('var-details')).toBeNull();
+
+    // Delete the selected variable mid error-triage. The selection empties, but
+    // the errors panel is model-level and must STAY open.
+    await act(async () => {
+      await capturedCanvasProps!.onDeleteSelection();
+    });
+    expect(screen.queryByTestId('error-details')).not.toBeNull();
+    expect(screen.queryByTestId('var-details')).toBeNull();
+  });
+
+  it('deleting a variable while ITS variable panel is open closes that panel (companion)', async () => {
+    act(() => {
+      render(React.createElement(Editor, makeProps()));
+    });
+    openVariableDetails();
+    expect(screen.queryByTestId('var-details')).not.toBeNull();
+
+    await act(async () => {
+      await capturedCanvasProps!.onDeleteSelection();
+    });
+    // The selection-tied variable panel closes (contrast with the errors panel
+    // above, which survives the same gesture).
+    expect(screen.queryByTestId('var-details')).toBeNull();
+  });
+
+  it('creating a variable clears the selection so a later single-select does not reopen the panel', async () => {
+    act(() => {
+      render(React.createElement(Editor, makeProps()));
+    });
+    openVariableDetails();
+    expect(screen.queryByTestId('var-details')).not.toBeNull();
+
+    // handleCreateVariable clears the selection to empty; the invariant must
+    // reset showDetails in that same commit.
+    await act(async () => {
+      await capturedCanvasProps!.onCreateVariable({ type: 'aux', uid: 0, name: 'y', x: 10, y: 10 });
+    });
+    expect(screen.queryByTestId('var-details')).toBeNull();
+
+    act(() => {
+      capturedCanvasProps!.onSetSelection(new Set([1]));
+    });
+    expect(screen.queryByTestId('var-details')).toBeNull();
+  });
+});

--- a/src/diagram/tests/editor-sim-spec-commit.test.ts
+++ b/src/diagram/tests/editor-sim-spec-commit.test.ts
@@ -1,0 +1,165 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Copyright 2026 The Simlin Authors. All rights reserved.
+ * Use of this source code is governed by the Apache License,
+ * Version 2.0, that can be found in the LICENSE file.
+ */
+
+// The Editor wires the model-properties drawer's onSimSpecCommit to a single
+// engine patch per settled field edit (issue #55): before the fix each typed
+// character fired applyPatch -- an undo-history entry and a scheduled save --
+// so typing "1900" recorded four entries and evicted real edits from the
+// 5-deep undo buffer. The drawer now debounces to one commit per settle; this
+// test asserts the Editor side turns each commit into exactly one applyPatch
+// (hence one undo entry) targeting the right sim-spec field.
+//
+// Mirrors editor-drawer-delete.test.ts: the drawer is mocked to a prop-recording
+// stub, Canvas is stubbed out, and the controller is stubbed so a seeded
+// snapshot supplies the project without WASM.
+
+import { TextEncoder, TextDecoder } from 'util';
+Object.assign(globalThis, { TextEncoder, TextDecoder });
+
+import * as React from 'react';
+import { act, render } from '@testing-library/react';
+
+import type { ModelPropertiesDrawer as ModelPropertiesDrawerType } from '../ModelPropertiesDrawer';
+import { ProjectController, type ProjectSnapshot } from '../project-controller';
+
+type DrawerProps = React.ComponentProps<typeof ModelPropertiesDrawerType>;
+let capturedDrawerProps: DrawerProps | undefined;
+
+jest.mock('../ModelPropertiesDrawer', () => ({
+  __esModule: true,
+  ModelPropertiesDrawer: (p: DrawerProps) => {
+    capturedDrawerProps = p;
+    return null;
+  },
+}));
+
+jest.mock('../drawing/Canvas', () => ({
+  __esModule: true,
+  Canvas: () => null,
+  inCreationUid: -2,
+}));
+
+import { Editor, type EditorProps } from '../Editor';
+
+function makeSnapshot(): ProjectSnapshot {
+  const view = {
+    nextUid: 1,
+    elements: [],
+    viewBox: { x: 0, y: 0, width: 800, height: 600 },
+    zoom: 1,
+    useLetteredPolarity: false,
+  };
+  return {
+    project: {
+      name: 'test-project',
+      models: new Map([['main', { name: 'main', variables: new Map(), views: [view], loopMetadata: [], groups: [] }]]),
+      simSpecs: {
+        start: 0,
+        stop: 100,
+        dt: { isReciprocal: false, value: 1 },
+        timeUnits: 'years',
+      },
+    },
+    modelName: 'main',
+    projectVersion: 1,
+    projectGeneration: 0,
+    status: 'ok',
+    cachedErrors: { simError: undefined, modelErrors: [], varErrors: new Map(), unitErrors: new Map() },
+    data: new Map(),
+    modelStack: [],
+    canUndo: false,
+    canRedo: false,
+    navResetSeq: 0,
+  } as unknown as ProjectSnapshot;
+}
+
+function makeProps(overrides: Partial<EditorProps> = {}): EditorProps {
+  return {
+    inputFormat: 'json',
+    initialProjectJson: '{}',
+    initialProjectVersion: 1,
+    name: 'test-project',
+    embedded: false,
+    readOnlyMode: false,
+    onSave: async () => 1,
+    ...overrides,
+  } as EditorProps;
+}
+
+describe('Editor sim-spec commit wiring (issue #55)', () => {
+  let applyPatch: jest.SpyInstance;
+
+  beforeEach(() => {
+    capturedDrawerProps = undefined;
+    jest.spyOn(ProjectController.prototype, 'getSnapshot').mockReturnValue(makeSnapshot());
+    jest.spyOn(ProjectController.prototype, 'openInitialProject').mockResolvedValue(undefined);
+    jest.spyOn(ProjectController.prototype, 'dispose').mockResolvedValue(undefined);
+    jest.spyOn(ProjectController.prototype, 'scheduleSimRun').mockImplementation(() => {});
+    jest.spyOn(ProjectController.prototype, 'subscribe').mockReturnValue(() => {});
+    applyPatch = jest.spyOn(ProjectController.prototype, 'applyPatch').mockResolvedValue(true);
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function render_(): void {
+    act(() => {
+      render(React.createElement(Editor, makeProps()));
+    });
+  }
+
+  test('a start-time commit fires exactly one applyPatch with setSimSpecs', async () => {
+    render_();
+    expect(capturedDrawerProps).toBeDefined();
+    await act(async () => {
+      capturedDrawerProps!.onSimSpecCommit('startTime', 1900);
+    });
+    expect(applyPatch).toHaveBeenCalledTimes(1);
+    const [patch] = applyPatch.mock.calls[0];
+    expect(patch.projectOps).toHaveLength(1);
+    expect(patch.projectOps[0].type).toBe('setSimSpecs');
+    expect(patch.projectOps[0].payload.simSpecs.startTime).toBe(1900);
+    // Fields the user did not touch keep the model values.
+    expect(patch.projectOps[0].payload.simSpecs.endTime).toBe(100);
+  });
+
+  test('a dt commit routes to the dt field as a string', async () => {
+    render_();
+    await act(async () => {
+      capturedDrawerProps!.onSimSpecCommit('dt', 0.5);
+    });
+    expect(applyPatch).toHaveBeenCalledTimes(1);
+    const [patch] = applyPatch.mock.calls[0];
+    expect(patch.projectOps[0].payload.simSpecs.dt).toBe('0.5');
+  });
+
+  test('a time-units commit routes the free string through', async () => {
+    render_();
+    await act(async () => {
+      capturedDrawerProps!.onSimSpecCommit('timeUnits', 'months');
+    });
+    expect(applyPatch).toHaveBeenCalledTimes(1);
+    const [patch] = applyPatch.mock.calls[0];
+    expect(patch.projectOps[0].payload.simSpecs.timeUnits).toBe('months');
+  });
+
+  test('three separate commits fire three applyPatches (one undo entry each)', async () => {
+    render_();
+    await act(async () => {
+      capturedDrawerProps!.onSimSpecCommit('startTime', 10);
+    });
+    await act(async () => {
+      capturedDrawerProps!.onSimSpecCommit('stopTime', 200);
+    });
+    await act(async () => {
+      capturedDrawerProps!.onSimSpecCommit('dt', 2);
+    });
+    expect(applyPatch).toHaveBeenCalledTimes(3);
+  });
+});

--- a/src/diagram/tests/flow-attach.test.ts
+++ b/src/diagram/tests/flow-attach.test.ts
@@ -1245,4 +1245,35 @@ describe('growEndpointDrag (existing cloud endpoint drag)', () => {
       expect(finalFlow.y).toBeCloseTo(200, 5);
     });
   });
+
+  it('diagonal drag: along-axis travel is preserved when the flow bends into an L (no cloud snap-back)', () => {
+    // The cloud has already been dragged 100px ALONG the axis; now the drag pushes
+    // perpendicular past the point where it dominates and the flow bends. The
+    // parallel (x) coordinate of the cloud must stay put across the bend -- the bug
+    // rebuilt the L from the ORIGINAL flow and discarded the 100px of along-axis
+    // travel, snapping the cloud back ~100px in one frame. (The perpendicular
+    // coordinate legitimately appears only at the bend: a straight flow is pinned
+    // to its axis until it reroutes, so only the PARALLEL axis is asserted here.)
+    const flow = stockToCloudFlow(); // stock edge x=122.5, cloud at (300,200)
+    const PARALLEL = -100; // cursor 100px right -> cloud x target 400
+    const frames: FlowViewElement[] = [];
+    for (let dy = 0; dy >= -200; dy -= 8) {
+      frames.push(growEndpointDrag(flow, false, { x: PARALLEL, y: dy }, undefined));
+    }
+
+    // Parallel-axis (x) continuity of the cloud endpoint across the bend: the
+    // buggy reroute jumped it 100px in a single frame.
+    for (let i = 1; i < frames.length; i++) {
+      const prevCloud = frames[i - 1].points[frames[i - 1].points.length - 1];
+      const curCloud = frames[i].points[frames[i].points.length - 1];
+      expect(Math.abs(curCloud.x - prevCloud.x)).toBeLessThan(20);
+    }
+
+    // End state: bent into an L with the cloud at the FULL dragged position.
+    const finalFlow = frames[frames.length - 1];
+    expect(finalFlow.points.length).toBe(3);
+    const finalCloud = finalFlow.points[finalFlow.points.length - 1];
+    expect(finalCloud.x).toBeCloseTo(400, 5); // 300 + 100 along-axis, not snapped to 300
+    expect(finalCloud.y).toBeCloseTo(400, 5); // 200 + 200 perpendicular
+  });
 });

--- a/src/diagram/tests/flow-attach.test.ts
+++ b/src/diagram/tests/flow-attach.test.ts
@@ -34,6 +34,7 @@ import {
   inCreationUid as sharedInCreationUid,
 } from '../drawing/creation-sentinels';
 import { StockWidth, StockHeight } from '../drawing/default';
+import { getSegments, findClosestSegment } from '../drawing/Flow';
 
 // ----- fixture helpers (mirroring flow-routing.test.ts patterns) -----
 
@@ -1066,5 +1067,170 @@ describe('growEndpointDrag (existing cloud endpoint drag)', () => {
     expect(src.x).toBeCloseTo(0 + StockWidth / 2); // right edge of the left-hand stock
     expect(src.x).not.toBe(0);
     expect(src.y).toBe(200);
+  });
+
+  // Regression for issue #53: "when moving a cloud, the flow label jumps around".
+  // The live drag re-routes from the ORIGINAL flow each pointermove with an
+  // accumulating moveDelta (that is what Canvas does -- r.elements holds the
+  // committed flow and moveDelta = press - cursor). As a perpendicular drag
+  // deepens the L, the valve (rendered at flow.x/y, the label anchors to it)
+  // must move CONTINUOUSLY with the cursor and never teleport onto the vertical
+  // riser flush against the stock. Sweeping the drag as small steps and
+  // measuring per-step valve displacement catches the segment flip-flop.
+  describe('perpendicular cloud drag keeps the valve continuous (issue #53)', () => {
+    // Index of the segment the valve currently sits on (closest to flow.x/y).
+    function valveSegmentIndex(flow: FlowViewElement): number {
+      const segs = getSegments(flow.points);
+      return findClosestSegment({ x: flow.x, y: flow.y }, segs).index;
+    }
+
+    // Assert per-step valve continuity across a swept drag. Consecutive frames
+    // with the SAME point count (same route topology) must move the valve only a
+    // little -- the teleport bug jumped it ~100px between two L frames. The ONE
+    // step where the point count changes (straight <-> L) is the "single
+    // unavoidable relocation" the requirements exempt; it must still be a
+    // sensible interior hop, not a jump to the stock corner. The measured
+    // topology hop is ~8px for a sink cloud (default bound leaves margin); the
+    // source-cloud case is inflated by the separate adjustFlows valve-reflection
+    // bug (#832) and passes its own looser bound, documented at its call site.
+    function expectContinuous(frames: FlowViewElement[], topologyBound = 15): void {
+      let sawTopologyChange = false;
+      for (let i = 1; i < frames.length; i++) {
+        const prev = frames[i - 1];
+        const cur = frames[i];
+        const disp = Math.hypot(cur.x - prev.x, cur.y - prev.y);
+        if (cur.points.length !== prev.points.length) {
+          expect(sawTopologyChange).toBe(false); // exactly one transition
+          sawTopologyChange = true;
+          expect(disp).toBeLessThan(topologyBound);
+        } else {
+          expect(disp).toBeLessThan(12);
+        }
+      }
+    }
+
+    // Sweep a perpendicular drag in small cursor steps, re-routing from the
+    // ORIGINAL flow each step (the live-drag contract), and return the sequence
+    // of grown flows. `fromTotal` defaults to 0 (start straight and deepen);
+    // pass a nonzero `fromTotal` with `total` = 0 to REVERSE the drag -- start
+    // from a formed L and collapse it back to straight.
+    function sweep(
+      original: FlowViewElement,
+      isSource: boolean,
+      perAxis: 'x' | 'y',
+      total: number,
+      step: number,
+      fromTotal = 0,
+    ): FlowViewElement[] {
+      const out: FlowViewElement[] = [];
+      const sign = Math.sign(total - fromTotal) || 1;
+      for (let d = fromTotal; sign > 0 ? d <= total : d >= total; d += sign * step) {
+        const moveDelta = perAxis === 'y' ? { x: 0, y: d } : { x: d, y: 0 };
+        out.push(growEndpointDrag(original, isSource, moveDelta, undefined));
+      }
+      return out;
+    }
+
+    it('sink cloud dragged straight down: valve tracks the cursor, no teleport to the stock corner', () => {
+      // stock edge at x=122.5, cloud sink at x=300, valve mid at x=200, y=200.
+      const flow = stockToCloudFlow();
+      // moveDelta.y negative drags the cloud DOWN. Sweep to a deep offset so we
+      // pass the point where the buggy "closest segment" flips onto the riser.
+      const frames = sweep(flow, false, 'y', -200, 4);
+
+      // Continuity: every same-topology step moves the valve only a little. The
+      // bug jumped the valve ~100px (onto the riser near the stock) at one step.
+      expectContinuous(frames);
+
+      // No segment flip-flop: after the L forms the valve stays on one segment.
+      const lFrames = frames.filter((f) => f.points.length === 3);
+      const firstL = valveSegmentIndex(lFrames[0]);
+      for (const f of lFrames) {
+        expect(valveSegmentIndex(f)).toBe(firstL);
+      }
+
+      // Final valve is interior to the cloud-adjacent (bottom, horizontal)
+      // segment -- tracking the cursor -- not pinned at the stock corner.
+      const finalFlow = frames[frames.length - 1];
+      const finalSink = finalFlow.points[finalFlow.points.length - 1];
+      expect(finalFlow.points.length).toBe(3);
+      // valve sits on the horizontal bottom segment (same Y as the descended sink)
+      expect(finalFlow.y).toBeCloseTo(finalSink.y, 5);
+      // ...and well away from the stock edge (x=122.5), roughly under its old x.
+      expect(finalFlow.x).toBeGreaterThan(150);
+      expect(finalFlow.x).toBeLessThan(finalSink.x);
+    });
+
+    it('source cloud dragged straight down: same continuity, valve never pins to the stock', () => {
+      // cloud source at x=100, stock sink edge at x=277.5, valve mid at x=200.
+      const flow = cloudToStockFlow();
+      const frames = sweep(flow, true, 'y', -200, 4);
+
+      // Looser topology-hop bound here: the straight->L hop is ~24px, inflated by
+      // the pre-existing adjustFlows valve-reflection bug (#832), which shifts a
+      // source cloud's STRAIGHT-mode valve to its mirror position. That is a
+      // separate defect; the #53 fix guarantees the same-topology steps stay
+      // tight (no teleport), which the <12px bound still enforces.
+      expectContinuous(frames, 30);
+
+      const finalFlow = frames[frames.length - 1];
+      const finalSource = finalFlow.points[0];
+      expect(finalFlow.points.length).toBe(3);
+      // valve on the cloud-adjacent (bottom, horizontal) segment, tracking the cloud
+      expect(finalFlow.y).toBeCloseTo(finalSource.y, 5);
+      expect(finalFlow.x).toBeGreaterThan(finalSource.x);
+      expect(finalFlow.x).toBeLessThan(250);
+    });
+
+    it('vertical flow, sink cloud dragged sideways: valve stays interior on the bent segment', () => {
+      const flow = makeFlowEl(10, 'f', 200, 200, [
+        { x: 200, y: 122.5, attachedToUid: 1 }, // stock bottom edge
+        { x: 200, y: 300, attachedToUid: 2 }, // cloud below
+      ]);
+      // Drag cloud to the RIGHT (perpendicular to the vertical flow).
+      const frames = sweep(flow, false, 'x', -200, 4);
+
+      expectContinuous(frames);
+
+      const finalFlow = frames[frames.length - 1];
+      const finalSink = finalFlow.points[finalFlow.points.length - 1];
+      expect(finalFlow.points.length).toBe(3);
+      // valve on the cloud-adjacent (bent, vertical) segment: same X as the sink,
+      // interior between the corner and the cloud (not flush at the corner).
+      expect(finalFlow.x).toBeCloseTo(finalSink.x, 5);
+      expect(finalFlow.y).toBeGreaterThan(150);
+      expect(finalFlow.y).toBeLessThan(finalSink.y);
+    });
+
+    it('reverse drag: an L collapsed back to straight keeps the valve continuous', () => {
+      // The user drags a sink cloud DOWN to form the L, then drags back UP so the
+      // L collapses to straight. Because the live drag re-routes from the ORIGINAL
+      // flow each frame, this is moveDelta.y sweeping from -200 back to 0. The
+      // valve must stay continuous the whole way and end interior on the restored
+      // straight segment -- no teleport as the riser shrinks to zero.
+      const flow = stockToCloudFlow();
+      const frames = sweep(flow, false, 'y', 0, 4, -200);
+
+      // Same continuity guarantees as the forward drag: tight within a topology,
+      // one bounded straight<->L hop (~8px for a sink cloud).
+      expectContinuous(frames);
+
+      // While the L exists the valve stays on a single segment (no flip-flop).
+      const lFrames = frames.filter((f) => f.points.length === 3);
+      const firstL = valveSegmentIndex(lFrames[0]);
+      for (const f of lFrames) {
+        expect(valveSegmentIndex(f)).toBe(firstL);
+      }
+
+      // The drag ended back at zero offset: the flow is straight again and the
+      // valve sits interior between the stock edge and the cloud, not pinned.
+      const finalFlow = frames[frames.length - 1];
+      expect(finalFlow.points.length).toBe(2);
+      const src = finalFlow.points[0];
+      const sink = finalFlow.points[1];
+      expect(finalFlow.x).toBeGreaterThan(src.x);
+      expect(finalFlow.x).toBeLessThan(sink.x);
+      expect(finalFlow.y).toBeCloseTo(200, 5);
+    });
   });
 });

--- a/src/diagram/tests/flow-attach.test.ts
+++ b/src/diagram/tests/flow-attach.test.ts
@@ -1069,6 +1069,22 @@ describe('growEndpointDrag (existing cloud endpoint drag)', () => {
     expect(src.y).toBe(200);
   });
 
+  it('grabbing a source cloud (zero delta) leaves an OFF-CENTER valve unmoved (issue #832)', () => {
+    // Source cloud (uid 2) on the left, stock sink edge on the right, valve
+    // deliberately OFF-CENTER (x=160, nearer the source). The instant the source
+    // cloud is grabbed -- before any real movement -- adjustFlows must not reflect
+    // the valve across the segment midpoint. Regression for the first-frame jump.
+    const flow = makeFlowEl(10, 'f', 160, 200, [
+      { x: 100, y: 200, attachedToUid: 2 }, // source cloud (min coord)
+      { x: 277.5, y: 200, attachedToUid: 1 }, // stock sink edge (max coord)
+    ]);
+    const grown = growEndpointDrag(flow, true, { x: 0, y: 0 }, undefined);
+
+    expect(grown.points.length).toBe(2);
+    expect(grown.x).toBeCloseTo(160, 5); // unchanged, not reflected to ~217.5
+    expect(grown.y).toBe(200);
+  });
+
   // Regression for issue #53: "when moving a cloud, the flow label jumps around".
   // The live drag re-routes from the ORIGINAL flow each pointermove with an
   // accumulating moveDelta (that is what Canvas does -- r.elements holds the
@@ -1090,9 +1106,8 @@ describe('growEndpointDrag (existing cloud endpoint drag)', () => {
     // step where the point count changes (straight <-> L) is the "single
     // unavoidable relocation" the requirements exempt; it must still be a
     // sensible interior hop, not a jump to the stock corner. The measured
-    // topology hop is ~8px for a sink cloud (default bound leaves margin); the
-    // source-cloud case is inflated by the separate adjustFlows valve-reflection
-    // bug (#832) and passes its own looser bound, documented at its call site.
+    // topology hop is ~8px for both sink and source clouds (default bound leaves
+    // margin); `topologyBound` stays overridable for any future looser case.
     function expectContinuous(frames: FlowViewElement[], topologyBound = 15): void {
       let sawTopologyChange = false;
       for (let i = 1; i < frames.length; i++) {
@@ -1166,12 +1181,9 @@ describe('growEndpointDrag (existing cloud endpoint drag)', () => {
       const flow = cloudToStockFlow();
       const frames = sweep(flow, true, 'y', -200, 4);
 
-      // Looser topology-hop bound here: the straight->L hop is ~24px, inflated by
-      // the pre-existing adjustFlows valve-reflection bug (#832), which shifts a
-      // source cloud's STRAIGHT-mode valve to its mirror position. That is a
-      // separate defect; the #53 fix guarantees the same-topology steps stay
-      // tight (no teleport), which the <12px bound still enforces.
-      expectContinuous(frames, 30);
+      // Default (15px) topology-hop bound: with the source-cloud valve reflection
+      // fixed (#832), the straight->L hop is ~8px here, same as the sink case.
+      expectContinuous(frames);
 
       const finalFlow = frames[frames.length - 1];
       const finalSource = finalFlow.points[0];

--- a/src/diagram/tests/flow-routing.test.ts
+++ b/src/diagram/tests/flow-routing.test.ts
@@ -2784,6 +2784,77 @@ describe('Flow routing', () => {
     });
   });
 
+  describe('UpdateCloudAndFlow - reroute preserves along-axis cloud travel (diagonal teleport)', () => {
+    // When a cloud drag has traveled ALONG the flow axis and then crosses the
+    // perpendicular threshold, the reroute rebuilds the L from the ORIGINAL
+    // 2-point flow (the live drag re-routes from the committed flow every frame).
+    // The reroute must apply BOTH the perpendicular AND the parallel component of
+    // the accumulated moveDelta to the cloud endpoint; applying only the
+    // perpendicular one snapped the cloud back to its original along-axis
+    // position -- a one-frame teleport. The reroute condition (perp > par) still
+    // holds while the parallel travel is large in absolute terms.
+
+    it('applies both deltas to a horizontal sink-cloud reroute (no along-axis snap-back)', () => {
+      const stockUid = 1;
+      const cloudUid = 3;
+      const stockEdgeX = 100 + StockWidth / 2; // 122.5
+      const flow = makeFlow(flowUid, 200, 200, [
+        { x: stockEdgeX, y: 200, attachedToUid: stockUid },
+        { x: 300, y: 200, attachedToUid: cloudUid },
+      ]);
+      const cloud = makeCloud(cloudUid, flowUid, 300, 200);
+
+      // Cloud dragged RIGHT by 150 (parallel) and DOWN by 160 (perpendicular,
+      // dominant so it reroutes). moveDelta is inverted (press - cursor).
+      const [newCloud, newFlow] = UpdateCloudAndFlow(cloud, flow, { x: -150, y: -160 });
+
+      expect(newFlow.points.length).toBe(3);
+      const sink = newFlow.points[2];
+      // sink lands at the FULL dragged position, not snapped back to x=300
+      expect(sink.x).toBe(450);
+      expect(sink.y).toBe(360);
+      expect(newCloud.x).toBe(450);
+      expect(newCloud.y).toBe(360);
+      // corner keeps the L orthogonal: vertical riser at the stock's x, then
+      // horizontal out to the cloud's new x.
+      const corner = newFlow.points[1];
+      expect(corner.x).toBe(stockEdgeX);
+      expect(corner.y).toBe(360);
+      // valve stays interior on the cloud-adjacent (horizontal) segment
+      expect(newFlow.y).toBe(360);
+      expect(newFlow.x).toBeGreaterThan(stockEdgeX);
+      expect(newFlow.x).toBeLessThan(450);
+    });
+
+    it('applies both deltas to a vertical source-cloud reroute (no along-axis snap-back)', () => {
+      const stockUid = 1;
+      const cloudUid = 3;
+      const stockEdgeY = 200 - StockHeight / 2; // 182.5 (top edge, stock below)
+      const flow = makeFlow(flowUid, 100, 150, [
+        { x: 100, y: 100, attachedToUid: cloudUid }, // source cloud at top
+        { x: 100, y: stockEdgeY, attachedToUid: stockUid },
+      ]);
+      const cloud = makeCloud(cloudUid, flowUid, 100, 100);
+
+      // Vertical flow: parallel axis is Y, perpendicular is X. Drag the source
+      // cloud DOWN by 150 (parallel) and RIGHT by 160 (perpendicular, dominant).
+      const [newCloud, newFlow] = UpdateCloudAndFlow(cloud, flow, { x: -160, y: -150 });
+
+      expect(newFlow.points.length).toBe(3);
+      const source = newFlow.points[0];
+      // source lands at the FULL dragged position, not snapped back to y=100
+      expect(source.x).toBe(260);
+      expect(source.y).toBe(250);
+      expect(newCloud.x).toBe(260);
+      expect(newCloud.y).toBe(250);
+      // corner: vertical run from the cloud down to the fixed end's y, then
+      // horizontal across to the stock.
+      const corner = newFlow.points[1];
+      expect(corner.x).toBe(260);
+      expect(corner.y).toBe(stockEdgeY);
+    });
+  });
+
   describe('UpdateCloudAndFlow - degenerate flow creation', () => {
     // When a flow is first created, both endpoints are at the same position.
     // The segment is both horizontal AND vertical (zero length).

--- a/src/diagram/tests/flow-routing.test.ts
+++ b/src/diagram/tests/flow-routing.test.ts
@@ -2710,6 +2710,80 @@ describe('Flow routing', () => {
     });
   });
 
+  describe('UpdateCloudAndFlow - source cloud valve is not reflected (issue #832)', () => {
+    // The mirror above happens to be idempotent only when the fixed otherEnd is
+    // the SMALLER coordinate (a sink cloud on the right). When the DRAGGED cloud
+    // is the smaller-coordinate end (a SOURCE cloud on the left), the old formula
+    // `base = min(otherEnd, cloud) + abs(fraction*d)` measured the valve's offset
+    // from the wrong reference and reflected an off-center valve across the
+    // segment midpoint on the very first drag frame (#832). The fix preserves the
+    // valve's fractional position anchored to otherEnd, so a zero/sub-threshold
+    // move leaves the valve put and a real drag scales it correctly.
+    //
+    // Fixture: SOURCE cloud (uid 3) at x=100 (first point), fixed other end (uid
+    // 1) at x=200, flow horizontal at y=100, valve off-center at x=175 (fraction
+    // 0.25 from otherEnd toward the cloud).
+    const makeSourceCase = (valveX: number, delta: { x: number; y: number }) => {
+      const cloud = makeCloud(3, 30, 100, 100);
+      const flow = makeFlow(30, valveX, 100, [
+        { x: 100, y: 100, attachedToUid: 3 },
+        { x: 200, y: 100, attachedToUid: 1 },
+      ]);
+      return UpdateCloudAndFlow(cloud, flow, delta);
+    };
+
+    it('leaves an off-center valve unmoved on a zero-delta source-cloud grab', () => {
+      // The reported bug: grabbing the source cloud (no movement yet) reflected
+      // the valve 175 -> 125. It must stay at 175.
+      const [newCloud, newFlow] = makeSourceCase(175, { x: 0, y: 0 });
+      expect(newCloud.x).toBe(100);
+      expect(newFlow.x).toBe(175);
+      expect(newFlow.y).toBe(100);
+    });
+
+    it('leaves an off-center valve unmoved on a sub-threshold perpendicular grab', () => {
+      // A 3px perpendicular twitch (below the 5px reroute threshold) still runs
+      // the axis-constrain path; the valve must not reflect.
+      const [, newFlow] = makeSourceCase(175, { x: 0, y: 3 });
+      expect(newFlow.points.length).toBe(2);
+      expect(newFlow.x).toBe(175);
+    });
+
+    it('preserves the valve fraction when the source cloud is dragged along-axis', () => {
+      // Drag the source cloud LEFT by 20 (cloud 100 -> 80). The valve was at
+      // fraction 0.25 from otherEnd(200): new x = 200 + 0.25*(80-200) = 170.
+      // The old mirror teleported it to 110.
+      const [newCloud, newFlow] = makeSourceCase(175, { x: 20, y: 0 });
+      expect(newCloud.x).toBe(80);
+      expect(newFlow.x).toBeCloseTo(170, 5);
+      expect(newFlow.y).toBe(100);
+    });
+
+    it('keeps the valve between the ends when the source cloud crosses past otherEnd', () => {
+      // Drag the source cloud RIGHT past the fixed end: cloud 100 -> 250, so the
+      // segment flips (cloud now to the right of otherEnd=200). The valve stays
+      // between them: 200 + 0.25*(250-200) = 212.5.
+      const [newCloud, newFlow] = makeSourceCase(175, { x: -150, y: 0 });
+      expect(newCloud.x).toBe(250);
+      expect(newFlow.x).toBeCloseTo(212.5, 5);
+      expect(newFlow.x).toBeGreaterThan(200);
+      expect(newFlow.x).toBeLessThan(250);
+    });
+
+    it('leaves an off-center valve unmoved on a zero-delta vertical (top) source grab', () => {
+      // Vertical flow: source cloud (uid 3) at the TOP (y=100, min), fixed end at
+      // y=200. Off-center valve at y=175. A zero-delta grab must not reflect it.
+      const cloud = makeCloud(3, 30, 100, 100);
+      const flow = makeFlow(30, 100, 175, [
+        { x: 100, y: 100, attachedToUid: 3 },
+        { x: 100, y: 200, attachedToUid: 1 },
+      ]);
+      const [, newFlow] = UpdateCloudAndFlow(cloud, flow, { x: 0, y: 0 });
+      expect(newFlow.x).toBe(100);
+      expect(newFlow.y).toBe(175);
+    });
+  });
+
   describe('UpdateCloudAndFlow - degenerate flow creation', () => {
     // When a flow is first created, both endpoints are at the same position.
     // The segment is both horizontal AND vertical (zero length).

--- a/src/diagram/tests/model-properties-drawer.test.tsx
+++ b/src/diagram/tests/model-properties-drawer.test.tsx
@@ -6,52 +6,269 @@ import * as React from 'react';
 import { render, screen, fireEvent, act, waitFor } from '@testing-library/react';
 
 import { ModelPropertiesDrawer } from '../ModelPropertiesDrawer';
+import type { SimSpecField } from '../sim-spec-draft';
 
-function renderDrawer(overrides: Partial<React.ComponentProps<typeof ModelPropertiesDrawer>> = {}) {
+type DrawerProps = React.ComponentProps<typeof ModelPropertiesDrawer>;
+
+function baseProps(overrides: Partial<DrawerProps> = {}): DrawerProps {
   const noop = () => {};
-  return render(
-    <ModelPropertiesDrawer
-      modelName="climate"
-      open={true}
-      onDrawerToggle={noop}
-      startTime={0}
-      stopTime={100}
-      dt={1}
-      timeUnits="years"
-      onStartTimeChange={noop}
-      onStopTimeChange={noop}
-      onDtChange={noop}
-      onTimeUnitsChange={noop}
-      onDownloadXmile={noop}
-      {...overrides}
-    />,
-  );
+  return {
+    modelName: 'climate',
+    open: true,
+    onDrawerToggle: noop,
+    startTime: 0,
+    stopTime: 100,
+    dt: 1,
+    timeUnits: 'years',
+    onSimSpecCommit: noop,
+    onDownloadXmile: noop,
+    ...overrides,
+  };
+}
+
+function renderDrawer(overrides: Partial<DrawerProps> = {}) {
+  return render(<ModelPropertiesDrawer {...baseProps(overrides)} />);
+}
+
+// Focus via the real DOM method so jsdom sets activeElement, which is what
+// makes a later `.blur()` (used by Enter/Escape) actually dispatch a blur.
+function focus(input: HTMLElement): void {
+  act(() => {
+    (input as HTMLInputElement).focus();
+  });
+}
+
+function getField(label: RegExp): HTMLInputElement {
+  return screen.getByLabelText(label) as HTMLInputElement;
 }
 
 describe('ModelPropertiesDrawer', () => {
-  test('always offers the model download', () => {
-    renderDrawer();
-    expect(screen.getByRole('button', { name: /download model/i })).not.toBeNull();
-  });
-
-  test('does not show a delete action when onDelete is not provided', () => {
-    renderDrawer();
-    expect(screen.queryByRole('button', { name: /delete project/i })).toBeNull();
-  });
-
-  test('shows a delete action when onDelete is provided', () => {
-    renderDrawer({ onDelete: jest.fn() });
-    expect(screen.getByRole('button', { name: /delete project/i })).not.toBeNull();
-  });
-
-  test('confirming the delete dialog invokes onDelete', async () => {
-    const onDelete = jest.fn().mockResolvedValue(undefined);
-    renderDrawer({ onDelete });
-    fireEvent.click(screen.getByRole('button', { name: /delete project/i }));
-    await waitFor(() => expect(screen.getByText(/delete this project\?/i)).not.toBeNull());
-    await act(async () => {
-      fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+  describe('existing affordances', () => {
+    test('always offers the model download', () => {
+      renderDrawer();
+      expect(screen.getByRole('button', { name: /download model/i })).not.toBeNull();
     });
-    expect(onDelete).toHaveBeenCalledTimes(1);
+
+    test('does not show a delete action when onDelete is not provided', () => {
+      renderDrawer();
+      expect(screen.queryByRole('button', { name: /delete project/i })).toBeNull();
+    });
+
+    test('shows a delete action when onDelete is provided', () => {
+      renderDrawer({ onDelete: jest.fn() });
+      expect(screen.getByRole('button', { name: /delete project/i })).not.toBeNull();
+    });
+
+    test('confirming the delete dialog invokes onDelete', async () => {
+      const onDelete = jest.fn().mockResolvedValue(undefined);
+      renderDrawer({ onDelete });
+      fireEvent.click(screen.getByRole('button', { name: /delete project/i }));
+      await waitFor(() => expect(screen.getByText(/delete this project\?/i)).not.toBeNull());
+      await act(async () => {
+        fireEvent.click(screen.getByRole('button', { name: /^delete$/i }));
+      });
+      expect(onDelete).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('sim-specs draft commit (issue #55)', () => {
+    test('displays the model values', () => {
+      renderDrawer();
+      expect(getField(/start time/i).value).toBe('0');
+      expect(getField(/stop time/i).value).toBe('100');
+      expect(getField(/^dt$/i).value).toBe('1');
+      expect(getField(/time units/i).value).toBe('years');
+    });
+
+    test('typing does NOT commit per keystroke', () => {
+      const onSimSpecCommit = jest.fn();
+      renderDrawer({ onSimSpecCommit });
+      const field = getField(/start time/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: '1' } });
+      fireEvent.change(field, { target: { value: '19' } });
+      fireEvent.change(field, { target: { value: '190' } });
+      fireEvent.change(field, { target: { value: '1900' } });
+      expect(onSimSpecCommit).not.toHaveBeenCalled();
+    });
+
+    test('blur commits exactly once with the final numeric value', () => {
+      const onSimSpecCommit = jest.fn();
+      renderDrawer({ onSimSpecCommit });
+      const field = getField(/start time/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: '1900' } });
+      fireEvent.blur(field);
+      expect(onSimSpecCommit).toHaveBeenCalledTimes(1);
+      expect(onSimSpecCommit).toHaveBeenCalledWith('startTime' satisfies SimSpecField, 1900);
+    });
+
+    test('Enter commits once', () => {
+      const onSimSpecCommit = jest.fn();
+      renderDrawer({ onSimSpecCommit });
+      const field = getField(/stop time/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: '250' } });
+      fireEvent.keyDown(field, { key: 'Enter' });
+      expect(onSimSpecCommit).toHaveBeenCalledTimes(1);
+      expect(onSimSpecCommit).toHaveBeenCalledWith('stopTime' satisfies SimSpecField, 250);
+    });
+
+    test('dt commits as a positive number', () => {
+      const onSimSpecCommit = jest.fn();
+      renderDrawer({ onSimSpecCommit });
+      const field = getField(/^dt$/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: '0.25' } });
+      fireEvent.blur(field);
+      expect(onSimSpecCommit).toHaveBeenCalledTimes(1);
+      expect(onSimSpecCommit).toHaveBeenCalledWith('dt' satisfies SimSpecField, 0.25);
+    });
+
+    test('a non-positive dt does not commit and reverts on blur', () => {
+      const onSimSpecCommit = jest.fn();
+      renderDrawer({ onSimSpecCommit });
+      const field = getField(/^dt$/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: '0' } });
+      fireEvent.blur(field);
+      expect(onSimSpecCommit).not.toHaveBeenCalled();
+      expect(field.value).toBe('1');
+    });
+
+    test('time units commits the free string', () => {
+      const onSimSpecCommit = jest.fn();
+      renderDrawer({ onSimSpecCommit });
+      const field = getField(/time units/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: 'months' } });
+      fireEvent.blur(field);
+      expect(onSimSpecCommit).toHaveBeenCalledTimes(1);
+      expect(onSimSpecCommit).toHaveBeenCalledWith('timeUnits' satisfies SimSpecField, 'months');
+    });
+
+    test('time units may be cleared to empty', () => {
+      const onSimSpecCommit = jest.fn();
+      renderDrawer({ onSimSpecCommit });
+      const field = getField(/time units/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: '' } });
+      fireEvent.blur(field);
+      expect(onSimSpecCommit).toHaveBeenCalledTimes(1);
+      expect(onSimSpecCommit).toHaveBeenCalledWith('timeUnits' satisfies SimSpecField, '');
+    });
+
+    test('empty numeric input does not commit and reverts on blur', () => {
+      const onSimSpecCommit = jest.fn();
+      renderDrawer({ onSimSpecCommit });
+      const field = getField(/start time/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: '' } });
+      fireEvent.blur(field);
+      expect(onSimSpecCommit).not.toHaveBeenCalled();
+      expect(field.value).toBe('0');
+    });
+
+    test('an unchanged value on blur does not commit', () => {
+      const onSimSpecCommit = jest.fn();
+      renderDrawer({ onSimSpecCommit });
+      const field = getField(/start time/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: '0' } });
+      fireEvent.blur(field);
+      expect(onSimSpecCommit).not.toHaveBeenCalled();
+    });
+
+    test('Escape reverts the draft without committing', () => {
+      const onSimSpecCommit = jest.fn();
+      renderDrawer({ onSimSpecCommit });
+      const field = getField(/start time/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: '4321' } });
+      expect(field.value).toBe('4321');
+      fireEvent.keyDown(field, { key: 'Escape' });
+      expect(onSimSpecCommit).not.toHaveBeenCalled();
+      expect(field.value).toBe('0');
+    });
+
+    test('Escape in a field does not dismiss the drawer', () => {
+      // Escape means "revert this field", not "close the drawer": the field
+      // handler stops propagation so the Drawer's own Escape-close listener
+      // never sees the key.
+      const onDrawerToggle = jest.fn();
+      renderDrawer({ onDrawerToggle });
+      const field = getField(/start time/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: '4321' } });
+      fireEvent.keyDown(field, { key: 'Escape' });
+      expect(onDrawerToggle).not.toHaveBeenCalled();
+    });
+
+    test('a props refresh while unfocused updates the display', () => {
+      const { rerender } = renderDrawer();
+      expect(getField(/start time/i).value).toBe('0');
+      rerender(<ModelPropertiesDrawer {...baseProps({ startTime: 50 })} />);
+      expect(getField(/start time/i).value).toBe('50');
+    });
+
+    test('a props refresh while focused does NOT clobber the draft', () => {
+      const onSimSpecCommit = jest.fn();
+      const { rerender } = renderDrawer({ onSimSpecCommit });
+      const field = getField(/start time/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: '1234' } });
+      // An engine refresh (e.g. autosave completing) republishes props.
+      rerender(<ModelPropertiesDrawer {...baseProps({ startTime: 999, onSimSpecCommit })} />);
+      expect(getField(/start time/i).value).toBe('1234');
+      expect(onSimSpecCommit).not.toHaveBeenCalled();
+    });
+
+    test('a valid commit keeps the typed value visible (no flash of the old value)', () => {
+      const onSimSpecCommit = jest.fn();
+      const { rerender } = renderDrawer({ onSimSpecCommit });
+      const field = getField(/start time/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: '1900' } });
+      fireEvent.blur(field);
+      // Before the engine round-trip republishes props the field still shows
+      // the committed value, not the pre-edit 0.
+      expect(getField(/start time/i).value).toBe('1900');
+      // Once the model catches up, the draft releases to the (equal) prop.
+      rerender(<ModelPropertiesDrawer {...baseProps({ startTime: 1900, onSimSpecCommit })} />);
+      expect(getField(/start time/i).value).toBe('1900');
+    });
+
+    test('committing one field then editing another commits each once', () => {
+      const onSimSpecCommit = jest.fn();
+      renderDrawer({ onSimSpecCommit });
+      const start = getField(/start time/i);
+      focus(start);
+      fireEvent.change(start, { target: { value: '10' } });
+      fireEvent.blur(start);
+      const stop = getField(/stop time/i);
+      focus(stop);
+      fireEvent.change(stop, { target: { value: '20' } });
+      fireEvent.blur(stop);
+      expect(onSimSpecCommit).toHaveBeenCalledTimes(2);
+      expect(onSimSpecCommit).toHaveBeenNthCalledWith(1, 'startTime', 10);
+      expect(onSimSpecCommit).toHaveBeenNthCalledWith(2, 'stopTime', 20);
+    });
+
+    test('unmounting a field with a pending draft (drawer close) commits on blur', () => {
+      // The Drawer never unmounts its children on close -- it CSS-hides the
+      // panel and its [open] effect restores focus to the previously-active
+      // element, which is what blurs the focused field and drives the commit.
+      // We assert that ordering explicitly: a blur commits, and whatever
+      // teardown follows (here, unmount) fires nothing further.
+      const onSimSpecCommit = jest.fn();
+      const { unmount } = renderDrawer({ onSimSpecCommit });
+      const field = getField(/start time/i);
+      focus(field);
+      fireEvent.change(field, { target: { value: '77' } });
+      fireEvent.blur(field);
+      expect(onSimSpecCommit).toHaveBeenCalledTimes(1);
+      unmount();
+      expect(onSimSpecCommit).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/src/diagram/tests/sim-spec-draft.test.ts
+++ b/src/diagram/tests/sim-spec-draft.test.ts
@@ -1,0 +1,80 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+import { formatSimSpecValue, resolveSimSpecDraft } from '../sim-spec-draft';
+
+describe('formatSimSpecValue', () => {
+  test('renders numbers as their default string form', () => {
+    expect(formatSimSpecValue(0)).toBe('0');
+    expect(formatSimSpecValue(100)).toBe('100');
+    expect(formatSimSpecValue(0.25)).toBe('0.25');
+  });
+
+  test('passes strings through unchanged', () => {
+    expect(formatSimSpecValue('years')).toBe('years');
+    expect(formatSimSpecValue('')).toBe('');
+  });
+});
+
+describe('resolveSimSpecDraft numeric fields', () => {
+  test('commits a changed, finite value', () => {
+    expect(resolveSimSpecDraft('startTime', '1900', 0)).toEqual({ shouldCommit: true, value: 1900 });
+    expect(resolveSimSpecDraft('stopTime', '50', 100)).toEqual({ shouldCommit: true, value: 50 });
+  });
+
+  test('tolerates surrounding whitespace', () => {
+    expect(resolveSimSpecDraft('startTime', '  12 ', 0)).toEqual({ shouldCommit: true, value: 12 });
+  });
+
+  test('does not commit an unchanged value', () => {
+    expect(resolveSimSpecDraft('startTime', '0', 0)).toEqual({ shouldCommit: false });
+    expect(resolveSimSpecDraft('stopTime', '100', 100)).toEqual({ shouldCommit: false });
+  });
+
+  test('rejects empty input (Number("") is 0, so this must be special-cased)', () => {
+    expect(resolveSimSpecDraft('startTime', '', 5)).toEqual({ shouldCommit: false });
+    expect(resolveSimSpecDraft('startTime', '   ', 5)).toEqual({ shouldCommit: false });
+  });
+
+  test('rejects non-numeric garbage', () => {
+    expect(resolveSimSpecDraft('startTime', 'abc', 5)).toEqual({ shouldCommit: false });
+    expect(resolveSimSpecDraft('startTime', '-', 5)).toEqual({ shouldCommit: false });
+    expect(resolveSimSpecDraft('stopTime', '1.2.3', 5)).toEqual({ shouldCommit: false });
+  });
+
+  test('rejects non-finite values', () => {
+    expect(resolveSimSpecDraft('startTime', 'Infinity', 5)).toEqual({ shouldCommit: false });
+    expect(resolveSimSpecDraft('startTime', 'NaN', 5)).toEqual({ shouldCommit: false });
+  });
+
+  test('accepts a negative start time (the engine, not the drawer, owns start<stop)', () => {
+    expect(resolveSimSpecDraft('startTime', '-10', 0)).toEqual({ shouldCommit: true, value: -10 });
+  });
+});
+
+describe('resolveSimSpecDraft dt', () => {
+  test('commits a positive dt', () => {
+    expect(resolveSimSpecDraft('dt', '0.5', 1)).toEqual({ shouldCommit: true, value: 0.5 });
+  });
+
+  test('rejects a non-positive dt', () => {
+    expect(resolveSimSpecDraft('dt', '0', 1)).toEqual({ shouldCommit: false });
+    expect(resolveSimSpecDraft('dt', '-1', 1)).toEqual({ shouldCommit: false });
+  });
+});
+
+describe('resolveSimSpecDraft timeUnits', () => {
+  test('commits a changed free string', () => {
+    expect(resolveSimSpecDraft('timeUnits', 'months', 'years')).toEqual({ shouldCommit: true, value: 'months' });
+  });
+
+  test('allows clearing to an empty string', () => {
+    expect(resolveSimSpecDraft('timeUnits', '', 'years')).toEqual({ shouldCommit: true, value: '' });
+  });
+
+  test('does not commit an unchanged string', () => {
+    expect(resolveSimSpecDraft('timeUnits', 'years', 'years')).toEqual({ shouldCommit: false });
+    expect(resolveSimSpecDraft('timeUnits', '', '')).toEqual({ shouldCommit: false });
+  });
+});

--- a/src/diagram/tests/variable-details-cancel.test.tsx
+++ b/src/diagram/tests/variable-details-cancel.test.tsx
@@ -236,6 +236,29 @@ describe('VariableDetails discard (Cancel / Escape)', () => {
     expect((editable as HTMLElement).textContent).toBe('a + b');
   });
 
+  it('switching to the Lookup Function tab commits a pending edit', async () => {
+    // The tab strip sits inside the card, so the blur toward it is an
+    // intra-panel blur the focusLeftPanel gate deliberately skips -- but the
+    // tab switch hides the equation editors (and the Lookup tab renders no
+    // Save/Cancel), so a pending edit would be stranded invisibly and dropped
+    // by the next keyed remount. Changing tabs must commit, like blur-away.
+    const { container, onEquationChange } = renderDetails(makeAux('x', 'a + b', { errors: forceEditorOpen }));
+    const editor = editorFor(container, '.eqnEditor');
+    await appendText(editor, 'Z');
+
+    const editable = container.querySelector('.eqnEditor') as HTMLElement;
+    const lookupTab = buttonByText(container, 'Lookup Function');
+    await act(async () => {
+      fireEvent.mouseDown(lookupTab);
+      fireEvent.blur(editable, { relatedTarget: lookupTab });
+      fireEvent.click(lookupTab);
+      await Promise.resolve();
+    });
+
+    expect(onEquationChange).toHaveBeenCalledTimes(1);
+    expect(onEquationChange).toHaveBeenCalledWith('x', 'a + bZ', undefined, undefined);
+  });
+
   it('blur to the canvas (focus leaves the panel) still commits the edit', async () => {
     const { container, onEquationChange } = renderDetails(makeAux('x', 'a + b', { errors: forceEditorOpen }));
     const editor = editorFor(container, '.eqnEditor');

--- a/src/diagram/tests/variable-details-cancel.test.tsx
+++ b/src/diagram/tests/variable-details-cancel.test.tsx
@@ -1,0 +1,374 @@
+/**
+ * @jest-environment jsdom
+ *
+ * Copyright 2026 The Simlin Authors. All rights reserved.
+ * Use of this source code is governed by the Apache License,
+ * Version 2.0, that can be found in the LICENSE file.
+ */
+
+// Discarding in-progress equation edits (GitHub issue #86). All three fields
+// (equation, units, notes) save on blur, which is load-bearing: a canvas-driven
+// edit blurs the panel editor to commit its text. The bug was that clicking
+// Cancel -- or pressing Escape -- blurred the focused editor FIRST, so the edit
+// committed before the discard ran. These tests pin that Cancel/Escape now win
+// over the blur-save while a genuine blur-away still commits.
+
+import { TextEncoder, TextDecoder } from 'util';
+Object.assign(globalThis, { TextEncoder, TextDecoder });
+
+beforeAll(() => {
+  // slate-react's keyDown pipeline gates on ReactEditor.hasEditableTarget ->
+  // element.isContentEditable before forwarding to our onKeyDown; jsdom lacks it.
+  Object.defineProperty(HTMLElement.prototype, 'isContentEditable', {
+    configurable: true,
+    get(this: HTMLElement): boolean {
+      return this.getAttribute('contenteditable') === 'true';
+    },
+  });
+  // jsdom does not implement Range.getBoundingClientRect, which the preview
+  // click-to-caret mapping calls. Stub it (and getClientRects) so clicking the
+  // equation preview opens the raw editor instead of throwing.
+  if (!('getBoundingClientRect' in Range.prototype)) {
+    const zero = () =>
+      ({ x: 0, y: 0, width: 0, height: 0, top: 0, left: 0, right: 0, bottom: 0, toJSON() {} }) as DOMRect;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Range.prototype as any).getBoundingClientRect = zero;
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (Range.prototype as any).getClientRects = () =>
+      ({ length: 0, item: () => null, [Symbol.iterator]: function* () {} }) as unknown as DOMRectList;
+  }
+});
+
+import * as React from 'react';
+import { render, act, fireEvent } from '@testing-library/react';
+import { Editor, Transforms } from 'slate';
+import { HistoryEditor } from 'slate-history';
+import { ELEMENT_TO_NODE } from 'slate-dom';
+import { VariableDetails } from '../VariableDetails';
+import { Aux, AuxViewElement, EquationError, ErrorCode } from '@simlin/core/datamodel';
+
+function makeAux(ident: string, equation: string, overrides: Partial<Aux> = {}): Aux {
+  return {
+    type: 'aux',
+    ident,
+    equation: { type: 'scalar', equation },
+    documentation: '',
+    units: '',
+    gf: undefined,
+    data: undefined,
+    errors: undefined,
+    unitErrors: undefined,
+    uid: undefined,
+    ...overrides,
+  };
+}
+
+function makeViewElement(ident: string): AuxViewElement {
+  return {
+    type: 'aux',
+    uid: 1,
+    name: ident,
+    ident,
+    var: undefined,
+    x: 0,
+    y: 0,
+    labelSide: 'right',
+    isZeroRadius: false,
+  };
+}
+
+// An equation error forces the raw equation editor open on mount (showPreview
+// gating), so the contenteditable is present to type into and stays present
+// after a discard (letting us assert the reverted content).
+const forceEditorOpen: EquationError[] = [{ start: 0, end: 1, code: 0 as unknown as ErrorCode }];
+
+const noop = () => {};
+
+interface Harness {
+  container: HTMLElement;
+  onEquationChange: jest.Mock;
+}
+
+function renderDetails(variable: Aux): Harness {
+  const onEquationChange = jest.fn();
+  const { container } = render(
+    <VariableDetails
+      variable={variable}
+      viewElement={makeViewElement(variable.ident)}
+      onDelete={noop}
+      onEquationChange={onEquationChange}
+      onTableChange={noop}
+      activeTab={0}
+      onActiveTabChange={noop}
+    />,
+  );
+  return { container, onEquationChange };
+}
+
+// The Slate editor instance backing a rendered Editable, reachable through
+// slate-dom's element->node map. Driving edits through it (rather than fake
+// DOM input events, which jsdom does not support for Slate) is the highest
+// fidelity typing available.
+function editorFor(container: HTMLElement, selector: string): Editor {
+  const el = container.querySelector(selector);
+  expect(el).not.toBeNull();
+  return ELEMENT_TO_NODE.get(el as HTMLElement) as unknown as Editor;
+}
+
+async function appendText(editor: Editor, text: string): Promise<void> {
+  await act(async () => {
+    Transforms.insertText(editor, text, { at: Editor.end(editor, []) });
+    // Slate defers its onChange to a microtask; nudge it and flush so the
+    // component's React state (and Save/Cancel enabled state) updates.
+    editor.onChange();
+    await Promise.resolve();
+  });
+}
+
+function stripZeroWidth(s: string | null): string {
+  return Array.from(s ?? '')
+    .filter((c) => c.charCodeAt(0) !== 0xfeff && c.charCodeAt(0) !== 0x200b)
+    .join('');
+}
+
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement {
+  const btn = Array.from(container.querySelectorAll('button')).find((b) => b.textContent === text);
+  expect(btn).toBeTruthy();
+  return btn as HTMLButtonElement;
+}
+
+async function openEquationEditorViaPreview(container: HTMLElement): Promise<void> {
+  const preview = container.querySelector('.eqnPreview');
+  expect(preview).not.toBeNull();
+  await act(async () => {
+    fireEvent.click(preview as Element);
+  });
+  await act(async () => {
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+  });
+}
+
+describe('VariableDetails discard (Cancel / Escape)', () => {
+  it('click Cancel discards the equation edit and reverts the field', async () => {
+    const { container, onEquationChange } = renderDetails(makeAux('x', 'a + b', { errors: forceEditorOpen }));
+    const editor = editorFor(container, '.eqnEditor');
+    await appendText(editor, 'Z');
+
+    const editable = container.querySelector('.eqnEditor') as HTMLElement;
+    expect(editable.textContent).toBe('a + bZ');
+    const cancel = buttonByText(container, 'Cancel');
+    expect(cancel.disabled).toBe(false);
+
+    // The browser sequence for a mouse click on Cancel: pointer-down (our
+    // preventDefault keeps focus, so relatedTarget is the button), then click.
+    const notPrevented = fireEvent.mouseDown(cancel);
+    expect(notPrevented).toBe(false); // onMouseDown preventDefault is wired
+    await act(async () => {
+      fireEvent.blur(editable, { relatedTarget: cancel });
+      fireEvent.click(cancel);
+      await Promise.resolve();
+    });
+
+    expect(onEquationChange).not.toHaveBeenCalled();
+    // The visible editor content reverted to the original equation.
+    expect((container.querySelector('.eqnEditor') as HTMLElement).textContent).toBe('a + b');
+    expect(buttonByText(container, 'Cancel').disabled).toBe(true);
+  });
+
+  it('keyboard-activated Cancel (no pointer-down) also discards', async () => {
+    const { container, onEquationChange } = renderDetails(makeAux('x', 'a + b', { errors: forceEditorOpen }));
+    const editor = editorFor(container, '.eqnEditor');
+    await appendText(editor, 'Z');
+
+    const editable = container.querySelector('.eqnEditor') as HTMLElement;
+    const cancel = buttonByText(container, 'Cancel');
+    // Tabbing to the button blurs the editor (relatedTarget = the button); then
+    // Enter/Space fires the click. No pointer-down occurs, so this exercises the
+    // focusLeftPanel guard, not the button's preventDefault.
+    await act(async () => {
+      fireEvent.blur(editable, { relatedTarget: cancel });
+      fireEvent.click(cancel);
+      await Promise.resolve();
+    });
+
+    expect(onEquationChange).not.toHaveBeenCalled();
+    expect((container.querySelector('.eqnEditor') as HTMLElement).textContent).toBe('a + b');
+  });
+
+  it('Escape discards the equation edit and reverts to the preview', async () => {
+    const { container, onEquationChange } = renderDetails(makeAux('x', 'a + b'));
+    await openEquationEditorViaPreview(container);
+    const editor = editorFor(container, '.eqnEditor');
+    await appendText(editor, 'Z');
+    expect((container.querySelector('.eqnEditor') as HTMLElement).textContent).toBe('a + bZ');
+
+    await act(async () => {
+      fireEvent.keyDown(container.querySelector('.eqnEditor') as Element, { key: 'Escape' });
+      await Promise.resolve();
+    });
+
+    expect(onEquationChange).not.toHaveBeenCalled();
+    // Escape exits the raw editor back to the preview, showing the original.
+    expect(container.querySelector('.eqnEditor')).toBeNull();
+    const preview = container.querySelector('.eqnPreview');
+    expect(preview).not.toBeNull();
+    expect(preview!.textContent).toContain('a + b');
+    expect(preview!.textContent).not.toContain('a + bZ');
+  });
+
+  it('Escape discards when an equation error pins the raw editor open', async () => {
+    // With a fatal error the editor cannot fall back to the preview, so it stays
+    // mounted after the discard -- a distinct branch from the no-error path
+    // above. The revert must land in the still-mounted editor.
+    const { container, onEquationChange } = renderDetails(makeAux('x', 'a + b', { errors: forceEditorOpen }));
+    const editor = editorFor(container, '.eqnEditor');
+    await appendText(editor, 'Z');
+    expect((container.querySelector('.eqnEditor') as HTMLElement).textContent).toBe('a + bZ');
+
+    await act(async () => {
+      fireEvent.keyDown(container.querySelector('.eqnEditor') as Element, { key: 'Escape' });
+      await Promise.resolve();
+    });
+
+    expect(onEquationChange).not.toHaveBeenCalled();
+    const editable = container.querySelector('.eqnEditor');
+    expect(editable).not.toBeNull();
+    expect((editable as HTMLElement).textContent).toBe('a + b');
+  });
+
+  it('blur to the canvas (focus leaves the panel) still commits the edit', async () => {
+    const { container, onEquationChange } = renderDetails(makeAux('x', 'a + b', { errors: forceEditorOpen }));
+    const editor = editorFor(container, '.eqnEditor');
+    await appendText(editor, 'Z');
+
+    const editable = container.querySelector('.eqnEditor') as HTMLElement;
+    // relatedTarget null models focus moving to a non-focusable canvas / nowhere.
+    await act(async () => {
+      fireEvent.blur(editable, { relatedTarget: null });
+      await Promise.resolve();
+    });
+
+    expect(onEquationChange).toHaveBeenCalledTimes(1);
+    expect(onEquationChange).toHaveBeenCalledWith('x', 'a + bZ', undefined, undefined);
+  });
+
+  it('Save commits the edited equation exactly once', async () => {
+    const { container, onEquationChange } = renderDetails(makeAux('x', 'a + b', { errors: forceEditorOpen }));
+    const editor = editorFor(container, '.eqnEditor');
+    await appendText(editor, 'Z');
+
+    const editable = container.querySelector('.eqnEditor') as HTMLElement;
+    const save = buttonByText(container, 'Save');
+    await act(async () => {
+      // Focus moves to Save (inside the panel) then the click fires. The blur
+      // must not double-commit; only the click's onClick should.
+      fireEvent.blur(editable, { relatedTarget: save });
+      fireEvent.click(save);
+      await Promise.resolve();
+    });
+
+    expect(onEquationChange).toHaveBeenCalledTimes(1);
+    expect(onEquationChange).toHaveBeenCalledWith('x', 'a + bZ', undefined, undefined);
+  });
+
+  it('Cancel discards an in-progress units edit', async () => {
+    const { container, onEquationChange } = renderDetails(makeAux('x', 'a + b'));
+    const unitsEditor = editorFor(container, '.unitsEditor');
+    await appendText(unitsEditor, 'kg');
+
+    const unitsEditable = container.querySelector('.unitsEditor') as HTMLElement;
+    expect(unitsEditable.textContent).toBe('kg');
+    const cancel = buttonByText(container, 'Cancel');
+    await act(async () => {
+      fireEvent.blur(unitsEditable, { relatedTarget: cancel });
+      fireEvent.click(cancel);
+      await Promise.resolve();
+    });
+
+    expect(onEquationChange).not.toHaveBeenCalled();
+    // The typed units are gone (the emptied field falls back to its
+    // placeholder), and with every field back to its original the actions
+    // disable again.
+    expect(stripZeroWidth((container.querySelector('.unitsEditor') as HTMLElement).textContent)).not.toContain('kg');
+    expect(buttonByText(container, 'Cancel').disabled).toBe(true);
+  });
+
+  it('Escape in the notes field discards its edit', async () => {
+    const { container, onEquationChange } = renderDetails(makeAux('x', 'a + b'));
+    const notesEditor = editorFor(container, '.notesEditor');
+    await appendText(notesEditor, 'hello');
+
+    const notesEditable = container.querySelector('.notesEditor') as HTMLElement;
+    expect(notesEditable.textContent).toBe('hello');
+    await act(async () => {
+      fireEvent.keyDown(notesEditable, { key: 'Escape' });
+      await Promise.resolve();
+    });
+
+    expect(onEquationChange).not.toHaveBeenCalled();
+    expect(stripZeroWidth((container.querySelector('.notesEditor') as HTMLElement).textContent)).not.toContain('hello');
+    expect(buttonByText(container, 'Cancel').disabled).toBe(true);
+  });
+
+  it('undo (Cmd+Z) after Cancel does not resurrect the discarded text', async () => {
+    // The editors are withHistory: without clearing history, the discard's own
+    // transforms are recorded, so one undo would invert the revert and bring the
+    // abandoned text back -- and a later blur would then commit it.
+    const { container, onEquationChange } = renderDetails(makeAux('x', 'a + b'));
+    const unitsEditor = editorFor(container, '.unitsEditor');
+    await appendText(unitsEditor, 'kg');
+
+    const cancel = buttonByText(container, 'Cancel');
+    await act(async () => {
+      fireEvent.blur(container.querySelector('.unitsEditor') as Element, { relatedTarget: cancel });
+      fireEvent.click(cancel);
+      await Promise.resolve();
+    });
+
+    // Drive the Slate history undo directly (jsdom cannot deliver the Cmd+Z
+    // chord through slate-react's input pipeline).
+    await act(async () => {
+      HistoryEditor.undo(unitsEditor as unknown as HistoryEditor);
+      unitsEditor.onChange();
+      await Promise.resolve();
+    });
+
+    expect(stripZeroWidth((container.querySelector('.unitsEditor') as HTMLElement).textContent)).not.toContain('kg');
+
+    // A blur-away after the undo must not commit resurrected text.
+    await act(async () => {
+      fireEvent.blur(container.querySelector('.unitsEditor') as Element, { relatedTarget: null });
+      await Promise.resolve();
+    });
+    expect(onEquationChange).not.toHaveBeenCalled();
+  });
+
+  it('intra-panel blur keeps the raw editor open; blur away collapses to preview and commits', async () => {
+    const { container, onEquationChange } = renderDetails(makeAux('x', 'a + b'));
+    await openEquationEditorViaPreview(container);
+    const editor = editorFor(container, '.eqnEditor');
+    await appendText(editor, 'Z');
+
+    // Blur toward another field inside the panel: no commit, and the raw editor
+    // stays open showing the pending edit rather than snapping to the preview.
+    const units = container.querySelector('.unitsEditor') as HTMLElement;
+    await act(async () => {
+      fireEvent.blur(container.querySelector('.eqnEditor') as Element, { relatedTarget: units });
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.eqnEditor')).not.toBeNull();
+    expect(container.querySelector('.eqnPreview')).toBeNull();
+    expect((container.querySelector('.eqnEditor') as HTMLElement).textContent).toBe('a + bZ');
+    expect(onEquationChange).not.toHaveBeenCalled();
+
+    // Blur out of the panel: commits and collapses back to the preview.
+    await act(async () => {
+      fireEvent.blur(container.querySelector('.eqnEditor') as Element, { relatedTarget: null });
+      await Promise.resolve();
+    });
+    expect(container.querySelector('.eqnEditor')).toBeNull();
+    expect(container.querySelector('.eqnPreview')).not.toBeNull();
+    expect(onEquationChange).toHaveBeenCalledTimes(1);
+    expect(onEquationChange).toHaveBeenCalledWith('x', 'a + bZ', undefined, undefined);
+  });
+});

--- a/src/diagram/tests/viewport.test.ts
+++ b/src/diagram/tests/viewport.test.ts
@@ -9,21 +9,26 @@
 import {
   MAX_ZOOM,
   MIN_ZOOM,
+  OFFSCREEN_VISIBLE_FRACTION,
   PINCH_ZOOM_DIVISOR,
   VELOCITY_THRESHOLD,
   calculateVelocity,
+  centerOffsetForBounds,
   clampZoom,
   frictionPosition,
   frictionVelocity,
+  isDiagramOffscreen,
   isMomentumDone,
   momentumOffsetAt,
   pinchOffset,
   pinchZoom,
   resizeViewBox,
+  visibleDiagramFraction,
   wheelPanOffset,
   wheelZoom,
   zoomAroundPoint,
 } from '../drawing/viewport';
+import type { Rect } from '../drawing/common';
 
 describe('clampZoom', () => {
   it('clamps to the supported range and passes through in-range values', () => {
@@ -194,5 +199,151 @@ describe('resizeViewBox', () => {
       width: 840,
       height: 580,
     });
+  });
+});
+
+describe('visibleDiagramFraction / isDiagramOffscreen (issue #52)', () => {
+  // A 100x100 model-space box at the origin, on a 1000x1000 canvas at zoom 1.
+  // With those defaults, offset.x = -N shifts the box's left edge to screen -N,
+  // so the visible width is trivially (100 - N) for 0 <= N <= 100.
+  const box: Rect = { left: 0, top: 0, right: 100, bottom: 100 };
+  const svg = { width: 1000, height: 1000 };
+
+  const cases: ReadonlyArray<{ name: string; offsetX: number; fraction: number; offscreen: boolean }> = [
+    { name: 'fully visible (centered at origin)', offsetX: 0, fraction: 1, offscreen: false },
+    { name: 'mostly visible (50%)', offsetX: -50, fraction: 0.5, offscreen: false },
+    { name: 'mostly offscreen (9%)', offsetX: -91, fraction: 0.09, offscreen: true },
+    { name: 'exactly at threshold (10%)', offsetX: -90, fraction: 0.1, offscreen: false },
+  ];
+
+  for (const c of cases) {
+    it(`${c.name}: fraction ${c.fraction}, offscreen=${c.offscreen}`, () => {
+      const offset = { x: c.offsetX, y: 0 };
+      expect(visibleDiagramFraction(box, offset, 1, svg)).toBeCloseTo(c.fraction, 6);
+      expect(isDiagramOffscreen(box, offset, 1, svg)).toBe(c.offscreen);
+    });
+  }
+
+  it('reports zero visible fraction for a box entirely off the canvas', () => {
+    const offset = { x: -5000, y: -5000 };
+    expect(visibleDiagramFraction(box, offset, 1, svg)).toBe(0);
+    expect(isDiagramOffscreen(box, offset, 1, svg)).toBe(true);
+  });
+
+  it('treats an empty (zero-area) box as fully visible and never offscreen', () => {
+    const emptyBox: Rect = { left: 0, top: 0, right: 0, bottom: 0 };
+    // Even with an absurd offset, an empty model must not trigger a re-center.
+    expect(visibleDiagramFraction(emptyBox, { x: -9999, y: -9999 }, 1, svg)).toBe(1);
+    expect(isDiagramOffscreen(emptyBox, { x: -9999, y: -9999 }, 1, svg)).toBe(false);
+  });
+
+  it('never reports offscreen when the canvas has not been measured (zero size)', () => {
+    // A far-offscreen box, but a 0x0 viewport means there is nothing to center
+    // against yet -- the shell waits for the first real measurement.
+    expect(isDiagramOffscreen(box, { x: -5000, y: -5000 }, 1, { width: 0, height: 0 })).toBe(false);
+  });
+
+  it('is computed in screen space: clipping against the fixed viewport depends on zoom', () => {
+    // The overlap is a screen-space ratio, so it is zoom-dependent by design: at
+    // zoom 2 the same model box covers twice the pixels, so a given model-space
+    // shift leaves more of it visible relative to the fixed 1000px viewport.
+    // zoom 1, offset -50: screen [-50,50] over box width 100 -> 50% visible.
+    expect(visibleDiagramFraction(box, { x: -50, y: 0 }, 1, svg)).toBeCloseTo(0.5, 6);
+    // zoom 2, offset -25: screen [-50,150] over box width 200 -> 150/200 visible.
+    expect(visibleDiagramFraction(box, { x: -25, y: 0 }, 2, svg)).toBeCloseTo(0.75, 6);
+  });
+
+  it('honors a caller-supplied threshold', () => {
+    const offset = { x: -70, y: 0 }; // 30% visible
+    expect(visibleDiagramFraction(box, offset, 1, svg)).toBeCloseTo(0.3, 6);
+    expect(isDiagramOffscreen(box, offset, 1, svg, 0.5)).toBe(true);
+    expect(isDiagramOffscreen(box, offset, 1, svg, 0.2)).toBe(false);
+  });
+
+  it('exposes a 10% default threshold', () => {
+    expect(OFFSCREEN_VISIBLE_FRACTION).toBe(0.1);
+  });
+
+  // A model whose on-screen bbox is LARGER than the viewport: normalizing by the
+  // box area alone would report a well-framed large model as mostly hidden and
+  // yank it to bbox-center on every open, permanently discarding the user's saved
+  // framing for exactly the large models where it matters most. The metric
+  // normalizes by min(boxArea, viewportArea) so "viewport full of diagram" reads
+  // 1.0 regardless of bbox size.
+  describe('big-box regime (bbox larger than the viewport)', () => {
+    const bigBox: Rect = { left: 0, top: 0, right: 3500, bottom: 3000 };
+    const smallViewport = { width: 1200, height: 800 };
+
+    it('a perfectly-centered big model is NOT offscreen', () => {
+      // Center the bbox (center 1750,1500) in the 1200x800 viewport at zoom 1.
+      const offset = centerOffsetForBounds(bigBox, 1, smallViewport);
+      // The viewport is entirely inside the bbox -> the whole viewport is filled
+      // with diagram -> fraction 1.0 under min-normalization.
+      expect(visibleDiagramFraction(bigBox, offset, 1, smallViewport)).toBeCloseTo(1, 6);
+      expect(isDiagramOffscreen(bigBox, offset, 1, smallViewport)).toBe(false);
+      // Guard against a box-area-normalized regression: it would read ~9% and
+      // (wrongly) trip the 10% threshold.
+      const boxAreaFraction =
+        (smallViewport.width * smallViewport.height) / ((bigBox.right - bigBox.left) * (bigBox.bottom - bigBox.top));
+      expect(boxAreaFraction).toBeLessThan(0.1);
+    });
+
+    it('a corner-framed big model (viewport wholly inside the bbox) is NOT offscreen', () => {
+      // Offset so the viewport sits near a corner of the model but is still
+      // entirely covered by diagram.
+      const offset = { x: -100, y: -100 };
+      expect(visibleDiagramFraction(bigBox, offset, 1, smallViewport)).toBeCloseTo(1, 6);
+      expect(isDiagramOffscreen(bigBox, offset, 1, smallViewport)).toBe(false);
+    });
+
+    it('a big model with only a sliver in view IS offscreen', () => {
+      // Pan so the bbox's left edge is at screen 1140: only a 60px-wide strip of
+      // the 1200px viewport shows diagram. 60*800 / min(bigBoxArea, 1200*800)
+      // = 48000 / 960000 = 5% < 10%.
+      const offset = { x: 1140, y: -100 };
+      expect(visibleDiagramFraction(bigBox, offset, 1, smallViewport)).toBeCloseTo(0.05, 6);
+      expect(isDiagramOffscreen(bigBox, offset, 1, smallViewport)).toBe(true);
+    });
+
+    it('a big model panned fully away IS offscreen', () => {
+      const offset = { x: -10000, y: -10000 };
+      expect(visibleDiagramFraction(bigBox, offset, 1, smallViewport)).toBe(0);
+      expect(isDiagramOffscreen(bigBox, offset, 1, smallViewport)).toBe(true);
+    });
+
+    it('a half-covered viewport reads 0.5 (viewport-area normalized)', () => {
+      // bbox left edge at screen 600 (viewport midpoint), full height covered:
+      // intersection 600x800 over the 1200x800 viewport = 0.5.
+      const offset = { x: 600, y: -100 };
+      expect(visibleDiagramFraction(bigBox, offset, 1, smallViewport)).toBeCloseTo(0.5, 6);
+      expect(isDiagramOffscreen(bigBox, offset, 1, smallViewport)).toBe(false);
+    });
+  });
+});
+
+describe('centerOffsetForBounds (issue #52)', () => {
+  const box: Rect = { left: 0, top: 0, right: 100, bottom: 100 };
+  const svg = { width: 1000, height: 1000 };
+
+  it('places the box center at the middle of the viewport at zoom 1', () => {
+    const offset = centerOffsetForBounds(box, 1, svg);
+    expect(offset).toEqual({ x: 450, y: 450 });
+    // Verify: box center (50,50) maps to the screen center (500,500).
+    expect((50 + offset.x) * 1).toBeCloseTo(500, 6);
+    expect((50 + offset.y) * 1).toBeCloseTo(500, 6);
+  });
+
+  it('accounts for zoom without changing it', () => {
+    const offset = centerOffsetForBounds(box, 2, svg);
+    expect((50 + offset.x) * 2).toBeCloseTo(500, 6);
+    expect((50 + offset.y) * 2).toBeCloseTo(500, 6);
+  });
+
+  it('centers an off-origin box', () => {
+    const shifted: Rect = { left: 200, top: 400, right: 300, bottom: 500 };
+    const offset = centerOffsetForBounds(shifted, 1, svg);
+    // Center (250, 450) must land at the viewport center (500, 500).
+    expect((250 + offset.x) * 1).toBeCloseTo(500, 6);
+    expect((450 + offset.y) * 1).toBeCloseTo(500, 6);
   });
 });


### PR DESCRIPTION
Seven fixes for users interactively creating and editing models, picked from the #733 backlog index plus three issues discovered (and fixed) along the way. Each fix was implemented by a dedicated agent, adversarially reviewed by an independent agent, and iterated until the review had no material findings; each landed as its own commit.

Fixes #86
Fixes #53
Fixes #52
Fixes #55
Fixes #529
Fixes #832

## What changed

- **Cancel/Escape discard equation edits (#86, `59c780fd`).** All three details-panel editors save on blur, and clicking Cancel blurred first — so Cancel *saved* the edit it was discarding. Blur now commits only when focus leaves the panel; Cancel/Save/Delete preventDefault on pointer-down; Escape discards on all three fields; the discard resets the live Slate documents and clears their undo history so Cmd+Z can't resurrect the abandoned text (found by the adversarial review). The load-bearing canvas-blur-commit is regression-tested. Browser-verified on the real macOS mouse path.
- **Flow valve/label stability during cloud drags (#53 `b8031d52`, #832 `91718548`, follow-up `d4199189`).** Browser-reproduced: dragging a cloud perpendicular so the flow bends into an L teleported the valve+label onto the stock corner (~100px, every frame) and committed it there. Root cause was closest-segment clamping against the fixed pre-drag valve; the valve now rides the segment the drag is growing. The review of that fix surfaced two more defects in the same code, both fixed here rather than deferred: grabbing a *source* cloud reflected an off-center valve ~22px on the first frame (#832, the old mirror math was only idempotent for sink drags — replaced with signed fraction preservation), and a diagonal drag that traveled along-axis before bending snapped the cloud back ~100-165px at the bend (the reroute discarded accumulated parallel travel — it now applies the full delta). Continuity is pinned by step-sweep tests (same-topology steps <12px, topology-change hop <15px, measured 8px).
- **Center the diagram when a saved view is offscreen (#52, `a780ee96`).** Once per mount, after the first real svg measurement, idle-only, never in embedded mode; commits through the no-undo viewport path. The adversarial review caught that the first-draft visibility metric would have yanked every large/zoomed-in model to center on open (fraction-of-bbox can never reach the threshold when the bbox dwarfs the viewport); the metric now normalizes by the smaller of bbox and viewport area, so a viewport full of diagram reads fully visible.
- **Selection-emptying edits no longer strand the details panel (#529, `370200b5`).** Most of #529 was already fixed by the React refactor (`onSelectionChanged` fires from a post-commit effect for every path). The residue: delete/create/flow-attach/link-attach (and a no-match search) left `showDetails: 'variable'` over an empty selection. They now route through one pure helper. Decision: the model-level errors panel is deliberately exempt — deleting a variable mid-error-triage keeps the error list open; empty-canvas click/Escape keep their broader dismiss-everything behavior.
- **Sim-specs edits commit on settle (#55, `c011e15e`).** Every keystroke in start/stop/dt/time-units fired an engine patch, an undo entry (typing "1900" evicted most of the 5-deep undo buffer), and a save — and clearing a field patched `Number('') === 0` into the model. Fields now hold a local draft and commit once on blur/Enter through a pure resolver that rejects empty/non-finite values and non-positive dt; Escape reverts the field without dismissing the drawer. Browser-verified.

## Issues handled without code

- **#110** (flows invisible when created dragging left/up): verified already fixed at HEAD by the recent flow-tool work — regression tests exist for both axes, and I browser-verified live creation drags in all directions. Closed with evidence.
- **#833** (filed): `applySimSpecChange`'s full-payload read-modify-write can lose a concurrent sim-specs commit. Pre-existing, sub-second window, not human-reachable today; tracked instead of hotfixed.

## Verification

Every fix has fail-then-pass unit coverage (+~1,050 net test lines; the diagram suite grew from 1,395 to 1,475 tests). #86, #53, #110, and #55 were additionally verified in a real browser against the dev stack; #52's mount path is covered by integration tests with real resize sequencing plus the reviewer's code-trace (synthetic pointer events can't drive the canvas viewport, so no browser E2E for that one). Pre-commit hooks (Rust + TS + Python) passed for every commit.

One known cosmetic behavior deliberately left alone: the perpendicular catch-up hop when a straight flow first bends (the flow is axis-pinned below the bend threshold, so the arrowhead catches up at the bend). It predates this work, is strictly smaller than before, and smoothing it is a reroute-threshold redesign rather than a bug fix.