### PR TITLE
diagram: three-valued unit-error kind; plain-language inference text

### DIFF
--- a/src/core/datamodel.ts
+++ b/src/core/datamodel.ts
@@ -52,11 +52,18 @@ export interface EquationError {
   readonly end: number;
 }
 
+// Mirrors the engine's three-valued unit-error kind (SimlinUnitErrorKind).
+// The kind determines where the error's `start`/`end` offsets point:
+// `definition` offsets index the units string; `consistency` offsets index
+// the equation; `inference` errors describe a contradiction spanning several
+// variables, so their offsets are not meaningful for any single field.
+export type UnitErrorKind = 'definition' | 'consistency' | 'inference';
+
 export interface UnitError {
   readonly code: ErrorCode;
   readonly start: number;
   readonly end: number;
-  readonly isConsistencyError: boolean;
+  readonly kind: UnitErrorKind;
   readonly details: string | undefined;
 }
 

--- a/src/core/tests/datamodel.test.ts
+++ b/src/core/tests/datamodel.test.ts
@@ -2089,7 +2089,7 @@ describe('variableHasError', () => {
     expect(
       variableHasError({
         ...base,
-        unitErrors: [{ code: ErrorCode.UnitMismatch, start: 0, end: 0, isConsistencyError: true, details: undefined }],
+        unitErrors: [{ code: ErrorCode.UnitMismatch, start: 0, end: 0, kind: 'consistency', details: undefined }],
       }),
     ).toBe(true);
   });
@@ -2107,7 +2107,7 @@ describe('display-only annotations never serialize', () => {
   // persisted into saved projects. Pin the exclusion.
   const annotations = {
     errors: [{ code: ErrorCode.EmptyEquation, start: 0, end: 0 }],
-    unitErrors: [{ code: ErrorCode.UnitMismatch, start: 0, end: 0, isConsistencyError: true, details: undefined }],
+    unitErrors: [{ code: ErrorCode.UnitMismatch, start: 0, end: 0, kind: 'consistency', details: undefined }],
     connectorErrors: [{ kind: 'missingConnector' as const, ident: 'a', name: 'a' }],
   };
 

--- a/src/diagram/equation-highlight.ts
+++ b/src/diagram/equation-highlight.ts
@@ -115,6 +115,12 @@ export function highlightSpansForLines(
  * so the entire declaration is underlined instead. Unit errors are non-fatal
  * project-wide, but within this field they are the error, hence 'error' red.
  *
+ * Inference errors underline nothing in either field: they describe a
+ * contradiction spanning several variables, so any single-field span would be
+ * arbitrary -- and their offsets point into an equation (possibly another
+ * variable's), never the units string. Their plain-language reason renders in
+ * the details panel instead.
+ *
  * An `end` of 0 is the engine's "to the end of the text" convention;
  * byteOffsetToUtf16 clamps, so any large value reads as "the end".
  */
@@ -137,15 +143,18 @@ export function highlightRangeForField(
   }
 
   if (isUnits) {
-    const definition = unitErrors.find((err) => !err.isConsistencyError);
+    const definition = unitErrors.find((err) => err.kind === 'definition');
     if (definition) {
       const endByte = definition.end === 0 ? Number.MAX_SAFE_INTEGER : definition.end;
       return { startByte: definition.start, endByte, kind: 'error' };
     }
-    return { startByte: 0, endByte: Number.MAX_SAFE_INTEGER, kind: 'error' };
+    if (unitErrors.some((err) => err.kind === 'consistency')) {
+      return { startByte: 0, endByte: Number.MAX_SAFE_INTEGER, kind: 'error' };
+    }
+    return undefined;
   }
 
-  const consistency = unitErrors.find((err) => err.isConsistencyError);
+  const consistency = unitErrors.find((err) => err.kind === 'consistency');
   if (!consistency) {
     return undefined;
   }

--- a/src/diagram/project-controller.ts
+++ b/src/diagram/project-controller.ts
@@ -26,6 +26,7 @@ import {
   Variable,
   EquationError,
   UnitError,
+  UnitErrorKind,
   SimError,
   ModelError,
   ErrorCode,
@@ -173,6 +174,20 @@ function getErrorDetails(error: unknown): ErrorDetailsLike {
   return {};
 }
 
+// Every Units-kind error the engine emits carries one of the three real
+// kinds; NotApplicable only appears on non-unit errors. Mapping it to
+// 'definition' is a defensive default for a malformed detail.
+function convertUnitErrorKind(kind: SimlinUnitErrorKind): UnitErrorKind {
+  switch (kind) {
+    case SimlinUnitErrorKind.Consistency:
+      return 'consistency';
+    case SimlinUnitErrorKind.Inference:
+      return 'inference';
+    default:
+      return 'definition';
+  }
+}
+
 /**
  * Convert the engine's flat error list into the model-scoped equation/unit
  * error maps the Editor renders. Errors for other models are filtered out.
@@ -204,7 +219,7 @@ export function convertErrorDetails(
         start: err.startOffset ?? 0,
         end: err.endOffset ?? 0,
         code: err.code as unknown as ErrorCode,
-        isConsistencyError: err.unitErrorKind === SimlinUnitErrorKind.Consistency,
+        kind: convertUnitErrorKind(err.unitErrorKind),
         // The bare reason ("computed units 'x' don't match specified units"),
         // NOT `err.message`: the message is terminal-formatted with a source
         // snippet + `~~~` underline + summary line, which renders as garbage
@@ -1118,7 +1133,10 @@ export class ProjectController {
       } else if (!err.variableName) {
         modelErrors.push({
           code: err.code as unknown as ErrorCode,
-          details: err.message ?? undefined,
+          // Prefer the bare reason over the terminal-formatted message (the
+          // unit-inference umbrella carries a plain-language sentence there);
+          // most model errors have no details and keep the message.
+          details: err.details ?? err.message ?? undefined,
         });
       }
     }

--- a/src/diagram/tests/equation-highlight.test.ts
+++ b/src/diagram/tests/equation-highlight.test.ts
@@ -2,7 +2,7 @@
 // Use of this source code is governed by the Apache License,
 // Version 2.0, that can be found in the LICENSE file.
 
-import { EquationError, UnitError, ErrorCode } from '@simlin/core/datamodel';
+import { EquationError, UnitError, UnitErrorKind, ErrorCode } from '@simlin/core/datamodel';
 
 import {
   applyToAllPrefix,
@@ -99,11 +99,13 @@ describe('highlightRangeForField', () => {
     start,
     end,
   });
-  const unitError = (isConsistencyError: boolean, start: number, end: number): UnitError => ({
-    code: isConsistencyError ? ErrorCode.UnitMismatch : ErrorCode.NoAppInUnits,
+  const codeForKind = (kind: UnitErrorKind): ErrorCode =>
+    kind === 'definition' ? ErrorCode.NoAppInUnits : ErrorCode.UnitMismatch;
+  const unitError = (kind: UnitErrorKind, start: number, end: number): UnitError => ({
+    code: codeForKind(kind),
     start,
     end,
-    isConsistencyError,
+    kind,
     details: undefined,
   });
 
@@ -117,24 +119,24 @@ describe('highlightRangeForField', () => {
   });
 
   it('equation errors take precedence over unit errors in the equation field', () => {
-    const range = highlightRangeForField('a + bad', [eqError(4, 7)], [unitError(true, 0, 7)], false);
+    const range = highlightRangeForField('a + bad', [eqError(4, 7)], [unitError('consistency', 0, 7)], false);
     expect(range).toEqual({ startByte: 4, endByte: 7, kind: 'error' });
   });
 
   it('underlines the whole units declaration for a consistency error', () => {
     // The consistency error's offsets point into the *equation*; the units
     // field underlines its entire declaration instead.
-    const range = highlightRangeForField('blerz/second', undefined, [unitError(true, 0, 6)], true);
+    const range = highlightRangeForField('blerz/second', undefined, [unitError('consistency', 0, 6)], true);
     expect(range).toEqual({ startByte: 0, endByte: Number.MAX_SAFE_INTEGER, kind: 'error' });
   });
 
   it('uses definition-error offsets in the units field', () => {
-    const range = highlightRangeForField('bad(units)', undefined, [unitError(false, 0, 3)], true);
+    const range = highlightRangeForField('bad(units)', undefined, [unitError('definition', 0, 3)], true);
     expect(range).toEqual({ startByte: 0, endByte: 3, kind: 'error' });
   });
 
   it('treats a definition error end of 0 as to-the-end', () => {
-    const range = highlightRangeForField('bad', undefined, [unitError(false, 1, 0)], true);
+    const range = highlightRangeForField('bad', undefined, [unitError('definition', 1, 0)], true);
     expect(range).toEqual({ startByte: 1, endByte: Number.MAX_SAFE_INTEGER, kind: 'error' });
   });
 
@@ -142,29 +144,57 @@ describe('highlightRangeForField', () => {
     const range = highlightRangeForField(
       'bad(units)',
       undefined,
-      [unitError(true, 0, 6), unitError(false, 0, 3)],
+      [unitError('consistency', 0, 6), unitError('definition', 0, 3)],
       true,
     );
     expect(range).toEqual({ startByte: 0, endByte: 3, kind: 'error' });
   });
 
   it('warns on the conflicting sub-expression in the equation field', () => {
-    const range = highlightRangeForField('a + b*c', undefined, [unitError(true, 4, 7)], false);
+    const range = highlightRangeForField('a + b*c', undefined, [unitError('consistency', 4, 7)], false);
     expect(range).toEqual({ startByte: 4, endByte: 7, kind: 'warning' });
   });
 
   it('suppresses a whole-equation consistency warning in the equation field', () => {
     // When the conflicting span is the entire equation the warning localizes
     // nothing; the units field carries the error underline instead.
-    expect(highlightRangeForField('2*aux1', undefined, [unitError(true, 0, 6)], false)).toBeUndefined();
+    expect(highlightRangeForField('2*aux1', undefined, [unitError('consistency', 0, 6)], false)).toBeUndefined();
   });
 
   it('suppresses a to-the-end consistency warning that starts at 0', () => {
-    expect(highlightRangeForField('2*aux1', undefined, [unitError(true, 0, 0)], false)).toBeUndefined();
+    expect(highlightRangeForField('2*aux1', undefined, [unitError('consistency', 0, 0)], false)).toBeUndefined();
   });
 
   it('ignores definition errors in the equation field', () => {
-    expect(highlightRangeForField('a + b', undefined, [unitError(false, 0, 3)], false)).toBeUndefined();
+    expect(highlightRangeForField('a + b', undefined, [unitError('definition', 0, 3)], false)).toBeUndefined();
+  });
+
+  it('underlines nothing for an inference error in the units field', () => {
+    // An inference error's offsets point into an equation (possibly another
+    // variable's), never the units string; no span in this field is right.
+    expect(highlightRangeForField('people/year', undefined, [unitError('inference', 2, 7)], true)).toBeUndefined();
+  });
+
+  it('underlines nothing for an inference error in the equation field', () => {
+    expect(highlightRangeForField('a + b', undefined, [unitError('inference', 2, 5)], false)).toBeUndefined();
+  });
+
+  it('keeps the consistency underline when an inference error is also present', () => {
+    const units = highlightRangeForField(
+      'people',
+      undefined,
+      [unitError('inference', 2, 7), unitError('consistency', 0, 6)],
+      true,
+    );
+    expect(units).toEqual({ startByte: 0, endByte: Number.MAX_SAFE_INTEGER, kind: 'error' });
+
+    const eqn = highlightRangeForField(
+      'a + b*c',
+      undefined,
+      [unitError('inference', 2, 7), unitError('consistency', 4, 7)],
+      false,
+    );
+    expect(eqn).toEqual({ startByte: 4, endByte: 7, kind: 'warning' });
   });
 
   it('returns undefined when there are no errors', () => {

--- a/src/diagram/tests/error-details.test.tsx
+++ b/src/diagram/tests/error-details.test.tsx
@@ -72,7 +72,7 @@ describe('ErrorDetails', () => {
         {...noErrors}
         varUnitErrors={
           new Map([
-            ['flow', [{ code: ErrorCode.UnitMismatch, start: 0, end: 1, isConsistencyError: true, details: 'm vs s' }]],
+            ['flow', [{ code: ErrorCode.UnitMismatch, start: 0, end: 1, kind: 'consistency', details: 'm vs s' }]],
           ])
         }
       />,
@@ -89,10 +89,7 @@ describe('ErrorDetails', () => {
         {...noErrors}
         varUnitErrors={
           new Map([
-            [
-              'flow',
-              [{ code: ErrorCode.UnitMismatch, start: 0, end: 1, isConsistencyError: true, details: undefined }],
-            ],
+            ['flow', [{ code: ErrorCode.UnitMismatch, start: 0, end: 1, kind: 'consistency', details: undefined }]],
           ])
         }
       />,

--- a/src/diagram/tests/project-controller.test.ts
+++ b/src/diagram/tests/project-controller.test.ts
@@ -635,9 +635,36 @@ describe('convertErrorDetails', () => {
     const errs = unitErrors.get('inflow');
     expect(errs).toHaveLength(1);
     expect(errs![0].details).toBe("computed units 'blerz' don't match specified units");
-    expect(errs![0].isConsistencyError).toBe(true);
+    expect(errs![0].kind).toBe('consistency');
     expect(errs![0].start).toBe(0);
     expect(errs![0].end).toBe(6);
+  });
+
+  it('maps the three-valued unit error kind through to core UnitError', () => {
+    const errAt = (unitErrorKind: SimlinUnitErrorKind, variableName: string): ErrorDetail =>
+      ({
+        modelName: 'main',
+        variableName,
+        kind: SimlinErrorKind.Units,
+        unitErrorKind,
+        code: 33,
+        startOffset: 0,
+        endOffset: 3,
+        message: null,
+        details: null,
+      }) as unknown as ErrorDetail;
+
+    const { unitErrors } = convertErrorDetails(
+      [
+        errAt(SimlinUnitErrorKind.Definition, 'a'),
+        errAt(SimlinUnitErrorKind.Consistency, 'b'),
+        errAt(SimlinUnitErrorKind.Inference, 'c'),
+      ],
+      'main',
+    );
+    expect(unitErrors.get('a')![0].kind).toBe('definition');
+    expect(unitErrors.get('b')![0].kind).toBe('consistency');
+    expect(unitErrors.get('c')![0].kind).toBe('inference');
   });
 
   it('leaves details undefined when the engine provides none', () => {
@@ -655,7 +682,7 @@ describe('convertErrorDetails', () => {
 
     const { unitErrors } = convertErrorDetails(errors, 'main');
     expect(unitErrors.get('x')![0].details).toBeUndefined();
-    expect(unitErrors.get('x')![0].isConsistencyError).toBe(false);
+    expect(unitErrors.get('x')![0].kind).toBe('definition');
   });
 });
 
@@ -698,6 +725,41 @@ describe('ProjectController error cache + navigation', () => {
     await flushTimers();
     expect(controller.getSnapshot().cachedErrors.varErrors.has('y')).toBe(true);
     expect(controller.getSnapshot().cachedErrors.varErrors.has('x')).toBe(false);
+    await controller.dispose();
+  });
+
+  it('prefers the bare details over the terminal-formatted message for model errors', async () => {
+    // The unit-inference umbrella diagnostic carries a plain-language
+    // sentence in `details`; the `message` twin is terminal-formatted and
+    // must not reach the errors panel when details is present.
+    const errorList: ErrorDetail[] = [
+      {
+        modelName: 'main',
+        variableName: null,
+        kind: SimlinErrorKind.Model,
+        code: 33,
+        message: "error in model 'main': unit_mismatch -- unit checking failed; inconsistent constraints:\n    1 == x",
+        details: "the units of 'a' and 'b' are inconsistent with each other",
+      } as unknown as ErrorDetail,
+      {
+        modelName: 'main',
+        variableName: null,
+        kind: SimlinErrorKind.Model,
+        code: 1,
+        message: 'error in model main: something broke',
+        details: null,
+      } as unknown as ErrorDetail,
+    ];
+    const engine = makeFakeEngine({ errors: errorList });
+    const { config } = makeControllerConfig({ engine });
+    const controller = new ProjectController(config);
+    await controller.openInitialProject();
+
+    const cached = await controller.refreshCachedErrors();
+    expect(cached?.modelErrors).toHaveLength(2);
+    expect(cached?.modelErrors[0].details).toBe("the units of 'a' and 'b' are inconsistent with each other");
+    // A model error without details still falls back to the message.
+    expect(cached?.modelErrors[1].details).toBe('error in model main: something broke');
     await controller.dispose();
   });
 

--- a/src/diagram/tests/variable-details-display.test.ts
+++ b/src/diagram/tests/variable-details-display.test.ts
@@ -32,7 +32,7 @@ const unitError: UnitError = {
   code: ErrorCode.BadTable,
   start: 0,
   end: 0,
-  isConsistencyError: true,
+  kind: 'consistency',
   details: 'dimensions are not equal',
 };
 

--- a/src/diagram/tests/variable-details-preview.test.tsx
+++ b/src/diagram/tests/variable-details-preview.test.tsx
@@ -115,7 +115,7 @@ describe('VariableDetails equation preview', () => {
 
   it('keeps the preview for a variable with only non-fatal unit warnings', () => {
     const unitErrors: UnitError[] = [
-      { start: 0, end: 0, code: 0 as unknown as ErrorCode, isConsistencyError: false, details: undefined },
+      { start: 0, end: 0, code: 0 as unknown as ErrorCode, kind: 'definition', details: undefined },
     ];
     const { container } = renderDetails(makeAux('rev', 'a + b', { unitErrors }));
 
@@ -159,7 +159,7 @@ describe('VariableDetails unit errors', () => {
     start: 0,
     end: 6,
     code: ErrorCode.UnitMismatch,
-    isConsistencyError: true,
+    kind: 'consistency',
     details,
   });
 
@@ -208,7 +208,7 @@ describe('VariableDetails unit errors', () => {
       start: 0,
       end: 5,
       code: ErrorCode.NoAppInUnits,
-      isConsistencyError: false,
+      kind: 'definition',
       details: undefined,
     };
     const { container } = renderDetails(makeAux('x', '1', { units: 'bad(u) * good', unitErrors: [defError] }));

--- a/src/simlin-engine/src/db/units.rs
+++ b/src/simlin-engine/src/db/units.rs
@@ -277,13 +277,23 @@ pub fn check_model_units(db: &dyn Db, model: SourceModel, project: SourceProject
     // available on the `InferenceResult` for callers that want it.
     let inference = crate::units_infer::infer(&models_s1, units_ctx, target_model);
     if has_declared_units && !inference.conflicts.is_empty() {
+        // The diagnostic detail is user-facing (it reaches the GUI's error
+        // panel): a plain-language sentence naming the involved variables,
+        // not the raw `1 == unit-expression` constraint dump. The full
+        // conflict list (with constraint text) remains available on the
+        // `InferenceResult` for callers that want it.
+        let friendly = match &inference.conflicts[0] {
+            crate::common::UnitError::InferenceError {
+                sources, details, ..
+            } => crate::errors::unit_inference_reason(sources, details.as_deref()),
+            other => format!("{other}"),
+        };
         let detail = if inference.conflicts.len() == 1 {
-            format!("{}", inference.conflicts[0])
+            friendly
         } else {
             format!(
-                "{} dimensional unit conflicts found during inference; first: {}",
-                inference.conflicts.len(),
-                inference.conflicts[0]
+                "{friendly} ({} unit problems found in total)",
+                inference.conflicts.len()
             )
         };
         CompilationDiagnostic(Diagnostic {

--- a/src/simlin-engine/src/errors.rs
+++ b/src/simlin-engine/src/errors.rs
@@ -4,6 +4,7 @@
 
 //! Helpers for formatting engine errors for human-readable output.
 
+use crate::builtins::Loc;
 use crate::common::{EquationError, Error, ErrorCode, UnitError};
 use crate::datamodel::{Equation, Project as DatamodelProject, Variable};
 use crate::db;
@@ -46,8 +47,9 @@ pub struct FormattedError {
     /// model/variable summary line that `message` carries (e.g. "computed
     /// units 'people' don't match specified units"). `message` is formatted
     /// for terminal output; GUI consumers that already show the variable in
-    /// context render this instead. Populated for unit errors that carry a
-    /// details string; None elsewhere.
+    /// context render this instead. Populated for unit errors (inference
+    /// errors always synthesize one via `unit_inference_reason`) and for
+    /// model-level errors whose `Error.details` is set; None elsewhere.
     pub details: Option<String>,
 }
 
@@ -100,6 +102,65 @@ fn format_equation_error(
         kind: FormattedErrorKind::Variable,
         unit_error_kind: None,
         details: None,
+    }
+}
+
+/// Join variable names for a user-facing sentence: `'a'`, `'a' and 'b'`,
+/// `'a', 'b', and 'c'`. Long lists are truncated to the first three names
+/// plus a count, so a macro-instantiated conflict with dozens of sources
+/// stays readable.
+fn join_quoted_names(names: &[&str]) -> String {
+    match names {
+        [] => String::new(),
+        [a] => format!("'{a}'"),
+        [a, b] => format!("'{a}' and '{b}'"),
+        [a, b, c] => format!("'{a}', '{b}', and '{c}'"),
+        [a, b, c, rest @ ..] => {
+            format!("'{a}', '{b}', '{c}', and {} more", rest.len())
+        }
+    }
+}
+
+/// The bare, user-facing reason for a unit inference error.
+///
+/// Inference conflicts are contradictions in the model-wide unit-constraint
+/// system, and the raw reason on `UnitError::InferenceError` shows the
+/// conflicting constraints in `1 == unit-expression` form with `@N`
+/// metavariables -- useful in terminal output, meaningless to a modeler in
+/// the GUI. A single-line reason is already plain language (e.g. the
+/// clarified macro conflict from `units_infer::clarify_macro_conflict`) and
+/// passes through; a multi-line constraint dump (or a missing reason) is
+/// replaced with a sentence naming the involved variables so the modeler
+/// knows where to look. The full constraint text still rides in the
+/// terminal-formatted `message`.
+pub(crate) fn unit_inference_reason(
+    sources: &[(String, Option<Loc>)],
+    details: Option<&str>,
+) -> String {
+    if let Some(details) = details
+        && !details.contains('\n')
+    {
+        return details.to_string();
+    }
+    // Sources are deduped by (var, loc), so the same variable can appear at
+    // several locations; dedupe by name (order-preserving) so the sentence
+    // never reads "'x' and 'x'" and the 1-vs-many phrasing is right.
+    let mut names: Vec<&str> = Vec::new();
+    for (var, _) in sources {
+        if !names.contains(&var.as_str()) {
+            names.push(var.as_str());
+        }
+    }
+    match names.len() {
+        0 => "the units implied by the model's equations are inconsistent".to_string(),
+        1 => format!(
+            "the units in the equation for {} are inconsistent; check its equation and declared units",
+            join_quoted_names(&names)
+        ),
+        _ => format!(
+            "the units of {} are inconsistent with each other; check the equations and declared units of these variables",
+            join_quoted_names(&names)
+        ),
     }
 }
 
@@ -199,7 +260,7 @@ fn format_unit_error(
                 end_offset: end,
                 kind: FormattedErrorKind::Units,
                 unit_error_kind: Some(UnitErrorKind::Inference),
-                details: details.clone(),
+                details: Some(unit_inference_reason(sources, details.as_deref())),
             }
         }
     }
@@ -247,7 +308,11 @@ pub fn format_diagnostic(diag: &db::Diagnostic) -> FormattedError {
                 end_offset: 0,
                 kind,
                 unit_error_kind,
-                details: None,
+                // Model-level `Error.details` is a bare reason by
+                // construction (e.g. the unit-inference umbrella built in
+                // db/units.rs), so it rides in `details` for GUI consumers
+                // just like per-variable unit errors.
+                details: err.details.clone(),
             }
         }
         DiagnosticError::Unit(err) => {
@@ -484,6 +549,97 @@ mod tests {
         let formatted = format_unit_error("test_model", "no_loc_var", None, &error);
         assert_eq!(formatted.start_offset, 0);
         assert_eq!(formatted.end_offset, 0);
+    }
+
+    #[test]
+    fn inference_error_details_are_user_facing() {
+        use crate::builtins::Loc;
+        use crate::common::UnitError;
+
+        // A multi-line constraint dump (what units_infer produces) is
+        // replaced in `details` by a plain-language sentence naming the
+        // involved variables; the terminal `message` keeps the full dump.
+        let dump = "unit checking failed; inconsistent constraints:\n    1 == people*@3\u{207b}\u{b9}\n    1 == @3";
+        let error = UnitError::InferenceError {
+            code: ErrorCode::UnitMismatch,
+            sources: vec![
+                ("birth_rate".to_string(), Some(Loc::new(0, 5))),
+                ("population".to_string(), None),
+            ],
+            details: Some(dump.to_string()),
+        };
+        let formatted = format_unit_error("main", "birth_rate", None, &error);
+        let details = formatted.details.expect("details missing");
+        assert!(
+            details.contains("'birth_rate'") && details.contains("'population'"),
+            "details should name the involved variables: {details}"
+        );
+        assert!(
+            !details.contains('\n') && !details.contains("1 =="),
+            "details must not carry the constraint dump: {details}"
+        );
+        let message = formatted.message.expect("message missing");
+        assert!(
+            message.contains("1 =="),
+            "terminal message keeps the constraint dump: {message}"
+        );
+
+        // A single involved variable reads as a within-equation problem.
+        let error = UnitError::InferenceError {
+            code: ErrorCode::UnitMismatch,
+            sources: vec![("flow".to_string(), None)],
+            details: Some(dump.to_string()),
+        };
+        let formatted = format_unit_error("main", "flow", None, &error);
+        let details = formatted.details.expect("details missing");
+        assert!(
+            details.contains("'flow'") && !details.contains('\n'),
+            "single-source details should name the variable: {details}"
+        );
+
+        // No sources and no details still yields a plain-language reason.
+        let error = UnitError::InferenceError {
+            code: ErrorCode::UnitMismatch,
+            sources: vec![],
+            details: None,
+        };
+        let formatted = format_unit_error("main", "x", None, &error);
+        let details = formatted.details.expect("details missing");
+        assert!(!details.is_empty() && !details.contains('\n'));
+
+        // Sources are deduped by (var, loc), so the same variable can appear
+        // at two locations; the sentence must not read "'x' and 'x'".
+        let error = UnitError::InferenceError {
+            code: ErrorCode::UnitMismatch,
+            sources: vec![
+                ("x".to_string(), Some(Loc::new(0, 3))),
+                ("x".to_string(), Some(Loc::new(5, 8))),
+            ],
+            details: Some(dump.to_string()),
+        };
+        let formatted = format_unit_error("main", "x", None, &error);
+        let details = formatted.details.expect("details missing");
+        assert_eq!(
+            details.matches("'x'").count(),
+            1,
+            "duplicate names must collapse: {details}"
+        );
+        assert!(
+            details.contains("the units in the equation for 'x'"),
+            "single distinct variable should use the one-variable phrasing: {details}"
+        );
+    }
+
+    #[test]
+    fn join_quoted_names_truncates_long_lists() {
+        assert_eq!(join_quoted_names(&[]), "");
+        assert_eq!(join_quoted_names(&["a"]), "'a'");
+        assert_eq!(join_quoted_names(&["a", "b"]), "'a' and 'b'");
+        assert_eq!(join_quoted_names(&["a", "b", "c"]), "'a', 'b', and 'c'");
+        assert_eq!(
+            join_quoted_names(&["a", "b", "c", "d", "e"]),
+            "'a', 'b', 'c', and 2 more"
+        );
     }
 
     #[test]

--- a/src/simlin-engine/src/unit_checking_test.rs
+++ b/src/simlin-engine/src/unit_checking_test.rs
@@ -959,4 +959,39 @@ mod tests {
             "Should have simulation results for mixed_inventory"
         );
     }
+
+    #[test]
+    fn inference_umbrella_detail_is_user_facing() {
+        // The model-level unit-inference warning reaches the GUI's error
+        // panel, so its detail must be a plain-language sentence naming the
+        // involved variables -- not the raw `1 == unit-expression`
+        // constraint dump (which stays available on `InferenceResult`).
+        use crate::db::{DiagnosticError, SimlinDb, collect_all_diagnostics, sync_from_datamodel};
+
+        let datamodel = TestProject::new("inference-umbrella")
+            .unit("apples", None)
+            .unit("oranges", None)
+            .aux_with_units("apple_count", "10", Some("apples"))
+            .aux_with_units("orange_count", "20", Some("oranges"))
+            .aux_with_units("fruit_total", "apple_count + orange_count", None)
+            .build_datamodel();
+        let db = SimlinDb::default();
+        let sync = sync_from_datamodel(&db, &datamodel);
+        let diagnostics = collect_all_diagnostics(&db, sync.project);
+        let umbrella = diagnostics.iter().find_map(|d| match &d.error {
+            DiagnosticError::Model(e) if e.code == crate::ErrorCode::UnitMismatch => {
+                Some(e.details.clone().unwrap_or_default())
+            }
+            _ => None,
+        });
+        let detail = umbrella.expect("expected a model-level unit inference warning");
+        assert!(
+            !detail.contains('\n') && !detail.contains("1 =="),
+            "detail should be plain language, not a constraint dump: {detail}"
+        );
+        assert!(
+            detail.contains('\''),
+            "detail should name the involved variables: {detail}"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #836

## Why

The diagram's `UnitError` collapsed the engine's three-valued unit-error kind (`Definition | Consistency | Inference`) into a boolean `isConsistencyError`, so a unit *inference* error was handled exactly like a *definition* error: its equation-relative offsets were applied to the units string, red-underlining an arbitrary wrong span of the units box.

## What

- **Core**: `UnitError.isConsistencyError` is replaced by `kind: 'definition' | 'consistency' | 'inference'`, mirroring the engine's `SimlinUnitErrorKind`. (`unitErrors` are attached at runtime and never serialized, so no proto/compat concern.)
- **Placement (Option A from the issue)**: inference errors underline *nothing* in either the units or equation field. They describe a contradiction spanning several variables, so any single-field span would be arbitrary -- and their offsets come from `sources.first()`, which may point into a *different variable's* equation. Their text renders in the details panel and errors panel instead. The whole-declaration units underline now fires only when a consistency error is actually present, instead of for any non-definition unit error.
- **User-facing text**: the raw inference reason is a `1 == unit-expression` constraint dump with `@N` metavariables -- meaningful in terminal output, noise for modelers. The engine now synthesizes a plain-language `details` naming the involved variables ("the units of 'births' and 'population' are inconsistent with each other; check the equations and declared units of these variables"); the terminal-formatted `message` keeps the full dump for CLI/MCP consumers. A single-line reason (e.g. the clarified macro conflict from GH #619) passes through untouched. The model-level umbrella diagnostic uses the same helper, and the diagram's model-error list prefers the bare `details` over the terminal-formatted `message`.

## Notes

- The per-variable inference path is currently latent -- the salsa pipeline surfaces inference conflicts only through the model-level umbrella (`variable: None`) -- so this pins the placement rule with tests before it can go live. Per-source attribution (the deferred "Option D") is tracked in #837.
- Browser-verified end-to-end against the rebuilt WASM: consistency squiggle spans the whole units declaration, definition squiggle lands on exact offsets, the friendly umbrella sentence renders in the errors panel, and fixing the units returns the model to error-free.
- Adversarially reviewed by a sub-agent; both findings addressed (order-preserving name dedupe so a two-location single-variable conflict never reads "'x' and 'x'", plus a test pinning the `details ?? message` preference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DyGQwfTBHuwGi7C7m5b3Th