### PR TITLE
vdf: resolve residual record-span overlap (SimService ghost columns)

### DIFF
--- a/docs/design/vdf.md
+++ b/docs/design/vdf.md
@@ -197,7 +197,11 @@ records is a subset of the owner records' value set, and the section-6 lookup
 record carries no back-pointer. A reader that has the model knows the descriptor
 set; a model-free reader recognises it from the lookup-def names (see
 "Name-to-OT mapping"). Once the descriptor records are set aside, the remaining
-owner spans form a clean, non-overlapping OT partition.
+owner spans form a non-overlapping OT partition **on every file whose overlaps
+the descriptor peel fully resolves** -- the whole tracked corpus except the
+two 2007-era SimService `Base.vdf` files, where some records survive the peel
+still in owner-vs-owner conflict. That residual case, and the stale-`f[11]`
+record phenomenon behind it, is described in "Residual OT-overlap" below.
 
 ### Slot table
 
@@ -643,6 +647,49 @@ of `RS HFC[COP, HFC type]`). Recovering the lookup variable's own series from an
 of these needs the model, not the VDF. (A `gf(Time)` lowering for such a bare
 lookup is an engine bug -- a table is not generally a function of time; see
 #597.)
+
+### Residual OT-overlap (stale-`f[11]` unsaved-variable records)
+
+The descriptor peel and the standalone drop resolve every owner/descriptor
+overlap on the whole tracked corpus **except** the two 2007-era SimService
+`Base.vdf` files (GH #841). On those, some decoded spans survive the peel still
+claiming a shared OT slot with another, differently-named span -- an
+owner-vs-owner conflict no structural signal (lexical lookup-def name, forward
+link) can adjudicate. Emitting both would let alphabetical column order
+silently pick the OT owner and scatter one variable's data under another
+variable's name.
+
+**Hypothesis: stale-`f[11]` records for unsaved variables.** The evidence points
+to the SimService writer emitting section-1 records for model variables that
+were **not saved in the run** (data variables, lookup/table definitions,
+supplementary vars), and those records carrying a stale `f[11]` -- plausibly the
+variable's slot in the *full runtime array*, while the file's OT contains only
+the *saved* variables. The stale `f[11]`-as-OT-start spans therefore land on
+arbitrary saved slots. The observed evidence on `Base.vdf`:
+
+- A wide ghost span `AGE SPECIFIC FERTILITY DISTRIBUTION FUNCTION` (an unsaved
+  lookup/table, `f[11] == 18 == n_lookups`, 82 elements) covers OT[18,100),
+  overlapping ~38 real narrow owners saved in that range (`c real gdp`,
+  `Capital Agriculture`, `CO2 in Deep Ocean`, ...). Because its `f[11]` is
+  **not** `< n_lookups`, it is never a peel candidate, so the peel can neither
+  remove it nor detect that it failed.
+- A mirror shape at OT[174,338): the real 164-element arrayed stock
+  `Population`, saved there, sits under 36 narrow ghost claimants (unsaved
+  tables/aux whose stale `f[11]` lands in the same range).
+- No record field separates the two populations: ghosts and real owners both
+  carry `f[14] == 0xf6800000`.
+
+**Stage 1 handling (`record_results::residual_overlap_components`).** After the
+peel and the standalone drop, the reader detects the still-conflicted spans:
+two spans conflict when they share an OT slot **and** carry different names
+(same-name overlap is the ordinary duplicate the per-name emitter dedup already
+resolves). Every span in a genuinely-contested component is **dropped** from
+emission -- honest missing data over a silent first-claim win -- and the
+component is surfaced on the per-file diagnostics
+(`VdfFile::residual_overlap_diagnostics` / the Python reader's
+`NamedResultsDiagnostics.residual_overlap`), analogous to
+`VdfData::unreconciled_ots`. The components are computed as data first, so a
+later stage can re-resolve a component before falling back to this drop.
 
 ### Worked example: a `SMOOTH1` call
 

--- a/docs/design/vdf.md
+++ b/docs/design/vdf.md
@@ -727,12 +727,16 @@ component:
 The whole recovery is **gated per file** on the measured alphabetical
 consistency of the uncontested owners (`RESIDUAL_ORDERING_GATE`, the fraction of
 adjacent OT-sorted owner pairs that are name-ordered): a file must clear
-**0.95** -- an overwhelming majority -- to run the oracle. The four probed
-corpus files measure 98.6-99.6% (and the two SimService files with residual
-components both sit at 0.9964), comfortably above the bar; the sub-0.95 corpus
-files are all tiny run files with no residual components. A file that does not
-exhibit the invariant fails the gate, the oracle abstains, and every residual
-span is honest-dropped -- so a non-alphabetical file is never mis-adjudicated. On the two SimService files the
+**0.95** -- an overwhelming majority -- to run the oracle. The gate also
+requires a minimum number of measured pairs (`RESIDUAL_ORDERING_MIN_PAIRS`, 8):
+below it the ratio carries no real evidence (with fewer than two owners it is
+vacuously 1.0), so the oracle abstains rather than adjudicate on nothing. The
+four probed corpus files measure 98.6-99.6% over ~840 pairs (and the two
+SimService files with residual components both sit at 0.9964), comfortably above
+both bars; the sub-0.95 corpus files are all tiny run files with no residual
+components. A file that does not exhibit the invariant -- or offers too few
+pairs to tell -- fails the gate, the oracle abstains, and every residual span is
+honest-dropped, so it is never mis-adjudicated. On the two SimService files the
 recovery is complete: every real owner is recovered (`Population`'s 164 elements,
 the oil reserve series, the four `indicated`/`industrial` owners) and nothing is
 left honest-dropped, so the diagnostics come back empty.

--- a/docs/design/vdf.md
+++ b/docs/design/vdf.md
@@ -679,17 +679,63 @@ arbitrary saved slots. The observed evidence on `Base.vdf`:
 - No record field separates the two populations: ghosts and real owners both
   carry `f[14] == 0xf6800000`.
 
-**Stage 1 handling (`record_results::residual_overlap_components`).** After the
-peel and the standalone drop, the reader detects the still-conflicted spans:
+**Detection (`record_results::residual_overlap_components`).** After the peel
+and the standalone drop, the reader detects the still-conflicted spans as data:
 two spans conflict when they share an OT slot **and** carry different names
 (same-name overlap is the ordinary duplicate the per-name emitter dedup already
-resolves). Every span in a genuinely-contested component is **dropped** from
-emission -- honest missing data over a silent first-claim win -- and the
-component is surfaced on the per-file diagnostics
-(`VdfFile::residual_overlap_diagnostics` / the Python reader's
-`NamedResultsDiagnostics.residual_overlap`), analogous to
-`VdfData::unreconciled_ots`. The components are computed as data first, so a
-later stage can re-resolve a component before falling back to this drop.
+resolves), and a union-find groups the transitively-conflicting spans into
+connected components.
+
+**Recovery (`record_results::resolve_residual_components`).** Each component is
+re-resolved from scratch, recovering the real owners and dropping only the
+ghosts. This leans on one empirical invariant: **Vensim allocates OT slots in
+case-insensitive alphabetical order within a run** (a "run" being a contiguous
+alphabetical block; run boundaries are where the sequence restarts). Per
+component:
+
+1. **Un-peel.** Discard the component's phase-1 overlap peels -- any peeled
+   descriptor that spatially overlaps a component span is given a second chance
+   (this recovers `c Identified Oil Reserve`, wrongly f10-peeled when it
+   collided with the wide ghost).
+2. **Lexical peel.** Drop spans whose names are lookupish (` lookup`, ` table`,
+   `graphical function`, ...) *without* the `f[11] < n_lookups` gate: a lookup
+   definition is a table, not a series, so its stale `f[11]` cannot
+   forward-link. This alone resolves the scalar pairs whose ghost is a table
+   (`c total population table`, `Coal Fraction Discoverable Table`, ...).
+3. **Ordering oracle (`residual_span_is_owner`).** A span is a real owner iff it
+   sits where the alphabetical allocation would put it, judged against an
+   anchor bracket. The nearest **uncontested** owners on each side are the
+   default anchors; an **inverted** bracket (prev sorts after next) signals a
+   run boundary between them, so only the more reliable prev side is tested
+   (this is how the wide ghost `AGE SPECIFIC ...`, which sorts before the `c *`
+   owners it covers, is dropped while every narrow owner passes). When a span is
+   bracketed on **both** sides by owners already **recovered** from adjacent
+   components, those win: recovered reals share the span's interleaved run, so
+   they are the reliable same-run evidence (this is what adjudicates
+   `indicated per capita fish demand` vs `China future GDP growth rate` at
+   OT 127 -- the recovered `Indicated China GDP`@123 / `indicated row Coal
+   demand`@128 bracket, not the nearest uncontested owner `cafe history`@124,
+   which belongs to a different run). The oracle iterates a fixpoint: a span
+   confirmed as an owner becomes an anchor for its neighbours.
+4. **Honest-drop fallback.** Any conflict the oracle cannot adjudicate (no
+   ordering-consistent owner) is dropped -- honest missing data over a silent
+   first-claim win -- and surfaced on the per-file diagnostics
+   (`VdfFile::residual_overlap_diagnostics` / the Python reader's
+   `NamedResultsDiagnostics.residual_overlap`), analogous to
+   `VdfData::unreconciled_ots`.
+
+The whole recovery is **gated per file** on the measured alphabetical
+consistency of the uncontested owners (`RESIDUAL_ORDERING_GATE`, the fraction of
+adjacent OT-sorted owner pairs that are name-ordered): a file must clear
+**0.95** -- an overwhelming majority -- to run the oracle. The four probed
+corpus files measure 98.6-99.6% (and the two SimService files with residual
+components both sit at 0.9964), comfortably above the bar; the sub-0.95 corpus
+files are all tiny run files with no residual components. A file that does not
+exhibit the invariant fails the gate, the oracle abstains, and every residual
+span is honest-dropped -- so a non-alphabetical file is never mis-adjudicated. On the two SimService files the
+recovery is complete: every real owner is recovered (`Population`'s 164 elements,
+the oil reserve series, the four `indicated`/`industrial` owners) and nothing is
+left honest-dropped, so the diagnostics come back empty.
 
 ### Worked example: a `SMOOTH1` call
 

--- a/src/simlin-engine/src/vdf.rs
+++ b/src/simlin-engine/src/vdf.rs
@@ -36,6 +36,20 @@ mod signatures;
 use record_results::build_record_result_columns;
 pub use section3::{VdfSection3Directory, VdfSection3DirectoryEntry};
 
+/// One residual OT-overlap component surfaced by
+/// [`VdfFile::residual_overlap_diagnostics`]: differently-named decoded spans
+/// that still claim a shared OT slot after descriptor peeling and the
+/// standalone lookup-only drop, all of which the reader drops from emission.
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct VdfResidualOverlap {
+    /// OT slots claimed by two or more differently-named spans of the
+    /// component (the genuine conflicts). Sorted ascending.
+    pub contested_ots: Vec<usize>,
+    /// Names of the decoded spans dropped from emission for this component.
+    /// Sorted by the spans' record index.
+    pub dropped_names: Vec<String>,
+}
+
 /// Names of stdlib module internal variables that DO consume OT entries.
 /// LV1/LV2/LV3/ST are stock-backed; DEL/DL/RT1/RT2 are non-stock. Used by
 /// the section-5 dimension recovery to exclude these helper names from the
@@ -1787,6 +1801,36 @@ impl VdfFile {
             }
         }
         out
+    }
+
+    /// Per-file residual OT-overlap diagnostics: decoded record spans that
+    /// still claim a shared OT slot after graphical-function descriptor
+    /// peeling and the standalone lookup-only drop, and which the reader
+    /// therefore DROPS from emission rather than letting alphabetical column
+    /// order silently pick an owner (see docs/design/vdf.md "Residual
+    /// OT-overlap"). Empty on every tracked corpus file except the two
+    /// SimService `Base.vdf` files, whose 2007-era writer emits stale-`f[11]`
+    /// records for unsaved variables. Mirrors the Python reader's
+    /// `NamedResultsDiagnostics.residual_overlap_*` surface.
+    pub fn residual_overlap_diagnostics(&self) -> Vec<VdfResidualOverlap> {
+        use record_results::{decoded_record_spans, identify_descriptor_records};
+        let name_key_to_name_index = self.record_name_key_to_name_index();
+        let section3_directory = self.parse_section3_directory();
+        let spans =
+            decoded_record_spans(self, &name_key_to_name_index, section3_directory.as_ref());
+        let desc_id = identify_descriptor_records(self, &spans);
+        desc_id
+            .residual_overlap_components
+            .iter()
+            .map(|component| VdfResidualOverlap {
+                contested_ots: component.contested_ots.clone(),
+                dropped_names: component
+                    .span_indices
+                    .iter()
+                    .filter_map(|&i| spans.get(i).map(|s| s.name.clone()))
+                    .collect(),
+            })
+            .collect()
     }
 
     /// Extract one data block's series aligned to the saved time axis.
@@ -4841,6 +4885,87 @@ mod tests {
                 id.standalone_drop_vetoed_candidates, 4,
                 "{path}: the four coincidental stocks are the withheld candidates"
             );
+        }
+    }
+
+    #[test]
+    fn test_residual_overlap_honest_drop_on_simservice_fixtures() {
+        // Stage 1 correctness floor for GH #841. Ref.vdf (and every file whose
+        // overlaps the peel already resolves) must have NO residual components,
+        // so the floor is a provable no-op there. SimService/Base.vdf's
+        // stale-f[11] unsaved-variable records survive the peel still in
+        // owner-vs-owner conflict; every such span must be DROPPED (no ghost
+        // `AGE SPECIFIC ...` columns) so no OT slot is ever claimed by two
+        // differently-named emitted owners. SimService half follows the
+        // third_party fixture-availability convention.
+        use super::record_results::{decoded_record_spans, identify_descriptor_records};
+
+        let ref_vdf = vdf_file("../../test/xmutil_test_models/Ref.vdf");
+        assert!(
+            ref_vdf.residual_overlap_diagnostics().is_empty(),
+            "Ref.vdf overlaps are fully resolved by the peel; the residual floor must be a no-op"
+        );
+
+        let fixtures = [
+            "../../third_party/uib_sd/spring_2008/SimService_BUENO/SimService/Model Files/Base.vdf",
+            "../../third_party/uib_sd/spring_2008/SimService_BUENO/SimService/Model Files/ctxt0001/Base.vdf",
+        ];
+        if !std::path::Path::new(fixtures[0]).exists() {
+            return;
+        }
+        for path in fixtures {
+            let sim = vdf_file(path);
+
+            // The residual diagnostics fire and name the #841 headline ghost.
+            let diagnostics = sim.residual_overlap_diagnostics();
+            assert!(
+                !diagnostics.is_empty(),
+                "{path}: residual overlap must be detected and reported"
+            );
+            let dropped_names: HashSet<&str> = diagnostics
+                .iter()
+                .flat_map(|c| c.dropped_names.iter().map(|s| s.as_str()))
+                .collect();
+            assert!(
+                dropped_names.contains("AGE SPECIFIC FERTILITY DISTRIBUTION FUNCTION"),
+                "{path}: the wide ghost span must be among the honest-dropped residual spans"
+            );
+            for component in &diagnostics {
+                assert!(
+                    !component.contested_ots.is_empty(),
+                    "{path}: every reported residual component must carry contested OTs"
+                );
+            }
+
+            // No emitted owner span may still overlap another differently-named
+            // emitted owner span, and no ghost column may be emitted.
+            let key_map = sim.record_name_key_to_name_index();
+            let dir = sim.parse_section3_directory();
+            let spans = decoded_record_spans(&sim, &key_map, dir.as_ref());
+            let id = identify_descriptor_records(&sim, &spans);
+            let mut slot_owner: HashMap<usize, &str> = HashMap::new();
+            for span in spans
+                .iter()
+                .filter(|s| !id.descriptor_indices.contains(&s.rec_idx))
+            {
+                assert!(
+                    !span
+                        .name
+                        .eq_ignore_ascii_case("AGE SPECIFIC FERTILITY DISTRIBUTION FUNCTION"),
+                    "{path}: the ghost span must not survive as an emitted owner"
+                );
+                for ot in span.start..span.end {
+                    if let Some(prev) = slot_owner.insert(ot, span.name.as_str())
+                        && prev != span.name.as_str()
+                    {
+                        panic!(
+                            "{path}: OT slot {ot} claimed by two emitted owners \
+                             ({prev:?} and {:?})",
+                            span.name
+                        );
+                    }
+                }
+            }
         }
     }
 

--- a/src/simlin-engine/src/vdf.rs
+++ b/src/simlin-engine/src/vdf.rs
@@ -4889,13 +4889,15 @@ mod tests {
     }
 
     #[test]
-    fn test_residual_overlap_honest_drop_on_simservice_fixtures() {
-        // Stage 1 correctness floor for GH #841. Ref.vdf (and every file whose
-        // overlaps the peel already resolves) must have NO residual components,
-        // so the floor is a provable no-op there. SimService/Base.vdf's
+    fn test_residual_overlap_recovery_on_simservice_fixtures() {
+        // Stage 2 recovery for GH #841. Ref.vdf (and every file whose overlaps
+        // the peel already resolves) has NO residual components, so the whole
+        // re-resolution is a provable no-op there. SimService/Base.vdf's
         // stale-f[11] unsaved-variable records survive the peel still in
-        // owner-vs-owner conflict; every such span must be DROPPED (no ghost
-        // `AGE SPECIFIC ...` columns) so no OT slot is ever claimed by two
+        // owner-vs-owner conflict; the re-resolution recovers every real owner
+        // (dropping only the ghosts) and, because every conflict is
+        // adjudicated, leaves NOTHING honest-dropped -- so the residual
+        // diagnostics come back empty. No OT slot may ever be claimed by two
         // differently-named emitted owners. SimService half follows the
         // third_party fixture-availability convention.
         use super::record_results::{decoded_record_spans, identify_descriptor_records};
@@ -4903,7 +4905,7 @@ mod tests {
         let ref_vdf = vdf_file("../../test/xmutil_test_models/Ref.vdf");
         assert!(
             ref_vdf.residual_overlap_diagnostics().is_empty(),
-            "Ref.vdf overlaps are fully resolved by the peel; the residual floor must be a no-op"
+            "Ref.vdf overlaps are fully resolved by the peel; re-resolution must be a no-op"
         );
 
         let fixtures = [
@@ -4913,47 +4915,99 @@ mod tests {
         if !std::path::Path::new(fixtures[0]).exists() {
             return;
         }
+        // The EXACT set of 41 ghost records the re-resolution must drop on both
+        // fixtures (the wide cluster-A ghost, the four scalar-pair ghosts, and
+        // the 36 cluster-B ghosts). Pinning the full set -- not a sample --
+        // plus the exact emitted-column count below means a wrongly-recovered
+        // unlisted ghost on an otherwise-unclaimed OT cannot slip past the
+        // no-double-claim check.
+        let ghosts = [
+            "AGE SPECIFIC FERTILITY DISTRIBUTION FUNCTION",
+            "China future GDP growth rate",
+            "Coal Capacity Utilisation in Production table",
+            "Coal Fraction Discoverable Table",
+            "DICE IPCC Other Rad Forcing Table",
+            "Effect of technology on productivity of investment in Coal production table",
+            "MAIZE FRACTION TABLE",
+            "Nuclear GENERATION EFFICIENCY table",
+            "Oil substitutability EFFECT ON Oil import",
+            "PC MEAT DEMAND FUNCTION",
+            "PC fish demand data",
+            "PC fish demand function",
+            "QDBTU to MB",
+            "ROW Coal demand function",
+            "Renewable Energy consumer real price",
+            "Renewable Resource price per MBTU",
+            "WOOD VALUE ADDED PER TON",
+            "c total population table",
+            "elasticity of fdi to fiscal pressure",
+            "electricity net export table",
+            "extra heavy table",
+            "forestry production in cubic meters",
+            "gas generation efficiency table",
+            "gas to liquids table",
+            "hydro electricity generation in BKWH table",
+            "meat value added per ton table",
+            "nuclear electricity demand in BKWH",
+            "overall carbon tax table",
+            "pc bushel domestic consumption non ethanol",
+            "petroleum generation efficiency table",
+            "private capital transfers over gdp table",
+            "private factor income table",
+            "private transfers table",
+            "relative china technology",
+            "renewable electricity price",
+            "renewable portfolio standard table",
+            "residential energy conservation",
+            "share of electricity for freight transportation",
+            "share of electricity for urban and commuter transportation",
+            "total fertility rate",
+            "value added agriculture products table",
+        ];
+        assert_eq!(ghosts.len(), 41);
+        let reals = [
+            "Indicated China GDP",
+            "indicated per capita fish demand",
+            "indicated row Coal demand",
+            "industrial electricity demand in BKWH",
+        ];
         for path in fixtures {
             let sim = vdf_file(path);
 
-            // The residual diagnostics fire and name the #841 headline ghost.
-            let diagnostics = sim.residual_overlap_diagnostics();
+            // Every conflict is adjudicated, so nothing is honest-dropped.
             assert!(
-                !diagnostics.is_empty(),
-                "{path}: residual overlap must be detected and reported"
+                sim.residual_overlap_diagnostics().is_empty(),
+                "{path}: the ordering oracle resolves every conflict; no residual remainder"
             );
-            let dropped_names: HashSet<&str> = diagnostics
-                .iter()
-                .flat_map(|c| c.dropped_names.iter().map(|s| s.as_str()))
-                .collect();
-            assert!(
-                dropped_names.contains("AGE SPECIFIC FERTILITY DISTRIBUTION FUNCTION"),
-                "{path}: the wide ghost span must be among the honest-dropped residual spans"
-            );
-            for component in &diagnostics {
-                assert!(
-                    !component.contested_ots.is_empty(),
-                    "{path}: every reported residual component must carry contested OTs"
-                );
-            }
 
-            // No emitted owner span may still overlap another differently-named
-            // emitted owner span, and no ghost column may be emitted.
             let key_map = sim.record_name_key_to_name_index();
             let dir = sim.parse_section3_directory();
             let spans = decoded_record_spans(&sim, &key_map, dir.as_ref());
             let id = identify_descriptor_records(&sim, &spans);
+            let emitted: HashSet<&str> = spans
+                .iter()
+                .filter(|s| !id.descriptor_indices.contains(&s.rec_idx))
+                .map(|s| s.name.as_str())
+                .collect();
+            for ghost in ghosts {
+                assert!(
+                    !emitted.iter().any(|n| n.eq_ignore_ascii_case(ghost)),
+                    "{path}: ghost {ghost:?} must not survive as an emitted owner"
+                );
+            }
+            for real in reals {
+                assert!(
+                    emitted.iter().any(|n| n.eq_ignore_ascii_case(real)),
+                    "{path}: real owner {real:?} must be recovered as an emitted owner"
+                );
+            }
+
+            // No OT slot may be claimed by two differently-named emitted owners.
             let mut slot_owner: HashMap<usize, &str> = HashMap::new();
             for span in spans
                 .iter()
                 .filter(|s| !id.descriptor_indices.contains(&s.rec_idx))
             {
-                assert!(
-                    !span
-                        .name
-                        .eq_ignore_ascii_case("AGE SPECIFIC FERTILITY DISTRIBUTION FUNCTION"),
-                    "{path}: the ghost span must not survive as an emitted owner"
-                );
                 for ot in span.start..span.end {
                     if let Some(prev) = slot_owner.insert(ot, span.name.as_str())
                         && prev != span.name.as_str()
@@ -4966,6 +5020,60 @@ mod tests {
                     }
                 }
             }
+
+            // The recovered owners carry the correct series: `Population` is a
+            // 164-element array, and the wrongly-f10-peeled `c Identified Oil
+            // Reserve` is re-admitted with its two known element series.
+            let results = sim
+                .to_results_via_records()
+                .unwrap_or_else(|e| panic!("{path}: to_results_via_records: {e}"));
+            // Exact emitted-column count (Time + every recovered owner element).
+            // Both fixtures decode to the same 1235 columns; a wrongly-recovered
+            // ghost would push this to 1236, a wrongly-dropped real below 1235.
+            assert_eq!(
+                results.offsets.len(),
+                1235,
+                "{path}: exact emitted-column count changed (residual recovery regressed)"
+            );
+            let population_elems = results
+                .offsets
+                .keys()
+                .filter(|k| k.to_string().starts_with("population["))
+                .count();
+            assert_eq!(
+                population_elems, 164,
+                "{path}: recovered Population must expose all 164 array elements"
+            );
+            let mut oil_endpoints: Vec<(f64, f64)> = results
+                .offsets
+                .iter()
+                .filter(|(k, _)| k.to_string().starts_with("c_identified_oil_reserve["))
+                .map(|(_, &col)| {
+                    let first = results.data[col];
+                    let last = results.data[(results.step_count - 1) * results.step_size + col];
+                    (first, last)
+                })
+                .collect();
+            oil_endpoints.sort_by(|a, b| b.0.total_cmp(&a.0));
+            assert_eq!(
+                oil_endpoints.len(),
+                2,
+                "{path}: recovered oil reserve must expose both element series"
+            );
+            // The initial reserves are stock initial conditions (identical
+            // across simulation contexts: Base.vdf and the ctxt0001 scenario);
+            // the finals differ by scenario but must show depletion. Pinning
+            // the initials proves the correct series was re-admitted at the
+            // right OT slots (a wrong slot would carry unrelated magnitudes).
+            let approx = |a: f64, b: f64| (a - b).abs() < 0.01;
+            assert!(
+                approx(oil_endpoints[0].0, 51000.0) && approx(oil_endpoints[1].0, 7900.0),
+                "{path}: recovered oil reserve initial values wrong: {oil_endpoints:?}"
+            );
+            assert!(
+                oil_endpoints[0].1 < oil_endpoints[0].0 && oil_endpoints[1].1 < oil_endpoints[1].0,
+                "{path}: recovered oil reserve must deplete from its initial value: {oil_endpoints:?}"
+            );
         }
     }
 

--- a/src/simlin-engine/src/vdf.rs
+++ b/src/simlin-engine/src/vdf.rs
@@ -5126,19 +5126,30 @@ mod tests {
             end: start + 1,
             sort_key: 0,
         };
+        // Nine alphabetically-ordered uncontested owners (>= RESIDUAL_ORDERING
+        // _MIN_PAIRS adjacent pairs, ratio 1.0) so the gate passes on real
+        // evidence, bracketing the slot-5 conflict: prev `e own`@4 and next
+        // `n own`@6 keep `m real` and drop `z ghost` (which sorts past `n own`).
         let spans = [
-            span(0, "a owner", 1),
-            span(1, "z owner", 9),
-            span(2, "m real", 5),    // fits [a owner, z owner] -> recovered
-            span(3, "zzz ghost", 5), // sorts past z owner -> dropped
+            span(0, "b own", 1),
+            span(1, "c own", 2),
+            span(2, "d own", 3),
+            span(3, "e own", 4),
+            span(4, "m real", 5),  // fits [e own, n own] -> recovered
+            span(5, "z ghost", 5), // sorts past n own -> dropped
+            span(6, "n own", 6),
+            span(7, "o own", 7),
+            span(8, "p own", 8),
+            span(9, "q own", 9),
+            span(10, "r own", 10),
         ];
         let id = identify_descriptor_records(&vdf, &spans);
         assert!(
-            id.descriptor_indices.contains(&3),
+            id.descriptor_indices.contains(&5),
             "the ghost must be dropped by the residual pass even with no lookups"
         );
         assert!(
-            !id.descriptor_indices.contains(&2),
+            !id.descriptor_indices.contains(&4),
             "the real owner must be recovered, not dropped"
         );
     }

--- a/src/simlin-engine/src/vdf.rs
+++ b/src/simlin-engine/src/vdf.rs
@@ -1805,13 +1805,16 @@ impl VdfFile {
 
     /// Per-file residual OT-overlap diagnostics: decoded record spans that
     /// still claim a shared OT slot after graphical-function descriptor
-    /// peeling and the standalone lookup-only drop, and which the reader
-    /// therefore DROPS from emission rather than letting alphabetical column
-    /// order silently pick an owner (see docs/design/vdf.md "Residual
-    /// OT-overlap"). Empty on every tracked corpus file except the two
-    /// SimService `Base.vdf` files, whose 2007-era writer emits stale-`f[11]`
-    /// records for unsaved variables. Mirrors the Python reader's
-    /// `NamedResultsDiagnostics.residual_overlap_*` surface.
+    /// peeling, the standalone lookup-only drop, AND the residual-overlap
+    /// re-resolution -- i.e. the conflicts the ordering oracle could not
+    /// adjudicate and therefore honest-dropped rather than letting alphabetical
+    /// column order silently pick an owner (see docs/design/vdf.md "Residual
+    /// OT-overlap"). Empty across the whole tracked corpus, including the two
+    /// SimService `Base.vdf` files whose stale-`f[11]` conflicts the oracle now
+    /// fully recovers; it is non-empty only when the per-file gate fails (a
+    /// non-alphabetical file) or the oracle leaves a conflict unadjudicated.
+    /// Mirrors the Python reader's `NamedResultsDiagnostics.residual_overlap`
+    /// surface.
     pub fn residual_overlap_diagnostics(&self) -> Vec<VdfResidualOverlap> {
         use record_results::{decoded_record_spans, identify_descriptor_records};
         let name_key_to_name_index = self.record_name_key_to_name_index();
@@ -5075,6 +5078,69 @@ mod tests {
                 "{path}: recovered oil reserve must deplete from its initial value: {oil_endpoints:?}"
             );
         }
+    }
+
+    #[test]
+    fn residual_pass_runs_on_lookup_free_file() {
+        // GH #844: a lookup-free VDF (`n_lookups == 0`) still reaches the
+        // residual-overlap re-resolution. Before the fix, `identify_descriptor
+        // _records` early-returned on `n_lookups == 0`, so a differently-named
+        // owner-vs-owner OT conflict on such a file was silently resolved by
+        // alphabetical emission order (Rust) / emitted twice (Python). Here the
+        // uncontested anchors `a owner`@1 / `z owner`@9 bracket slot 5, so the
+        // ordering oracle keeps the real owner `m real` and drops the ghost
+        // `zzz ghost` (which sorts past the next anchor) -- with zero lookups.
+        use super::record_results::{DecodedRecordSpan, identify_descriptor_records};
+
+        // Minimal lookup-free file: `offset_table_count == 0` makes
+        // `section6_lookup_records()` return None, i.e. n_lookups == 0.
+        let vdf = VdfFile {
+            data: Vec::new(),
+            time_point_count: 0,
+            bitmap_size: 0,
+            block_time_point_count: 0,
+            block_bitmap_size: 0,
+            data_time_point_count: 0,
+            data_bitmap_size: 0,
+            sections: Vec::new(),
+            names: Vec::new(),
+            name_section_idx: None,
+            slot_table: Vec::new(),
+            slot_table_offset: 0,
+            records: Vec::new(),
+            offset_table_start: 0,
+            offset_table_count: 0,
+            first_data_block: 0,
+            header_final_values_offset: 0,
+            header_lookup_mapping_offset: 0,
+        };
+        assert!(
+            vdf.section6_lookup_records().is_none(),
+            "fixture must have zero lookup records"
+        );
+
+        let span = |rec_idx: usize, name: &str, start: usize| DecodedRecordSpan {
+            rec_idx,
+            name: name.to_string(),
+            start,
+            end: start + 1,
+            sort_key: 0,
+        };
+        let spans = [
+            span(0, "a owner", 1),
+            span(1, "z owner", 9),
+            span(2, "m real", 5),    // fits [a owner, z owner] -> recovered
+            span(3, "zzz ghost", 5), // sorts past z owner -> dropped
+        ];
+        let id = identify_descriptor_records(&vdf, &spans);
+        assert!(
+            id.descriptor_indices.contains(&3),
+            "the ghost must be dropped by the residual pass even with no lookups"
+        );
+        assert!(
+            !id.descriptor_indices.contains(&2),
+            "the real owner must be recovered, not dropped"
+        );
     }
 
     #[test]

--- a/src/simlin-engine/src/vdf/record_results.rs
+++ b/src/simlin-engine/src/vdf/record_results.rs
@@ -632,11 +632,23 @@ fn spans_overlap(a: &DecodedRecordSpan, b: &DecodedRecordSpan) -> bool {
     !(a.end <= b.start || b.end <= a.start)
 }
 
-/// Whether span `idx` still overlaps another span in `active`.
+/// Whether two spans are in genuine residual CONFLICT: overlapping extents AND
+/// different names. Same-name overlaps are NOT conflicts -- they are ordinary
+/// duplicate records for one variable that the per-name emission dedup owns
+/// (keep-lowest-start), exactly the rule `residual_overlap_components` uses to
+/// build the components. Using name-blind overlap here would honest-drop a
+/// same-name duplicate pair that a differently-named ghost dragged into a
+/// component, losing the variable entirely (GH #844).
+fn spans_conflict(a: &DecodedRecordSpan, b: &DecodedRecordSpan) -> bool {
+    spans_overlap(a, b) && a.name != b.name
+}
+
+/// Whether span `idx` still conflicts with another span in `active` (different
+/// name, overlapping extent).
 fn overlaps_any(idx: usize, active: &[usize], spans: &[DecodedRecordSpan]) -> bool {
     active
         .iter()
-        .any(|&other| other != idx && spans_overlap(&spans[idx], &spans[other]))
+        .any(|&other| other != idx && spans_conflict(&spans[idx], &spans[other]))
 }
 
 /// Fraction of adjacent OT-sorted uncontested-owner pairs that are name-ordered
@@ -778,8 +790,10 @@ fn resolve_residual_components(
     }
 
     // Per-component active sets: component spans + un-peeled phase-1 descriptors
-    // overlapping any component span (a phase-1 descriptor is given a second
-    // chance exactly when it collides with a component's spans).
+    // conflicting with any original component span (a phase-1 descriptor is
+    // given a second chance exactly when it cross-name-collides with a
+    // component's spans; a same-name overlap is not a conflict, so it stays
+    // dropped -- its owner twin already represents it).
     let mut comp_active: Vec<Vec<usize>> = Vec::with_capacity(components.len());
     let mut unpeeled_recidx: HashSet<usize> = HashSet::new();
     for c in components {
@@ -789,7 +803,7 @@ fn resolve_residual_components(
             if phase1_descriptors.contains(&span.rec_idx)
                 && component_spans
                     .iter()
-                    .any(|&cs| spans_overlap(span, &spans[cs]))
+                    .any(|&cs| spans_conflict(span, &spans[cs]))
             {
                 active.push(i);
                 unpeeled_recidx.insert(span.rec_idx);
@@ -884,7 +898,7 @@ fn resolve_residual_components(
         let mut contested: Vec<usize> = Vec::new();
         for (ai, &a) in leftover.iter().enumerate() {
             for &b in &leftover[ai + 1..] {
-                if spans_overlap(&spans[a], &spans[b]) {
+                if spans_conflict(&spans[a], &spans[b]) {
                     let lo = spans[a].start.max(spans[b].start);
                     let hi = spans[a].end.min(spans[b].end);
                     contested.extend(lo..hi);
@@ -1969,6 +1983,35 @@ mod resolve_residual_tests {
         assert!(
             !res.dropped.contains(&8) && !res.readmitted.contains(&8),
             "d tar overlaps only an un-peeled descriptor, so it must stay untouched"
+        );
+        assert!(res.unresolved_components.is_empty());
+    }
+
+    /// Same-name duplicate pair inside a component. A differently-named ghost
+    /// drags TWO same-name duplicate records for one variable into a component.
+    /// The conflict predicate is name-aware (matching the detector), so once the
+    /// ghost is dropped the same-name pair no longer registers as conflicting:
+    /// BOTH survive re-resolution and flow to the per-name emission dedup, just
+    /// as they would outside a residual component -- the variable is NOT lost
+    /// (GH #844). A name-blind predicate would honest-drop both.
+    #[test]
+    fn same_name_duplicate_pair_survives_when_ghost_dropped() {
+        let spans = [
+            span(0, "a", 1, 1),         // uncontested prev anchor
+            span(1, "z", 9, 1),         // uncontested next anchor
+            span(2, "m dup", 5, 1),     // duplicate record A for variable `m dup`
+            span(3, "m dup", 5, 1),     // duplicate record B (same name, same slot)
+            span(4, "zzz ghost", 5, 1), // ghost, sorts past the next anchor -> dropped
+        ];
+        let components = residual_overlap_components(&spans, &HashSet::new());
+        // The same-name pair is pulled into the ghost's component.
+        assert_eq!(components.len(), 1);
+        assert_eq!(components[0].span_indices, vec![2, 3, 4]);
+        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0);
+        assert_eq!(dropped_names(&res, &spans), vec!["zzz ghost"]);
+        assert!(
+            !res.dropped.contains(&2) && !res.dropped.contains(&3),
+            "both same-name duplicates must survive re-resolution (dedup owns them)"
         );
         assert!(res.unresolved_components.is_empty());
     }

--- a/src/simlin-engine/src/vdf/record_results.rs
+++ b/src/simlin-engine/src/vdf/record_results.rs
@@ -201,6 +201,13 @@ pub(super) fn decoded_record_spans(
 /// would let a future file quietly resurrect ghost columns. The flags are
 /// exposed for tests and future diagnostics; they have no effect on the
 /// descriptor membership decision itself.
+///
+/// `residual_overlap_components` records the still-conflicted spans dropped by
+/// the residual-overlap floor (see [`residual_overlap_components`]): every span
+/// in each component is added to `descriptor_indices` and therefore NOT
+/// emitted, so no OT slot is ever resolved by alphabetical emission order.
+/// The components are retained as data (not just the drop set) so a later
+/// re-resolution stage can narrow the drop before it falls back to this floor.
 #[derive(Clone, Debug, Default)]
 pub(super) struct DescriptorIdentification {
     pub(super) descriptor_indices: HashSet<usize>,
@@ -210,6 +217,23 @@ pub(super) struct DescriptorIdentification {
     pub(super) standalone_drop_veto_fired: bool,
     #[allow(dead_code)]
     pub(super) standalone_drop_vetoed_candidates: usize,
+    pub(super) residual_overlap_components: Vec<ResidualOverlapComponent>,
+}
+
+/// A residual OT-overlap component: two or more DIFFERENTLY-named decoded
+/// spans that still claim a shared OT slot after descriptor peeling and the
+/// standalone lookup-only drop. Stage 1 drops every span in the component
+/// from emission (honest missing data over a silent alphabetical first-claim
+/// win); the component is retained here so a later stage can re-resolve it
+/// before falling back to the drop.
+#[derive(Clone, Debug, Default)]
+pub(super) struct ResidualOverlapComponent {
+    /// Indices into the `spans` slice for every span in the component (all
+    /// dropped in Stage 1).
+    pub(super) span_indices: Vec<usize>,
+    /// OT slots claimed by two or more differently-named spans of the
+    /// component (the genuine conflicts). Sorted ascending.
+    pub(super) contested_ots: Vec<usize>,
 }
 
 /// Outcome of the standalone lookup-only descriptor detection: the records
@@ -420,12 +444,135 @@ pub(super) fn identify_descriptor_records(
     );
     descriptor_indices.extend(standalone.dropped);
 
+    // Residual-overlap floor. After peeling overlap-path descriptors and
+    // dropping standalone lookup-only tables, some differently-named spans can
+    // STILL claim a shared OT slot -- an owner-vs-owner conflict no structural
+    // signal resolved. Compute those components as data, then (Stage 1) drop
+    // every span in them so the emission path never lets alphabetical order
+    // silently pick an OT owner. A later stage re-resolves a component before
+    // this drop; the components are threaded out on `DescriptorIdentification`.
+    let residual_overlap_components = residual_overlap_components(spans, &descriptor_indices);
+    for component in &residual_overlap_components {
+        for &span_idx in &component.span_indices {
+            descriptor_indices.insert(spans[span_idx].rec_idx);
+        }
+    }
+
     DescriptorIdentification {
         descriptor_indices,
         used_f10_fallback,
         standalone_drop_veto_fired: standalone.veto_fired,
         standalone_drop_vetoed_candidates: standalone.vetoed_candidates,
+        residual_overlap_components,
     }
+}
+
+/// Detect residual OT-overlap among the decoded spans that survive descriptor
+/// peeling and the standalone lookup-only drop (functional core: takes the
+/// spans plus the already-dropped `rec_idx` set, so it is unit-testable on
+/// synthetic inputs with no fixture).
+///
+/// `identify_descriptor_records` resolves the owner/descriptor `f[11]` union
+/// for the overlaps a structural signal can adjudicate (the lexical
+/// lookup-def name test, the section-6 forward link). On the 2007-era
+/// SimService writer that is not enough: it emits section-1 records for model
+/// variables that were NOT saved in the run (data variables, lookup/table
+/// definitions, supplementary vars), and those records carry a stale `f[11]`
+/// (plausibly the variable's slot in the full runtime array, while the file's
+/// OT contains only saved variables). The stale `f[11]`-as-OT-start spans land
+/// on arbitrary saved slots; most fail the `f11 < n_lookups` candidacy gate, so
+/// the overlap peel can neither remove them nor detect that it failed, and the
+/// component exits still conflicted (see docs/design/vdf.md "Residual
+/// OT-overlap" and the stale-`f[11]` hypothesis).
+///
+/// Emitting both spans would let alphabetical emission order silently pick the
+/// OT owner and scatter one variable's data under another variable's name. This
+/// returns the residual components; the caller drops every span in them.
+///
+/// Conflict is DIFFERENT-name only: two spans of the same name that overlap are
+/// the ordinary same-variable duplicate the emitter's per-name dedup already
+/// resolves (lowest start wins), not a cross-variable ownership conflict. Every
+/// span sharing a genuinely-contested slot (one carrying two distinct names) is
+/// pulled into the component and dropped, since the whole slot is ambiguous.
+fn residual_overlap_components(
+    spans: &[DecodedRecordSpan],
+    dropped: &HashSet<usize>,
+) -> Vec<ResidualOverlapComponent> {
+    // slot -> surviving span indices claiming it.
+    let mut by_slot: HashMap<usize, Vec<usize>> = HashMap::new();
+    for (i, span) in spans.iter().enumerate() {
+        if dropped.contains(&span.rec_idx) {
+            continue;
+        }
+        for ot in span.start..span.end {
+            by_slot.entry(ot).or_default().push(i);
+        }
+    }
+
+    // A slot is genuinely contested iff two of its claimants carry distinct
+    // names. Union every span on such a slot (the whole slot is ambiguous) and
+    // record the slot as contested.
+    let mut uf = UnionFind::new(spans.len());
+    let mut conflicted: HashSet<usize> = HashSet::new();
+    let mut contested_slot_reps: Vec<(usize, usize)> = Vec::new(); // (ot, rep span idx)
+    for (&ot, slot_spans) in &by_slot {
+        let mut distinct_names = false;
+        'pairs: for a in 0..slot_spans.len() {
+            for b in (a + 1)..slot_spans.len() {
+                if spans[slot_spans[a]].name != spans[slot_spans[b]].name {
+                    distinct_names = true;
+                    break 'pairs;
+                }
+            }
+        }
+        if !distinct_names {
+            continue;
+        }
+        let base = slot_spans[0];
+        for &other in slot_spans {
+            uf.union(base, other);
+            conflicted.insert(other);
+        }
+        contested_slot_reps.push((ot, base));
+    }
+
+    if conflicted.is_empty() {
+        return Vec::new();
+    }
+
+    // Group conflicted spans by union-find root; collect each component's
+    // contested OTs by the same root.
+    let mut spans_by_root: HashMap<usize, Vec<usize>> = HashMap::new();
+    for &i in &conflicted {
+        spans_by_root.entry(uf.find(i)).or_default().push(i);
+    }
+    let mut ots_by_root: HashMap<usize, Vec<usize>> = HashMap::new();
+    for &(ot, rep) in &contested_slot_reps {
+        ots_by_root.entry(uf.find(rep)).or_default().push(ot);
+    }
+
+    let mut components: Vec<ResidualOverlapComponent> = spans_by_root
+        .into_iter()
+        .map(|(root, mut span_indices)| {
+            span_indices.sort_unstable();
+            let mut contested_ots = ots_by_root.remove(&root).unwrap_or_default();
+            contested_ots.sort_unstable();
+            contested_ots.dedup();
+            ResidualOverlapComponent {
+                span_indices,
+                contested_ots,
+            }
+        })
+        .collect();
+    // Deterministic order (HashMap iteration is not): by first contested OT,
+    // then by first span index.
+    components.sort_by_key(|c| {
+        (
+            c.contested_ots.first().copied().unwrap_or(usize::MAX),
+            c.span_indices.first().copied().unwrap_or(usize::MAX),
+        )
+    });
+    components
 }
 
 /// Identify *standalone* (non-overlapping) graphical-function descriptor
@@ -1181,6 +1328,129 @@ mod standalone_descriptor_tests {
         );
         assert!(outcome.veto_fired);
         assert_eq!(outcome.vetoed_candidates, 1);
+    }
+}
+
+#[cfg(test)]
+mod residual_overlap_tests {
+    use super::*;
+
+    fn span_with_len(rec_idx: usize, name: &str, start: usize, len: usize) -> DecodedRecordSpan {
+        DecodedRecordSpan {
+            rec_idx,
+            name: name.to_string(),
+            start,
+            end: start + len,
+            sort_key: 0,
+        }
+    }
+
+    fn scalar(rec_idx: usize, name: &str, start: usize) -> DecodedRecordSpan {
+        span_with_len(rec_idx, name, start, 1)
+    }
+
+    /// A clean, non-overlapping owner partition (the corpus norm once
+    /// descriptors are peeled) yields NO residual components, so the floor is
+    /// a provable no-op on every file the peel already resolves.
+    #[test]
+    fn clean_partition_has_no_residual_components() {
+        let spans = [
+            scalar(0, "alpha", 1),
+            scalar(1, "beta", 2),
+            span_with_len(2, "gamma", 3, 3),
+        ];
+        let components = residual_overlap_components(&spans, &HashSet::new());
+        assert!(
+            components.is_empty(),
+            "no overlap must produce no residual components: {components:?}"
+        );
+    }
+
+    /// Two differently-named spans that share an OT slot after peeling are a
+    /// genuine owner-vs-owner conflict: both are pulled into one component so
+    /// the caller can drop them (honest missing data over a silent
+    /// alphabetical first-claim win).
+    #[test]
+    fn distinct_name_overlap_is_a_residual_component() {
+        let spans = [scalar(0, "china gdp", 5), scalar(1, "row coal demand", 5)];
+        let components = residual_overlap_components(&spans, &HashSet::new());
+        assert_eq!(components.len(), 1, "one contested slot, one component");
+        assert_eq!(components[0].span_indices, vec![0, 1]);
+        assert_eq!(components[0].contested_ots, vec![5]);
+    }
+
+    /// Two overlapping spans of the SAME name are the ordinary
+    /// same-variable duplicate the per-name emitter dedup already resolves;
+    /// they must NOT be flagged as a cross-variable conflict (dropping both
+    /// would lose the variable entirely).
+    #[test]
+    fn same_name_overlap_is_not_residual() {
+        let spans = [scalar(0, "population", 3), scalar(1, "population", 3)];
+        let components = residual_overlap_components(&spans, &HashSet::new());
+        assert!(
+            components.is_empty(),
+            "same-name overlap is not a residual conflict: {components:?}"
+        );
+    }
+
+    /// A wide ghost span (a stale-`f[11]` unsaved-variable record) covering
+    /// several narrow real owners forms ONE component containing the ghost
+    /// and every owner it overlaps -- the `SimService/Base.vdf` cluster-A
+    /// shape. Stage 1 drops the whole component; a later stage re-resolves it.
+    #[test]
+    fn wide_ghost_over_narrow_owners_forms_one_component() {
+        let spans = [
+            span_with_len(0, "age specific fertility distribution function", 2, 6),
+            scalar(1, "c real gdp", 2),
+            scalar(2, "capital agriculture", 4),
+            span_with_len(3, "co2 in deep ocean", 5, 3),
+            // An unrelated, non-overlapping owner outside the ghost span.
+            scalar(4, "agricultural land in use", 20),
+        ];
+        let components = residual_overlap_components(&spans, &HashSet::new());
+        assert_eq!(components.len(), 1, "one wide ghost, one component");
+        assert_eq!(
+            components[0].span_indices,
+            vec![0, 1, 2, 3],
+            "the ghost and every owner it covers are in the component; the \
+             disjoint owner is not"
+        );
+        assert_eq!(components[0].contested_ots, vec![2, 4, 5, 6, 7]);
+    }
+
+    /// A span already dropped (a peeled descriptor or standalone lookup-only
+    /// table) is invisible to residual detection: it cannot re-introduce a
+    /// conflict it is no longer part of.
+    #[test]
+    fn dropped_span_is_excluded() {
+        let spans = [scalar(0, "china gdp", 5), scalar(1, "row coal demand", 5)];
+        // Span 1 (rec_idx 1) was already dropped upstream, so span 0 no longer
+        // conflicts with anything.
+        let dropped: HashSet<usize> = [1usize].into_iter().collect();
+        let components = residual_overlap_components(&spans, &dropped);
+        assert!(
+            components.is_empty(),
+            "a dropped span cannot form a residual conflict: {components:?}"
+        );
+    }
+
+    /// Two disjoint conflicts produce two separate components, ordered
+    /// deterministically by first contested OT.
+    #[test]
+    fn disjoint_conflicts_are_separate_components() {
+        let spans = [
+            scalar(0, "b var", 30),
+            scalar(1, "a var", 30),
+            scalar(2, "d var", 10),
+            scalar(3, "c var", 10),
+        ];
+        let components = residual_overlap_components(&spans, &HashSet::new());
+        assert_eq!(components.len(), 2);
+        // Deterministic order: the OT-10 conflict comes before the OT-30 one.
+        assert_eq!(components[0].contested_ots, vec![10]);
+        assert_eq!(components[0].span_indices, vec![2, 3]);
+        assert_eq!(components[1].contested_ots, vec![30]);
+        assert_eq!(components[1].span_indices, vec![0, 1]);
     }
 }
 

--- a/src/simlin-engine/src/vdf/record_results.rs
+++ b/src/simlin-engine/src/vdf/record_results.rs
@@ -444,26 +444,33 @@ pub(super) fn identify_descriptor_records(
     );
     descriptor_indices.extend(standalone.dropped);
 
-    // Residual-overlap floor. After peeling overlap-path descriptors and
-    // dropping standalone lookup-only tables, some differently-named spans can
-    // STILL claim a shared OT slot -- an owner-vs-owner conflict no structural
-    // signal resolved. Compute those components as data, then (Stage 1) drop
-    // every span in them so the emission path never lets alphabetical order
-    // silently pick an OT owner. A later stage re-resolves a component before
-    // this drop; the components are threaded out on `DescriptorIdentification`.
-    let residual_overlap_components = residual_overlap_components(spans, &descriptor_indices);
-    for component in &residual_overlap_components {
-        for &span_idx in &component.span_indices {
-            descriptor_indices.insert(spans[span_idx].rec_idx);
-        }
+    // Residual-overlap re-resolution. After peeling overlap-path descriptors
+    // and dropping standalone lookup-only tables, some differently-named spans
+    // can STILL claim a shared OT slot -- an owner-vs-owner conflict no
+    // structural signal resolved. Compute those components as data, then
+    // re-resolve each from scratch (lexical peel of table names + the
+    // alphabetical-ordering oracle), recovering the real owners and dropping
+    // only the ghosts. Whatever the oracle cannot adjudicate is honest-dropped
+    // and threaded out on `DescriptorIdentification` for the diagnostics.
+    let phase1_descriptors = descriptor_indices.clone();
+    let residual_components = residual_overlap_components(spans, &descriptor_indices);
+    let resolution = resolve_residual_components(
+        spans,
+        &residual_components,
+        &phase1_descriptors,
+        RESIDUAL_ORDERING_GATE,
+    );
+    for rec_idx in &resolution.readmitted {
+        descriptor_indices.remove(rec_idx);
     }
+    descriptor_indices.extend(resolution.dropped.iter().copied());
 
     DescriptorIdentification {
         descriptor_indices,
         used_f10_fallback,
         standalone_drop_veto_fired: standalone.veto_fired,
         standalone_drop_vetoed_candidates: standalone.vetoed_candidates,
-        residual_overlap_components,
+        residual_overlap_components: resolution.unresolved_components,
     }
 }
 
@@ -573,6 +580,330 @@ fn residual_overlap_components(
         )
     });
     components
+}
+
+/// Minimum fraction of adjacent uncontested-owner pairs (sorted by OT) that
+/// must be alphabetically ordered for the ordering oracle to run on a file.
+///
+/// Vensim allocates OT slots in case-insensitive alphabetical order within a
+/// run, so a genuine run file's uncontested owners are overwhelmingly ordered
+/// (the four probed corpus files measure 98.6-99.6%; the residual few percent
+/// of breaks are run boundaries). A file below this bar does not exhibit the
+/// invariant, so the oracle abstains and every residual span is honest-dropped
+/// (Stage 1 semantics). The bar is a principled "overwhelming majority", not
+/// tuned to make any one file pass.
+const RESIDUAL_ORDERING_GATE: f64 = 0.95;
+
+/// Outcome of re-resolving the residual-overlap components (Stage 2).
+///
+/// `dropped` are `rec_idx`es the re-resolution drops (ghosts + the honest-drop
+/// fallback). `readmitted` are `rec_idx`es phase 1 peeled that the
+/// re-resolution recovered as real owners (e.g. `c Identified Oil Reserve`).
+/// `unresolved_components` are the honest-dropped remainder the oracle could
+/// not adjudicate, surfaced on the diagnostics (empty when every component
+/// fully resolves, as on `SimService/Base.vdf`).
+#[derive(Clone, Debug, Default)]
+pub(super) struct ResidualResolution {
+    pub(super) dropped: HashSet<usize>,
+    pub(super) readmitted: HashSet<usize>,
+    pub(super) unresolved_components: Vec<ResidualOverlapComponent>,
+}
+
+/// Case-insensitive Vensim OT-allocation sort key (mirrors the Python reader's
+/// `_vensim_sort_key`). Names in the corpus are ASCII, so this matches the
+/// Python `str.lower()` byte-for-byte.
+fn vensim_sort_key(name: &str) -> String {
+    name.to_lowercase()
+}
+
+fn spans_overlap(a: &DecodedRecordSpan, b: &DecodedRecordSpan) -> bool {
+    !(a.end <= b.start || b.end <= a.start)
+}
+
+/// Whether span `idx` still overlaps another span in `active`.
+fn overlaps_any(idx: usize, active: &[usize], spans: &[DecodedRecordSpan]) -> bool {
+    active
+        .iter()
+        .any(|&other| other != idx && spans_overlap(&spans[idx], &spans[other]))
+}
+
+/// Fraction of adjacent OT-sorted uncontested-owner pairs that are name-ordered
+/// -- the measured strength of Vensim's alphabetical OT allocation on this
+/// file. 1.0 when there are fewer than two owners.
+fn alphabetical_consistency(uncontested_by_ot: &[usize], spans: &[DecodedRecordSpan]) -> f64 {
+    if uncontested_by_ot.len() < 2 {
+        return 1.0;
+    }
+    let mut ok = 0usize;
+    for w in uncontested_by_ot.windows(2) {
+        if vensim_sort_key(&spans[w[0]].name) <= vensim_sort_key(&spans[w[1]].name) {
+            ok += 1;
+        }
+    }
+    ok as f64 / (uncontested_by_ot.len() - 1) as f64
+}
+
+/// Ordering verdict for a span given its prev/next anchor bracket (all args are
+/// case-insensitive sort keys). An INVERTED bracket (`prev > next`) means a run
+/// boundary sits between the anchors, so the unreliable next side is dropped
+/// and only the prev side is tested (the cluster-A case, where the next anchor
+/// `agricultural land in use` sorts before the real `c *` owners). Otherwise
+/// the name must fall within `[prev, next]`.
+fn ordering_ok(prev: Option<&str>, next: Option<&str>, name: &str) -> bool {
+    if let (Some(p), Some(n)) = (prev, next)
+        && p > n
+    {
+        return p <= name;
+    }
+    prev.is_none_or(|p| p <= name) && next.is_none_or(|n| name <= n)
+}
+
+/// Nearest span in the OT-`start`-sorted `sorted` list with start strictly
+/// before `start`.
+fn anchor_prev(sorted: &[usize], spans: &[DecodedRecordSpan], start: usize) -> Option<usize> {
+    let pos = sorted.partition_point(|&i| spans[i].start < start);
+    (pos > 0).then(|| sorted[pos - 1])
+}
+
+/// Nearest span in the OT-`start`-sorted `sorted` list with start at or after
+/// `end`.
+fn anchor_next(sorted: &[usize], spans: &[DecodedRecordSpan], end: usize) -> Option<usize> {
+    let pos = sorted.partition_point(|&i| spans[i].start < end);
+    sorted.get(pos).copied()
+}
+
+/// Ordering-oracle verdict: does `span_idx` sit where Vensim's alphabetical OT
+/// allocation would put a real owner?
+///
+/// Anchors come in two tiers. When a RECOVERED real owner (a residual-component
+/// span already confirmed this pass) brackets the span on BOTH sides, that tier
+/// wins: recovered reals share the span's interleaved run, so they are the
+/// reliable same-run evidence (this is what adjudicates `indicated per capita
+/// fish demand` vs `China future GDP growth rate` at OT 127 -- the recovered
+/// `Indicated China GDP`@123 / `indicated row Coal demand`@128 bracket, not the
+/// nearest uncontested owner `cafe history`@124, which is a different run).
+/// Otherwise the file's uncontested owners are the anchors.
+fn residual_span_is_owner(
+    span_idx: usize,
+    recovered_sorted: &[usize],
+    uncontested_sorted: &[usize],
+    spans: &[DecodedRecordSpan],
+) -> bool {
+    let name_key = vensim_sort_key(&spans[span_idx].name);
+    let start = spans[span_idx].start;
+    let end = spans[span_idx].end;
+    let rp = anchor_prev(recovered_sorted, spans, start);
+    let rn = anchor_next(recovered_sorted, spans, end);
+    if let (Some(p), Some(n)) = (rp, rn) {
+        return ordering_ok(
+            Some(&vensim_sort_key(&spans[p].name)),
+            Some(&vensim_sort_key(&spans[n].name)),
+            &name_key,
+        );
+    }
+    let up = anchor_prev(uncontested_sorted, spans, start).map(|i| vensim_sort_key(&spans[i].name));
+    let un = anchor_next(uncontested_sorted, spans, end).map(|i| vensim_sort_key(&spans[i].name));
+    ordering_ok(up.as_deref(), un.as_deref(), &name_key)
+}
+
+/// Re-resolve each residual-overlap component from scratch, recovering the real
+/// owners and dropping only the ghosts (stale-`f[11]` unsaved-variable
+/// records). Functional core: operates on the decoded spans plus the phase-1
+/// descriptor set, so it is unit-testable on synthetic inputs.
+///
+/// Per component (see docs/design/vdf.md "Residual OT-overlap"):
+/// (a) discard the component's phase-1 overlap peels that spatially belong to
+///     it (un-peel: any phase-1 descriptor overlapping a component span, e.g.
+///     the wrongly f10-peeled `c Identified Oil Reserve`), then
+/// (b) LEXICALLY peel spans whose names are lookupish, WITHOUT the
+///     `f11 < n_lookups` gate -- a lookup definition is a table, not a series,
+///     so its stale `f[11]` cannot forward-link, then
+/// (c) adjudicate the remaining conflicts with the alphabetical-ordering oracle
+///     ([`residual_span_is_owner`]), iterating a fixpoint so a span confirmed as
+///     an owner becomes an anchor for its neighbours, then
+/// (d) honest-drop anything still in conflict (surfaced on the diagnostics).
+///
+/// Gated per file: if the uncontested owners do not exhibit the
+/// alphabetical-allocation invariant (`gate_threshold`), the oracle abstains and
+/// every residual span is honest-dropped (Stage 1 semantics), so a file that
+/// does not follow the invariant is never mis-adjudicated.
+fn resolve_residual_components(
+    spans: &[DecodedRecordSpan],
+    components: &[ResidualOverlapComponent],
+    phase1_descriptors: &HashSet<usize>,
+    gate_threshold: f64,
+) -> ResidualResolution {
+    let mut dropped: HashSet<usize> = HashSet::new();
+    if components.is_empty() {
+        return ResidualResolution::default();
+    }
+
+    let comp_span_idx: HashSet<usize> = components
+        .iter()
+        .flat_map(|c| c.span_indices.iter().copied())
+        .collect();
+
+    // Uncontested owners: the clean, non-conflicted owner partition -- the
+    // alphabetical reference. Sorted by OT start.
+    let mut uncontested: Vec<usize> = (0..spans.len())
+        .filter(|&i| !phase1_descriptors.contains(&spans[i].rec_idx) && !comp_span_idx.contains(&i))
+        .collect();
+    uncontested.sort_by_key(|&i| (spans[i].start, spans[i].rec_idx));
+
+    // Gate: abstain (honest-drop all) when the file does not exhibit the
+    // alphabetical invariant.
+    if alphabetical_consistency(&uncontested, spans) < gate_threshold {
+        for c in components {
+            for &i in &c.span_indices {
+                dropped.insert(spans[i].rec_idx);
+            }
+        }
+        return ResidualResolution {
+            dropped,
+            readmitted: HashSet::new(),
+            unresolved_components: components.to_vec(),
+        };
+    }
+
+    // Per-component active sets: component spans + un-peeled phase-1 descriptors
+    // overlapping any component span (a phase-1 descriptor is given a second
+    // chance exactly when it collides with a component's spans).
+    let mut comp_active: Vec<Vec<usize>> = Vec::with_capacity(components.len());
+    let mut unpeeled_recidx: HashSet<usize> = HashSet::new();
+    for c in components {
+        let mut active: Vec<usize> = c.span_indices.clone();
+        let component_spans = active.clone();
+        for (i, span) in spans.iter().enumerate() {
+            if phase1_descriptors.contains(&span.rec_idx)
+                && component_spans
+                    .iter()
+                    .any(|&cs| spans_overlap(span, &spans[cs]))
+            {
+                active.push(i);
+                unpeeled_recidx.insert(span.rec_idx);
+            }
+        }
+        active.sort_by_key(|&i| (spans[i].start, spans[i].rec_idx));
+        comp_active.push(active);
+    }
+
+    // (a) lexical peel: drop lookupish table names (no `f11 < n_lookups` gate).
+    for active in &mut comp_active {
+        active.retain(|&i| {
+            if is_lookupish_name(&spans[i].name) {
+                dropped.insert(spans[i].rec_idx);
+                false
+            } else {
+                true
+            }
+        });
+    }
+
+    // (b)+(c) fixpoint: confirm non-overlapping spans as recovered owners, then
+    // drop the decisive ghosts, until no component changes.
+    let mut recovered: Vec<usize> = Vec::new();
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for active in &mut comp_active {
+            let mut still = Vec::with_capacity(active.len());
+            for &i in active.iter() {
+                if overlaps_any(i, active, spans) {
+                    still.push(i);
+                } else {
+                    recovered.push(i);
+                    changed = true;
+                }
+            }
+            *active = still;
+        }
+        recovered.sort_by_key(|&i| (spans[i].start, spans[i].rec_idx));
+        for active in &mut comp_active {
+            let overl: Vec<usize> = active
+                .iter()
+                .copied()
+                .filter(|&i| overlaps_any(i, active, spans))
+                .collect();
+            if overl.is_empty() {
+                continue;
+            }
+            let mut ghosts: Vec<usize> = Vec::new();
+            let mut has_owner = false;
+            for &i in &overl {
+                if residual_span_is_owner(i, &recovered, &uncontested, spans) {
+                    has_owner = true;
+                } else {
+                    ghosts.push(i);
+                }
+            }
+            if has_owner && !ghosts.is_empty() {
+                let ghost_set: HashSet<usize> = ghosts.iter().copied().collect();
+                for &i in &ghosts {
+                    dropped.insert(spans[i].rec_idx);
+                }
+                active.retain(|&i| !ghost_set.contains(&i));
+                changed = true;
+            }
+        }
+    }
+
+    // (d) honest-drop the still-conflicted remainder; report it on diagnostics.
+    let mut unresolved: Vec<ResidualOverlapComponent> = Vec::new();
+    for (c, active) in components.iter().zip(comp_active.iter()) {
+        let leftover: Vec<usize> = active
+            .iter()
+            .copied()
+            .filter(|&i| overlaps_any(i, active, spans))
+            .collect();
+        if leftover.is_empty() {
+            continue;
+        }
+        let leftover_set: HashSet<usize> = leftover.iter().copied().collect();
+        let mut span_indices: Vec<usize> = c
+            .span_indices
+            .iter()
+            .copied()
+            .filter(|i| leftover_set.contains(i))
+            .collect();
+        span_indices.sort_unstable();
+        for &i in &leftover {
+            dropped.insert(spans[i].rec_idx);
+        }
+        let mut contested: Vec<usize> = Vec::new();
+        for (ai, &a) in leftover.iter().enumerate() {
+            for &b in &leftover[ai + 1..] {
+                if spans_overlap(&spans[a], &spans[b]) {
+                    let lo = spans[a].start.max(spans[b].start);
+                    let hi = spans[a].end.min(spans[b].end);
+                    contested.extend(lo..hi);
+                }
+            }
+        }
+        contested.sort_unstable();
+        contested.dedup();
+        unresolved.push(ResidualOverlapComponent {
+            span_indices,
+            contested_ots: contested,
+        });
+    }
+
+    // Un-peeled phase-1 descriptors that were kept are readmitted as owners.
+    let mut kept_recidx: HashSet<usize> = recovered.iter().map(|&i| spans[i].rec_idx).collect();
+    for active in &comp_active {
+        for &i in active {
+            kept_recidx.insert(spans[i].rec_idx);
+        }
+    }
+    let readmitted: HashSet<usize> = unpeeled_recidx
+        .into_iter()
+        .filter(|r| kept_recidx.contains(r) && !dropped.contains(r))
+        .collect();
+
+    ResidualResolution {
+        dropped,
+        readmitted,
+        unresolved_components: unresolved,
+    }
 }
 
 /// Identify *standalone* (non-overlapping) graphical-function descriptor
@@ -1451,6 +1782,204 @@ mod residual_overlap_tests {
         assert_eq!(components[0].span_indices, vec![2, 3]);
         assert_eq!(components[1].contested_ots, vec![30]);
         assert_eq!(components[1].span_indices, vec![0, 1]);
+    }
+}
+
+/// Stage 2 re-resolution (`resolve_residual_components`): the ordering oracle,
+/// exercised on synthetic spans that reproduce each Base.vdf trap in miniature.
+#[cfg(test)]
+mod resolve_residual_tests {
+    use super::*;
+
+    fn span(rec_idx: usize, name: &str, start: usize, len: usize) -> DecodedRecordSpan {
+        DecodedRecordSpan {
+            rec_idx,
+            name: name.to_string(),
+            start,
+            end: start + len,
+            sort_key: 0,
+        }
+    }
+
+    fn dropped_names<'a>(res: &ResidualResolution, spans: &'a [DecodedRecordSpan]) -> Vec<&'a str> {
+        let mut names: Vec<&str> = spans
+            .iter()
+            .filter(|s| res.dropped.contains(&s.rec_idx))
+            .map(|s| s.name.as_str())
+            .collect();
+        names.sort_unstable();
+        names
+    }
+
+    /// Empty components -> the whole re-resolution is a no-op (the corpus norm:
+    /// 139/141 files have no residual overlap at all).
+    #[test]
+    fn empty_components_is_noop() {
+        let spans = [span(0, "a", 1, 1), span(1, "b", 2, 1)];
+        let res = resolve_residual_components(&spans, &[], &HashSet::new(), RESIDUAL_ORDERING_GATE);
+        assert!(res.dropped.is_empty() && res.readmitted.is_empty());
+        assert!(res.unresolved_components.is_empty());
+    }
+
+    /// Run-boundary trap (cluster A). A wide ghost sorts BEFORE the real owners
+    /// it covers; the next uncontested anchor sorts before the prev anchor (a
+    /// run boundary), so the oracle falls back to the reliable prev side alone.
+    /// The ghost fails prev and is dropped; every narrow owner passes.
+    #[test]
+    fn run_boundary_prev_only_drops_wide_ghost() {
+        // Uncontested anchors: `c gas`@1 (prev) and `agri`@30 (next, sorts
+        // before `c gas` -> inverted bracket -> prev-only).
+        let spans = [
+            span(0, "c gas", 1, 1),
+            span(1, "agri", 30, 1),
+            span(2, "age ghost", 3, 4), // wide ghost [3,7)
+            span(3, "c oil", 3, 1),
+            span(4, "c pig", 4, 1),
+            span(5, "c rat", 5, 1),
+            span(6, "c sun", 6, 1),
+        ];
+        let components = residual_overlap_components(&spans, &HashSet::new());
+        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0);
+        assert_eq!(dropped_names(&res, &spans), vec!["age ghost"]);
+        assert!(res.readmitted.is_empty());
+        assert!(res.unresolved_components.is_empty());
+    }
+
+    /// Recovered-anchor discrimination (comp2). Two non-lookupish spans share a
+    /// slot; the nearest UNCONTESTED owners bracket BOTH (neither can be told
+    /// apart that way). Only the recovered reals from the adjacent
+    /// lexical-peel-resolved pairs form the tight same-run bracket that drops
+    /// the ghost -- proving the recovered-anchor tier is load-bearing.
+    #[test]
+    fn recovered_anchor_bracket_resolves_scalar_pair() {
+        let spans = [
+            span(0, "tbl x lookup", 9, 2),  // comp1 lookupish ghost [9,11)
+            span(1, "ind a", 10, 1),        // comp1 real
+            span(2, "ind b", 12, 1),        // comp2 real (the hard one)
+            span(3, "cat food", 12, 1),     // comp2 ghost (non-lookupish, run X)
+            span(4, "tbl y lookup", 13, 2), // comp3 lookupish ghost [13,15)
+            span(5, "ind c", 14, 1),        // comp3 real
+            // Uncontested owners that loosely bracket comp2 on BOTH sides but
+            // cannot discriminate (both candidates fall within [a1, z1]).
+            span(6, "a1", 11, 1),
+            span(7, "z1", 16, 1),
+        ];
+        let components = residual_overlap_components(&spans, &HashSet::new());
+        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0);
+        assert_eq!(
+            dropped_names(&res, &spans),
+            vec!["cat food", "tbl x lookup", "tbl y lookup"]
+        );
+        assert!(res.unresolved_components.is_empty());
+    }
+
+    /// Inconclusive -> honest-drop fallback. When no candidate for a shared slot
+    /// is ordering-consistent (no owner to keep), the oracle abstains on that
+    /// conflict and both spans are honest-dropped and surfaced on the
+    /// diagnostics -- never silently first-claimed.
+    #[test]
+    fn inconclusive_conflict_is_honest_dropped() {
+        let spans = [
+            span(0, "a", 1, 1),
+            span(1, "b", 9, 1),
+            // Both sort AFTER the next anchor `b`@9 -> neither is a valid owner.
+            span(2, "yyy", 5, 1),
+            span(3, "zzz", 5, 1),
+        ];
+        let components = residual_overlap_components(&spans, &HashSet::new());
+        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0);
+        assert_eq!(dropped_names(&res, &spans), vec!["yyy", "zzz"]);
+        assert_eq!(res.unresolved_components.len(), 1);
+        assert_eq!(res.unresolved_components[0].contested_ots, vec![5]);
+    }
+
+    /// Un-peel + readmit (the `c Identified Oil Reserve` case). A phase-1
+    /// overlap-peeled descriptor that spatially belongs to a component is given
+    /// a second chance; when the oracle keeps it, it is readmitted as an owner.
+    #[test]
+    fn unpeeled_descriptor_is_readmitted_when_kept() {
+        let spans = [
+            span(0, "c gas", 1, 1),
+            span(1, "agri", 20, 1),
+            span(2, "age ghost", 8, 4), // wide ghost [8,12)
+            span(3, "c pig", 9, 1),
+            span(4, "c rat", 10, 1),
+            span(5, "c sun", 11, 1),
+            span(6, "c oil", 7, 2), // phase-1 descriptor [7,9), overlaps ghost @8
+        ];
+        let phase1: HashSet<usize> = [6usize].into_iter().collect();
+        let components = residual_overlap_components(&spans, &phase1);
+        let res = resolve_residual_components(&spans, &components, &phase1, 0.0);
+        assert_eq!(dropped_names(&res, &spans), vec!["age ghost"]);
+        assert_eq!(res.readmitted, [6usize].into_iter().collect());
+        assert!(res.unresolved_components.is_empty());
+    }
+
+    /// Lexically lookupish names in a component are peeled WITHOUT the
+    /// `f11 < n_lookups` gate: a lookup definition is a table, not a series.
+    #[test]
+    fn lexical_peel_drops_lookupish_names() {
+        let spans = [
+            span(0, "real var", 1, 1),
+            span(1, "real var2", 2, 1),
+            span(2, "foo lookup", 1, 2), // lookupish ghost [1,3)
+        ];
+        let components = residual_overlap_components(&spans, &HashSet::new());
+        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0);
+        assert_eq!(dropped_names(&res, &spans), vec!["foo lookup"]);
+        assert!(res.unresolved_components.is_empty());
+    }
+
+    /// Chained-descriptor un-peel boundary. A phase-1 descriptor is un-peeled
+    /// iff it overlaps an ORIGINAL component span -- never merely a
+    /// previously-un-peeled descriptor. `d oil`@[9,12) overlaps the ghost and
+    /// is un-peeled (and kept -> readmitted); `d tar`@[11,13) overlaps only
+    /// `d oil`, so it stays a descriptor and is neither dropped nor readmitted.
+    /// Pins the Rust/Python bit-parity contract on this constructible case.
+    #[test]
+    fn chained_descriptor_is_not_transitively_unpeeled() {
+        let spans = [
+            span(0, "c gas", 1, 1),     // uncontested prev anchor
+            span(1, "zz", 30, 1),       // uncontested next anchor
+            span(2, "age ghost", 5, 5), // wide ghost [5,10)
+            span(3, "d1", 5, 1),
+            span(4, "d2", 6, 1),
+            span(5, "d3", 7, 1),
+            span(6, "d4", 8, 1),
+            span(7, "d oil", 9, 3), // phase-1 descriptor [9,12), overlaps ghost @9
+            span(8, "d tar", 11, 2), // phase-1 descriptor [11,13), overlaps ONLY d oil
+        ];
+        let phase1: HashSet<usize> = [7usize, 8].into_iter().collect();
+        let components = residual_overlap_components(&spans, &phase1);
+        let res = resolve_residual_components(&spans, &components, &phase1, 0.0);
+        assert_eq!(dropped_names(&res, &spans), vec!["age ghost"]);
+        assert_eq!(res.readmitted, [7usize].into_iter().collect());
+        assert!(
+            !res.dropped.contains(&8) && !res.readmitted.contains(&8),
+            "d tar overlaps only an un-peeled descriptor, so it must stay untouched"
+        );
+        assert!(res.unresolved_components.is_empty());
+    }
+
+    /// Gate abstention. A file whose uncontested owners do NOT exhibit the
+    /// alphabetical-allocation invariant fails the gate, so the oracle abstains
+    /// and every residual span is honest-dropped (Stage 1 semantics).
+    #[test]
+    fn gate_abstains_when_owners_not_alphabetical() {
+        // Badly-shuffled uncontested owners -> low alphabetical consistency.
+        let spans = [
+            span(0, "z", 1, 1),
+            span(1, "a", 2, 1),
+            span(2, "m", 3, 1),
+            span(3, "b", 4, 1),
+            span(4, "ghost", 10, 1),
+            span(5, "owner", 10, 1),
+        ];
+        let components = residual_overlap_components(&spans, &HashSet::new());
+        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.95);
+        // Both contested spans dropped; the component is reported unresolved.
+        assert_eq!(dropped_names(&res, &spans), vec!["ghost", "owner"]);
+        assert_eq!(res.unresolved_components.len(), 1);
     }
 }
 

--- a/src/simlin-engine/src/vdf/record_results.rs
+++ b/src/simlin-engine/src/vdf/record_results.rs
@@ -307,142 +307,154 @@ pub(super) fn identify_descriptor_records(
     spans: &[DecodedRecordSpan],
 ) -> DescriptorIdentification {
     let n_lookups = vdf.section6_lookup_records().map(|v| v.len()).unwrap_or(0);
-    if n_lookups == 0 || spans.is_empty() {
+    if spans.is_empty() {
         return DescriptorIdentification::default();
-    }
-
-    // Build OT-slot -> spans-claiming-it. Spans that share any OT slot with
-    // another span are descriptor-pair candidates.
-    let mut by_slot: HashMap<usize, Vec<usize>> = HashMap::new();
-    for (i, span) in spans.iter().enumerate() {
-        for ot in span.start..span.end {
-            by_slot.entry(ot).or_default().push(i);
-        }
-    }
-
-    // Connected components of overlapping spans (union-find on span indices).
-    let mut uf = UnionFind::new(spans.len());
-    for slot_spans in by_slot.values() {
-        if slot_spans.len() >= 2 {
-            let base = slot_spans[0];
-            for &other in &slot_spans[1..] {
-                uf.union(base, other);
-            }
-        }
-    }
-
-    // A span participates in overlap iff some OT in its range has 2+
-    // claimants.
-    let mut overlapping: HashSet<usize> = HashSet::new();
-    for slot_spans in by_slot.values() {
-        if slot_spans.len() >= 2 {
-            overlapping.extend(slot_spans.iter().copied());
-        }
-    }
-
-    let mut components: HashMap<usize, Vec<usize>> = HashMap::new();
-    for (i, _) in spans.iter().enumerate() {
-        if overlapping.contains(&i) {
-            let root = uf.find(i);
-            components.entry(root).or_default().push(i);
-        }
     }
 
     let mut descriptor_indices: HashSet<usize> = HashSet::new();
     let mut used_f10_fallback = false;
+    let mut standalone_veto_fired = false;
+    let mut standalone_vetoed_candidates = 0usize;
 
-    for component in components.values() {
-        // Iteratively peel off descriptor records until the component is
-        // internally non-overlapping. Candidates are restricted to records
-        // whose `f[11]` is in `[0, lookup_count)` -- the structural
-        // pre-condition for the lookup-record forward link.
-        let mut active: Vec<usize> = component.clone();
-        loop {
-            let mut comp_by_slot: HashMap<usize, Vec<usize>> = HashMap::new();
-            for &i in &active {
-                let span = &spans[i];
-                for ot in span.start..span.end {
-                    comp_by_slot.entry(ot).or_default().push(i);
-                }
+    // The overlap-path descriptor peel and the standalone lookup-only drop both
+    // forward-link through section-6 lookup records, so they run ONLY when the
+    // file has lookups. The residual-overlap pass further below is name/OT-based
+    // and must run UNCONDITIONALLY: a lookup-free file can still carry the
+    // stale-f[11] owner-vs-owner conflict this guards against, and skipping it
+    // would silently resolve by alphabetical emission order (GH #844).
+    if n_lookups > 0 {
+        // Build OT-slot -> spans-claiming-it. Spans that share any OT slot with
+        // another span are descriptor-pair candidates.
+        let mut by_slot: HashMap<usize, Vec<usize>> = HashMap::new();
+        for (i, span) in spans.iter().enumerate() {
+            for ot in span.start..span.end {
+                by_slot.entry(ot).or_default().push(i);
             }
-            let mut still_overlapping: HashSet<usize> = HashSet::new();
-            for slot_spans in comp_by_slot.values() {
-                if slot_spans.len() >= 2 {
-                    still_overlapping.extend(slot_spans.iter().copied());
-                }
-            }
-            if still_overlapping.is_empty() {
-                break;
-            }
-            let candidates: Vec<usize> = active
-                .iter()
-                .copied()
-                .filter(|&i| {
-                    if !still_overlapping.contains(&i) {
-                        return false;
-                    }
-                    let f11 = vdf.records[spans[i].rec_idx].fields[11] as usize;
-                    f11 < n_lookups
-                })
-                .collect();
-            if candidates.is_empty() {
-                // Owner-only overlap with no descriptor candidate: leave the
-                // component alone. The caller (or precision report) is
-                // expected to surface a residual `record-span-overlap`.
-                break;
-            }
-            let lookupish: Vec<usize> = candidates
-                .iter()
-                .copied()
-                .filter(|&i| is_lookupish_name(&spans[i].name))
-                .collect();
-            let descriptor_span_idx = if lookupish.len() == 1 {
-                lookupish[0]
-            } else {
-                used_f10_fallback = true;
-                *candidates
-                    .iter()
-                    .max_by_key(|&&i| (spans[i].sort_key, spans[i].rec_idx))
-                    .expect("candidates non-empty")
-            };
-            descriptor_indices.insert(spans[descriptor_span_idx].rec_idx);
-            active.retain(|&i| i != descriptor_span_idx);
         }
-    }
 
-    // Standalone (non-overlapping) descriptors: a lookup-only variable Vensim
-    // saves only as a descriptor record (a graphical-function definition). The
-    // overlap path above never sees it (it collides with nothing), so it would
-    // otherwise decode at its spurious `f[11]`-as-OT-start ghost slot. A bare
-    // lookup is a table, not a time series, so recognise it and DROP it -- its
-    // values, where they matter, are carried by the consumer variables that
-    // call it (separately-emitted owners).
-    let lookup_records = vdf.section6_lookup_records();
-    let lookup_word10: Vec<usize> = lookup_records
-        .as_ref()
-        .map(|recs| recs.iter().map(|r| r.ot_index()).collect())
-        .unwrap_or_default();
-    let lookup_word11: Vec<usize> = lookup_records
-        .as_ref()
-        .map(|recs| recs.iter().map(|r| r.output_width()).collect())
-        .unwrap_or_default();
-    let class_codes = vdf.section6_ot_class_codes().unwrap_or_default();
-    let f11_by_span: Vec<u32> = spans
-        .iter()
-        .map(|s| vdf.records[s.rec_idx].fields[11])
-        .collect();
-    let standalone = standalone_lookup_only_descriptors(
-        spans,
-        &f11_by_span,
-        &overlapping,
-        &descriptor_indices,
-        n_lookups,
-        &lookup_word10,
-        &lookup_word11,
-        &class_codes,
-        vdf.offset_table_count,
-    );
-    descriptor_indices.extend(standalone.dropped);
+        // Connected components of overlapping spans (union-find on span indices).
+        let mut uf = UnionFind::new(spans.len());
+        for slot_spans in by_slot.values() {
+            if slot_spans.len() >= 2 {
+                let base = slot_spans[0];
+                for &other in &slot_spans[1..] {
+                    uf.union(base, other);
+                }
+            }
+        }
+
+        // A span participates in overlap iff some OT in its range has 2+
+        // claimants.
+        let mut overlapping: HashSet<usize> = HashSet::new();
+        for slot_spans in by_slot.values() {
+            if slot_spans.len() >= 2 {
+                overlapping.extend(slot_spans.iter().copied());
+            }
+        }
+
+        let mut components: HashMap<usize, Vec<usize>> = HashMap::new();
+        for (i, _) in spans.iter().enumerate() {
+            if overlapping.contains(&i) {
+                let root = uf.find(i);
+                components.entry(root).or_default().push(i);
+            }
+        }
+
+        for component in components.values() {
+            // Iteratively peel off descriptor records until the component is
+            // internally non-overlapping. Candidates are restricted to records
+            // whose `f[11]` is in `[0, lookup_count)` -- the structural
+            // pre-condition for the lookup-record forward link.
+            let mut active: Vec<usize> = component.clone();
+            loop {
+                let mut comp_by_slot: HashMap<usize, Vec<usize>> = HashMap::new();
+                for &i in &active {
+                    let span = &spans[i];
+                    for ot in span.start..span.end {
+                        comp_by_slot.entry(ot).or_default().push(i);
+                    }
+                }
+                let mut still_overlapping: HashSet<usize> = HashSet::new();
+                for slot_spans in comp_by_slot.values() {
+                    if slot_spans.len() >= 2 {
+                        still_overlapping.extend(slot_spans.iter().copied());
+                    }
+                }
+                if still_overlapping.is_empty() {
+                    break;
+                }
+                let candidates: Vec<usize> = active
+                    .iter()
+                    .copied()
+                    .filter(|&i| {
+                        if !still_overlapping.contains(&i) {
+                            return false;
+                        }
+                        let f11 = vdf.records[spans[i].rec_idx].fields[11] as usize;
+                        f11 < n_lookups
+                    })
+                    .collect();
+                if candidates.is_empty() {
+                    // Owner-only overlap with no descriptor candidate: leave the
+                    // component alone. The caller (or precision report) is
+                    // expected to surface a residual `record-span-overlap`.
+                    break;
+                }
+                let lookupish: Vec<usize> = candidates
+                    .iter()
+                    .copied()
+                    .filter(|&i| is_lookupish_name(&spans[i].name))
+                    .collect();
+                let descriptor_span_idx = if lookupish.len() == 1 {
+                    lookupish[0]
+                } else {
+                    used_f10_fallback = true;
+                    *candidates
+                        .iter()
+                        .max_by_key(|&&i| (spans[i].sort_key, spans[i].rec_idx))
+                        .expect("candidates non-empty")
+                };
+                descriptor_indices.insert(spans[descriptor_span_idx].rec_idx);
+                active.retain(|&i| i != descriptor_span_idx);
+            }
+        }
+
+        // Standalone (non-overlapping) descriptors: a lookup-only variable Vensim
+        // saves only as a descriptor record (a graphical-function definition). The
+        // overlap path above never sees it (it collides with nothing), so it would
+        // otherwise decode at its spurious `f[11]`-as-OT-start ghost slot. A bare
+        // lookup is a table, not a time series, so recognise it and DROP it -- its
+        // values, where they matter, are carried by the consumer variables that
+        // call it (separately-emitted owners).
+        let lookup_records = vdf.section6_lookup_records();
+        let lookup_word10: Vec<usize> = lookup_records
+            .as_ref()
+            .map(|recs| recs.iter().map(|r| r.ot_index()).collect())
+            .unwrap_or_default();
+        let lookup_word11: Vec<usize> = lookup_records
+            .as_ref()
+            .map(|recs| recs.iter().map(|r| r.output_width()).collect())
+            .unwrap_or_default();
+        let class_codes = vdf.section6_ot_class_codes().unwrap_or_default();
+        let f11_by_span: Vec<u32> = spans
+            .iter()
+            .map(|s| vdf.records[s.rec_idx].fields[11])
+            .collect();
+        let standalone = standalone_lookup_only_descriptors(
+            spans,
+            &f11_by_span,
+            &overlapping,
+            &descriptor_indices,
+            n_lookups,
+            &lookup_word10,
+            &lookup_word11,
+            &class_codes,
+            vdf.offset_table_count,
+        );
+        descriptor_indices.extend(standalone.dropped);
+        standalone_veto_fired = standalone.veto_fired;
+        standalone_vetoed_candidates = standalone.vetoed_candidates;
+    }
 
     // Residual-overlap re-resolution. After peeling overlap-path descriptors
     // and dropping standalone lookup-only tables, some differently-named spans
@@ -468,8 +480,8 @@ pub(super) fn identify_descriptor_records(
     DescriptorIdentification {
         descriptor_indices,
         used_f10_fallback,
-        standalone_drop_veto_fired: standalone.veto_fired,
-        standalone_drop_vetoed_candidates: standalone.vetoed_candidates,
+        standalone_drop_veto_fired: standalone_veto_fired,
+        standalone_drop_vetoed_candidates: standalone_vetoed_candidates,
         residual_overlap_components: resolution.unresolved_components,
     }
 }

--- a/src/simlin-engine/src/vdf/record_results.rs
+++ b/src/simlin-engine/src/vdf/record_results.rs
@@ -471,6 +471,7 @@ pub(super) fn identify_descriptor_records(
         &residual_components,
         &phase1_descriptors,
         RESIDUAL_ORDERING_GATE,
+        RESIDUAL_ORDERING_MIN_PAIRS,
     );
     for rec_idx in &resolution.readmitted {
         descriptor_indices.remove(rec_idx);
@@ -605,6 +606,23 @@ fn residual_overlap_components(
 /// (Stage 1 semantics). The bar is a principled "overwhelming majority", not
 /// tuned to make any one file pass.
 const RESIDUAL_ORDERING_GATE: f64 = 0.95;
+
+/// Minimum number of adjacent uncontested-owner pairs a file must have for the
+/// ordering oracle to run. Below it the oracle abstains (the component
+/// honest-drops with diagnostics), because a ratio measured over one or two
+/// pairs carries no real evidence -- with fewer than two owners the ratio is
+/// vacuously 1.0 and would pass the gate with zero measured support.
+///
+/// The exact value is NOT corpus-supported: any floor between 2 and ~800 is
+/// indistinguishable, since the only component-bearing files (the two
+/// SimService `Base.vdf`) measure ~840 pairs, far above any small floor. It
+/// exists purely as cheap fail-safe insurance -- abstention costs only recovery
+/// (Stage 1 honest-drop stays correct), never correctness, so erring toward
+/// abstention on thin evidence is always safe. Note that below ~20 pairs the
+/// 0.95 ratio already demands near-perfect ordering, which is the intended
+/// behavior when evidence is thin; this floor just forbids the degenerate
+/// zero/one-pair case outright.
+const RESIDUAL_ORDERING_MIN_PAIRS: usize = 8;
 
 /// Outcome of re-resolving the residual-overlap components (Stage 2).
 ///
@@ -747,15 +765,20 @@ fn residual_span_is_owner(
 ///     an owner becomes an anchor for its neighbours, then
 /// (d) honest-drop anything still in conflict (surfaced on the diagnostics).
 ///
-/// Gated per file: if the uncontested owners do not exhibit the
-/// alphabetical-allocation invariant (`gate_threshold`), the oracle abstains and
-/// every residual span is honest-dropped (Stage 1 semantics), so a file that
-/// does not follow the invariant is never mis-adjudicated.
+/// Gated per file: the oracle runs only when the uncontested owners supply at
+/// least `min_pairs` adjacent pairs AND exhibit the alphabetical-allocation
+/// invariant (ratio >= `gate_threshold`). Otherwise it abstains and every
+/// residual span is honest-dropped (Stage 1 semantics), so a file that does not
+/// follow the invariant -- or offers too little evidence to tell -- is never
+/// mis-adjudicated. (Production passes `RESIDUAL_ORDERING_GATE` /
+/// `RESIDUAL_ORDERING_MIN_PAIRS`; oracle-mechanics unit tests pass `0.0` / `0`
+/// to open the gate, exactly as they already open the ratio side.)
 fn resolve_residual_components(
     spans: &[DecodedRecordSpan],
     components: &[ResidualOverlapComponent],
     phase1_descriptors: &HashSet<usize>,
     gate_threshold: f64,
+    min_pairs: usize,
 ) -> ResidualResolution {
     let mut dropped: HashSet<usize> = HashSet::new();
     if components.is_empty() {
@@ -774,9 +797,12 @@ fn resolve_residual_components(
         .collect();
     uncontested.sort_by_key(|&i| (spans[i].start, spans[i].rec_idx));
 
-    // Gate: abstain (honest-drop all) when the file does not exhibit the
-    // alphabetical invariant.
-    if alphabetical_consistency(&uncontested, spans) < gate_threshold {
+    // Gate: abstain (honest-drop all) when the file offers too few
+    // uncontested-owner pairs to measure, OR does not exhibit the alphabetical
+    // invariant. The pair-count check is FIRST so the vacuous <2-owner case
+    // (where `alphabetical_consistency` is 1.0) can never pass on zero evidence.
+    let n_pairs = uncontested.len().saturating_sub(1);
+    if n_pairs < min_pairs || alphabetical_consistency(&uncontested, spans) < gate_threshold {
         for c in components {
             for &i in &c.span_indices {
                 dropped.insert(spans[i].rec_idx);
@@ -1842,7 +1868,13 @@ mod resolve_residual_tests {
     #[test]
     fn empty_components_is_noop() {
         let spans = [span(0, "a", 1, 1), span(1, "b", 2, 1)];
-        let res = resolve_residual_components(&spans, &[], &HashSet::new(), RESIDUAL_ORDERING_GATE);
+        let res = resolve_residual_components(
+            &spans,
+            &[],
+            &HashSet::new(),
+            RESIDUAL_ORDERING_GATE,
+            RESIDUAL_ORDERING_MIN_PAIRS,
+        );
         assert!(res.dropped.is_empty() && res.readmitted.is_empty());
         assert!(res.unresolved_components.is_empty());
     }
@@ -1865,7 +1897,7 @@ mod resolve_residual_tests {
             span(6, "c sun", 6, 1),
         ];
         let components = residual_overlap_components(&spans, &HashSet::new());
-        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0);
+        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0, 0);
         assert_eq!(dropped_names(&res, &spans), vec!["age ghost"]);
         assert!(res.readmitted.is_empty());
         assert!(res.unresolved_components.is_empty());
@@ -1891,7 +1923,7 @@ mod resolve_residual_tests {
             span(7, "z1", 16, 1),
         ];
         let components = residual_overlap_components(&spans, &HashSet::new());
-        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0);
+        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0, 0);
         assert_eq!(
             dropped_names(&res, &spans),
             vec!["cat food", "tbl x lookup", "tbl y lookup"]
@@ -1913,7 +1945,7 @@ mod resolve_residual_tests {
             span(3, "zzz", 5, 1),
         ];
         let components = residual_overlap_components(&spans, &HashSet::new());
-        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0);
+        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0, 0);
         assert_eq!(dropped_names(&res, &spans), vec!["yyy", "zzz"]);
         assert_eq!(res.unresolved_components.len(), 1);
         assert_eq!(res.unresolved_components[0].contested_ots, vec![5]);
@@ -1935,7 +1967,7 @@ mod resolve_residual_tests {
         ];
         let phase1: HashSet<usize> = [6usize].into_iter().collect();
         let components = residual_overlap_components(&spans, &phase1);
-        let res = resolve_residual_components(&spans, &components, &phase1, 0.0);
+        let res = resolve_residual_components(&spans, &components, &phase1, 0.0, 0);
         assert_eq!(dropped_names(&res, &spans), vec!["age ghost"]);
         assert_eq!(res.readmitted, [6usize].into_iter().collect());
         assert!(res.unresolved_components.is_empty());
@@ -1951,7 +1983,7 @@ mod resolve_residual_tests {
             span(2, "foo lookup", 1, 2), // lookupish ghost [1,3)
         ];
         let components = residual_overlap_components(&spans, &HashSet::new());
-        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0);
+        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0, 0);
         assert_eq!(dropped_names(&res, &spans), vec!["foo lookup"]);
         assert!(res.unresolved_components.is_empty());
     }
@@ -1977,7 +2009,7 @@ mod resolve_residual_tests {
         ];
         let phase1: HashSet<usize> = [7usize, 8].into_iter().collect();
         let components = residual_overlap_components(&spans, &phase1);
-        let res = resolve_residual_components(&spans, &components, &phase1, 0.0);
+        let res = resolve_residual_components(&spans, &components, &phase1, 0.0, 0);
         assert_eq!(dropped_names(&res, &spans), vec!["age ghost"]);
         assert_eq!(res.readmitted, [7usize].into_iter().collect());
         assert!(
@@ -2007,7 +2039,7 @@ mod resolve_residual_tests {
         // The same-name pair is pulled into the ghost's component.
         assert_eq!(components.len(), 1);
         assert_eq!(components[0].span_indices, vec![2, 3, 4]);
-        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0);
+        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.0, 0);
         assert_eq!(dropped_names(&res, &spans), vec!["zzz ghost"]);
         assert!(
             !res.dropped.contains(&2) && !res.dropped.contains(&3),
@@ -2016,9 +2048,10 @@ mod resolve_residual_tests {
         assert!(res.unresolved_components.is_empty());
     }
 
-    /// Gate abstention. A file whose uncontested owners do NOT exhibit the
-    /// alphabetical-allocation invariant fails the gate, so the oracle abstains
-    /// and every residual span is honest-dropped (Stage 1 semantics).
+    /// Gate abstention (RATIO). A file whose uncontested owners do NOT exhibit
+    /// the alphabetical-allocation invariant fails the gate, so the oracle
+    /// abstains and every residual span is honest-dropped (Stage 1 semantics).
+    /// `min_pairs == 0` isolates the ratio side of the gate.
     #[test]
     fn gate_abstains_when_owners_not_alphabetical() {
         // Badly-shuffled uncontested owners -> low alphabetical consistency.
@@ -2031,9 +2064,36 @@ mod resolve_residual_tests {
             span(5, "owner", 10, 1),
         ];
         let components = residual_overlap_components(&spans, &HashSet::new());
-        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.95);
+        let res = resolve_residual_components(&spans, &components, &HashSet::new(), 0.95, 0);
         // Both contested spans dropped; the component is reported unresolved.
         assert_eq!(dropped_names(&res, &spans), vec!["ghost", "owner"]);
+        assert_eq!(res.unresolved_components.len(), 1);
+    }
+
+    /// Gate abstention (MIN_PAIRS). Codex's scenario: a file with a residual
+    /// component but too few uncontested owners to measure -- one anchor `m`,
+    /// zero adjacent pairs -- must NOT let the oracle run on vacuous evidence
+    /// (which would silently drop the real owner `a real` while emitting the
+    /// ghost `z ghost`, or vice versa). With `min_pairs > 0` the gate abstains:
+    /// BOTH contested spans honest-drop and the component surfaces on the
+    /// diagnostics. A `gate_threshold` of 0.0 proves the abstention is driven by
+    /// the pair-count floor, not the ratio (GH #844).
+    #[test]
+    fn gate_abstains_on_too_few_measured_pairs() {
+        let spans = [
+            span(0, "m", 3, 1),      // the lone uncontested owner (0 adjacent pairs)
+            span(1, "a real", 5, 1), // real owner (would sort below the ghost)
+            span(2, "z ghost", 5, 1),
+        ];
+        let components = residual_overlap_components(&spans, &HashSet::new());
+        let res = resolve_residual_components(
+            &spans,
+            &components,
+            &HashSet::new(),
+            0.0,
+            RESIDUAL_ORDERING_MIN_PAIRS,
+        );
+        assert_eq!(dropped_names(&res, &spans), vec!["a real", "z ghost"]);
         assert_eq!(res.unresolved_components.len(), 1);
     }
 }

--- a/src/simlin-engine/src/vdf/section5_dims.rs
+++ b/src/simlin-engine/src/vdf/section5_dims.rs
@@ -275,15 +275,72 @@ pub(super) fn recover_dimension_sets_via_sec5(vdf: &VdfFile) -> Vec<VdfDimension
     if anchors.is_empty() {
         return Vec::new();
     }
-    let sec5 = match vdf.parse_section5_set_stream() {
-        Some((_, entries, _)) => entries,
-        None => return Vec::new(),
-    };
+    // Fast path: the pinned 1:1 anchor/sec5 alignment enables full recovery
+    // (complete roots plus subrange subsequence projection).
+    if let Some(sets) = recover_paired_dimension_sets(vdf, &anchors) {
+        return sets;
+    }
+    // Fallback: when the anchor/sec5 counts disagree (or section 5 is absent)
+    // the subrange subsequence rule cannot run, but complete root dims come
+    // straight from their record field[8] element groups and need no
+    // section 5 at all. Recovering them here mirrors the Python reader, whose
+    // `_recover_record_dimension_sets` emits complete roots independently of
+    // `recover_all_dimension_elements` (the sec5-paired subrange step): the
+    // SimService `Base.vdf` files (18 anchors vs 43 section-5 entries) recover
+    // `country`/`layers`/... this way. Without it the arrayed owners fall back
+    // to numeric element labels and diverge from the Python reader.
+    complete_root_dimension_sets(&anchors)
+}
+
+/// Emit one `VdfDimensionSet` per COMPLETE root dim directly from its record
+/// field[8] element group, with no section-5 dependency (mirrors step 1 of the
+/// Python reader's `_recover_record_dimension_sets`). Deterministic: anchors
+/// arrive from [`recover_anchors`] in `(group_id, name)` order, and the first
+/// occurrence of each name wins.
+///
+/// The keep-first dedup is load-bearing for Rust/Python parity: the Python
+/// mirror applies the identical dedup, without which a duplicate-named complete
+/// anchor would leave two same-name entries there and its cardinality-match
+/// label fallback would drop to numeric labels while this deduped reader emits
+/// real ones. No corpus file has such duplicates, so the two stay in lockstep.
+fn complete_root_dimension_sets(anchors: &[Anchor]) -> Vec<VdfDimensionSet> {
+    let mut seen: HashSet<String> = HashSet::new();
+    let mut out = Vec::new();
+    for anchor in anchors {
+        if !anchor.complete {
+            continue;
+        }
+        if !seen.insert(anchor.name.to_lowercase()) {
+            continue;
+        }
+        out.push(VdfDimensionSet {
+            name: anchor.name.clone(),
+            elements: anchor
+                .elements
+                .iter()
+                .map(|(_, name)| name.clone())
+                .collect(),
+        });
+    }
+    out
+}
+
+/// Full dimension recovery under the pinned 1:1 anchor/section-5 alignment
+/// (complete roots plus subrange subsequence projection). Returns `None` when
+/// section 5 is absent or the anchor/section-5 counts disagree, so the caller
+/// can fall back to the section-5-free complete-root recovery.
+fn recover_paired_dimension_sets(
+    vdf: &VdfFile,
+    anchors: &[Anchor],
+) -> Option<Vec<VdfDimensionSet>> {
+    let sec5 = vdf
+        .parse_section5_set_stream()
+        .map(|(_, entries, _)| entries)?;
     // Anchor/sec5 pairing rule requires a 1:1 match. If the counts
     // disagree, the fixture does not satisfy the pinned alignment rule
-    // and we bail out rather than fabricate a partial recovery.
+    // and we fall back rather than fabricate a partial recovery.
     if anchors.len() != sec5.len() {
-        return Vec::new();
+        return None;
     }
 
     // Collect payloads in the same canonical order (f[8]-ascending).
@@ -381,8 +438,10 @@ pub(super) fn recover_dimension_sets_via_sec5(vdf: &VdfFile) -> Vec<VdfDimension
     }
 
     // Emit results in anchor order for stability across runs.
-    anchors
-        .iter()
-        .filter_map(|a| results.remove(&a.name))
-        .collect()
+    Some(
+        anchors
+            .iter()
+            .filter_map(|a| results.remove(&a.name))
+            .collect(),
+    )
 }

--- a/src/simlin-engine/tests/integration/vdf_parity.rs
+++ b/src/simlin-engine/tests/integration/vdf_parity.rs
@@ -33,14 +33,28 @@ use simlin_engine::common::{Canonical, Ident};
 use simlin_engine::vdf::{VdfFile, VdfKind, probe_vdf_kind};
 
 /// Directories walked for parity fixtures. `test/` is always present; the
-/// zambaqui third_party corpus rides the existence-continue convention
-/// (optional checkout, skipped when absent) because it is the only corpus
-/// source of 0x53 sensitivity runs and of header-0x74 data-grid blocks on a
-/// genuinely third bitmap width (GH #842) -- pinning cross-reader agreement
-/// there keeps the two data-grid implementations in lockstep. The rest of
-/// `third_party/` stays excluded to bound the harness runtime.
+/// two third_party corpora ride the existence-continue convention (optional
+/// checkout, skipped when absent):
+///
+/// - `zambaqui` is the only corpus source of 0x53 sensitivity runs and of
+///   header-0x74 data-grid blocks on a genuinely third bitmap width (GH
+///   #842) -- pinning cross-reader agreement there keeps the two data-grid
+///   implementations in lockstep.
+/// - `spring_2008` is the only corpus source of residual OT-overlap files:
+///   the two SimService `Base.vdf` files, whose 2007-era writer emits
+///   stale-`f[11]` records for unsaved variables that survive descriptor
+///   peeling still in owner-vs-owner conflict (GH #841). Pinning the readers
+///   here keeps the residual-overlap honest-drop identical on both sides
+///   (without it the Python reader would emit both contested names while
+///   Rust dropped one, silently diverging).
+///
+/// The rest of `third_party/` stays excluded to bound the harness runtime.
 fn parity_corpus_roots() -> &'static [&'static str] {
-    &["../../test", "../../third_party/uib_sd/zambaqui"]
+    &[
+        "../../test",
+        "../../third_party/uib_sd/zambaqui",
+        "../../third_party/uib_sd/spring_2008",
+    ]
 }
 
 fn collect_vdf_files(dir: &Path) -> Vec<PathBuf> {

--- a/tools/test_vdf_xray.py
+++ b/tools/test_vdf_xray.py
@@ -2391,6 +2391,28 @@ class ResolveResidualComponentsTests(unittest.TestCase):
         self.assertIn(3, di.descriptor_indices, "ghost must be dropped with no lookups")
         self.assertNotIn(2, di.descriptor_indices, "real owner must be recovered")
 
+    def test_same_name_duplicate_pair_survives_when_ghost_dropped(self):
+        # GH #844: a differently-named ghost drags TWO same-name duplicate
+        # records into a component. The conflict predicate is name-aware, so
+        # once the ghost is dropped the same-name pair is no longer conflicting:
+        # BOTH survive re-resolution and flow to the per-name emission dedup. A
+        # name-blind predicate would honest-drop both, losing the variable.
+        spans = [
+            self._span(0, "a", 1, 1),
+            self._span(1, "z", 9, 1),
+            self._span(2, "m dup", 5, 1),
+            self._span(3, "m dup", 5, 1),
+            self._span(4, "zzz ghost", 5, 1),
+        ]
+        comps = vdf_xray.residual_overlap_components(spans, set())
+        self.assertEqual(len(comps), 1)
+        self.assertEqual(comps[0].span_indices, [2, 3, 4])
+        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0)
+        self.assertEqual(self._dropped_names(res, spans), ["zzz ghost"])
+        self.assertNotIn(2, res.dropped)
+        self.assertNotIn(3, res.dropped)
+        self.assertEqual(res.unresolved_components, [])
+
     def test_gate_abstains_when_owners_not_alphabetical(self):
         spans = [
             self._span(0, "z", 1, 1),

--- a/tools/test_vdf_xray.py
+++ b/tools/test_vdf_xray.py
@@ -1679,6 +1679,56 @@ class StandaloneLookupOnlyDescriptorTests(unittest.TestCase):
         self.assertTrue(diagnostics.standalone_drop_veto_fired)
         self.assertEqual(diagnostics.standalone_drop_vetoed_candidates, 4)
 
+    def test_residual_overlap_honest_drop_on_fixtures(self) -> None:
+        # Stage 1 correctness floor for GH #841. Ref.vdf (and every file whose
+        # overlaps the peel already resolves) has NO residual components, so
+        # the floor is a provable no-op there. SimService/Base.vdf's
+        # stale-f[11] unsaved-variable records survive the peel still in
+        # owner-vs-owner conflict; every such span must be DROPPED (no ghost
+        # `age specific ...` columns, no OT slot claimed by two names), so the
+        # Python reader stops emitting BOTH names for a contested slot and
+        # matches the Rust reader.
+        ref = parse_fixture("test/xmutil_test_models/Ref.vdf")
+        _, ref_diag = vdf_xray.extract_named_results_with_diagnostics(ref)
+        self.assertEqual(ref_diag.residual_overlap, [])
+
+        relpaths = [
+            "third_party/uib_sd/spring_2008/SimService_BUENO/SimService/Model Files/Base.vdf",
+            "third_party/uib_sd/spring_2008/SimService_BUENO/SimService/Model Files/ctxt0001/Base.vdf",
+        ]
+        if not (REPO_ROOT / relpaths[0]).exists():
+            self.skipTest("third_party SimService fixtures not available")
+
+        for relpath in relpaths:
+            with self.subTest(relpath=relpath):
+                vdf = parse_fixture(relpath)
+                spans = vdf_xray.decoded_record_spans(vdf)
+                desc = vdf_xray.identify_descriptor_records(vdf, spans)
+                results, diag = vdf_xray.extract_named_results_with_diagnostics(vdf)
+                self.assertIsNotNone(results)
+                assert results is not None
+
+                # The residual diagnostics fire and name the #841 headline ghost.
+                self.assertTrue(diag.residual_overlap)
+                dropped_names = {
+                    spans[i].name
+                    for component in diag.residual_overlap
+                    for i in component.span_indices
+                }
+                self.assertIn(
+                    "AGE SPECIFIC FERTILITY DISTRIBUTION FUNCTION", dropped_names)
+                for component in diag.residual_overlap:
+                    self.assertTrue(component.contested_ots)
+
+                # No ghost column emitted, and no OT slot claimed twice.
+                names = {result.name for result in results}
+                self.assertFalse(
+                    any(name.lower().startswith("age specific") for name in names))
+                ot_indices = [result.ot_index for result in results]
+                self.assertEqual(
+                    len(ot_indices), len(set(ot_indices)),
+                    "no OT slot may be claimed by two emitted columns")
+
     def test_simservice_stocks_are_not_dropped_as_lookup_only(self) -> None:
         # Regression for the SimService false positives: four real dynamic
         # stocks whose OT starts collide with the lookup-index range must

--- a/tools/test_vdf_xray.py
+++ b/tools/test_vdf_xray.py
@@ -2269,7 +2269,8 @@ class ResolveResidualComponentsTests(unittest.TestCase):
     def test_empty_components_is_noop(self):
         spans = [self._span(0, "a", 1, 1), self._span(1, "b", 2, 1)]
         res = vdf_xray.resolve_residual_components(
-            spans, [], set(), vdf_xray.RESIDUAL_ORDERING_GATE)
+            spans, [], set(), vdf_xray.RESIDUAL_ORDERING_GATE,
+            vdf_xray.RESIDUAL_ORDERING_MIN_PAIRS)
         self.assertFalse(res.dropped)
         self.assertFalse(res.readmitted)
         self.assertEqual(res.unresolved_components, [])
@@ -2285,7 +2286,7 @@ class ResolveResidualComponentsTests(unittest.TestCase):
             self._span(6, "c sun", 6, 1),
         ]
         comps = vdf_xray.residual_overlap_components(spans, set())
-        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0)
+        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0, 0)
         self.assertEqual(self._dropped_names(res, spans), ["age ghost"])
         self.assertFalse(res.readmitted)
         self.assertEqual(res.unresolved_components, [])
@@ -2302,7 +2303,7 @@ class ResolveResidualComponentsTests(unittest.TestCase):
             self._span(7, "z1", 16, 1),
         ]
         comps = vdf_xray.residual_overlap_components(spans, set())
-        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0)
+        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0, 0)
         self.assertEqual(
             self._dropped_names(res, spans),
             ["cat food", "tbl x lookup", "tbl y lookup"])
@@ -2316,7 +2317,7 @@ class ResolveResidualComponentsTests(unittest.TestCase):
             self._span(3, "zzz", 5, 1),
         ]
         comps = vdf_xray.residual_overlap_components(spans, set())
-        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0)
+        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0, 0)
         self.assertEqual(self._dropped_names(res, spans), ["yyy", "zzz"])
         self.assertEqual(len(res.unresolved_components), 1)
         self.assertEqual(res.unresolved_components[0].contested_ots, [5])
@@ -2333,7 +2334,7 @@ class ResolveResidualComponentsTests(unittest.TestCase):
         ]
         phase1 = {6}
         comps = vdf_xray.residual_overlap_components(spans, phase1)
-        res = vdf_xray.resolve_residual_components(spans, comps, phase1, 0.0)
+        res = vdf_xray.resolve_residual_components(spans, comps, phase1, 0.0, 0)
         self.assertEqual(self._dropped_names(res, spans), ["age ghost"])
         self.assertEqual(res.readmitted, {6})
         self.assertEqual(res.unresolved_components, [])
@@ -2345,7 +2346,7 @@ class ResolveResidualComponentsTests(unittest.TestCase):
             self._span(2, "foo lookup", 1, 2),
         ]
         comps = vdf_xray.residual_overlap_components(spans, set())
-        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0)
+        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0, 0)
         self.assertEqual(self._dropped_names(res, spans), ["foo lookup"])
         self.assertEqual(res.unresolved_components, [])
 
@@ -2363,7 +2364,7 @@ class ResolveResidualComponentsTests(unittest.TestCase):
         ]
         phase1 = {7, 8}
         comps = vdf_xray.residual_overlap_components(spans, phase1)
-        res = vdf_xray.resolve_residual_components(spans, comps, phase1, 0.0)
+        res = vdf_xray.resolve_residual_components(spans, comps, phase1, 0.0, 0)
         self.assertEqual(self._dropped_names(res, spans), ["age ghost"])
         self.assertEqual(res.readmitted, {7})
         # d tar overlaps only an un-peeled descriptor, so it stays untouched.
@@ -2381,15 +2382,26 @@ class ResolveResidualComponentsTests(unittest.TestCase):
             def section6_lookup_records(self):
                 return []
 
+        # Nine alphabetically-ordered uncontested owners (>= MIN_PAIRS pairs,
+        # ratio 1.0) so the gate passes on real evidence; prev `e own`@4 / next
+        # `n own`@6 bracket the slot-5 conflict, keeping `m real`, dropping the
+        # ghost `z ghost` (which sorts past `n own`).
         spans = [
-            self._span(0, "a owner", 1, 1),
-            self._span(1, "z owner", 9, 1),
-            self._span(2, "m real", 5, 1),    # fits [a owner, z owner] -> recovered
-            self._span(3, "zzz ghost", 5, 1),  # sorts past z owner -> dropped
+            self._span(0, "b own", 1, 1),
+            self._span(1, "c own", 2, 1),
+            self._span(2, "d own", 3, 1),
+            self._span(3, "e own", 4, 1),
+            self._span(4, "m real", 5, 1),   # fits [e own, n own] -> recovered
+            self._span(5, "z ghost", 5, 1),  # sorts past n own -> dropped
+            self._span(6, "n own", 6, 1),
+            self._span(7, "o own", 7, 1),
+            self._span(8, "p own", 8, 1),
+            self._span(9, "q own", 9, 1),
+            self._span(10, "r own", 10, 1),
         ]
         di = vdf_xray.identify_descriptor_records(_NoLookupVdf(), spans)
-        self.assertIn(3, di.descriptor_indices, "ghost must be dropped with no lookups")
-        self.assertNotIn(2, di.descriptor_indices, "real owner must be recovered")
+        self.assertIn(5, di.descriptor_indices, "ghost must be dropped with no lookups")
+        self.assertNotIn(4, di.descriptor_indices, "real owner must be recovered")
 
     def test_same_name_duplicate_pair_survives_when_ghost_dropped(self):
         # GH #844: a differently-named ghost drags TWO same-name duplicate
@@ -2407,13 +2419,15 @@ class ResolveResidualComponentsTests(unittest.TestCase):
         comps = vdf_xray.residual_overlap_components(spans, set())
         self.assertEqual(len(comps), 1)
         self.assertEqual(comps[0].span_indices, [2, 3, 4])
-        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0)
+        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0, 0)
         self.assertEqual(self._dropped_names(res, spans), ["zzz ghost"])
         self.assertNotIn(2, res.dropped)
         self.assertNotIn(3, res.dropped)
         self.assertEqual(res.unresolved_components, [])
 
     def test_gate_abstains_when_owners_not_alphabetical(self):
+        # RATIO gate: low alphabetical consistency -> abstain. min_pairs=0
+        # isolates the ratio side.
         spans = [
             self._span(0, "z", 1, 1),
             self._span(1, "a", 2, 1),
@@ -2423,8 +2437,26 @@ class ResolveResidualComponentsTests(unittest.TestCase):
             self._span(5, "owner", 10, 1),
         ]
         comps = vdf_xray.residual_overlap_components(spans, set())
-        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.95)
+        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.95, 0)
         self.assertEqual(self._dropped_names(res, spans), ["ghost", "owner"])
+        self.assertEqual(len(res.unresolved_components), 1)
+
+    def test_gate_abstains_on_too_few_measured_pairs(self):
+        # MIN_PAIRS gate (GH #844, codex round 3): one uncontested anchor `m`
+        # (0 adjacent pairs) is too little evidence, so the oracle must NOT run
+        # (which would silently drop the real `a real` while keeping the ghost
+        # `z ghost`). With the production floor the gate abstains: BOTH contested
+        # spans honest-drop and the component surfaces on diagnostics.
+        # gate_threshold=0.0 proves the pair-count floor drives it, not the ratio.
+        spans = [
+            self._span(0, "m", 3, 1),
+            self._span(1, "a real", 5, 1),
+            self._span(2, "z ghost", 5, 1),
+        ]
+        comps = vdf_xray.residual_overlap_components(spans, set())
+        res = vdf_xray.resolve_residual_components(
+            spans, comps, set(), 0.0, vdf_xray.RESIDUAL_ORDERING_MIN_PAIRS)
+        self.assertEqual(self._dropped_names(res, spans), ["a real", "z ghost"])
         self.assertEqual(len(res.unresolved_components), 1)
 
 

--- a/tools/test_vdf_xray.py
+++ b/tools/test_vdf_xray.py
@@ -2371,6 +2371,26 @@ class ResolveResidualComponentsTests(unittest.TestCase):
         self.assertNotIn(8, res.readmitted)
         self.assertEqual(res.unresolved_components, [])
 
+    def test_residual_pass_runs_on_lookup_free_file(self):
+        # GH #844: identify_descriptor_records must reach the residual pass even
+        # when the file has zero lookup records. Before the fix it early-returned
+        # on n_lookups == 0, so a differently-named owner-vs-owner OT conflict on
+        # such a file emitted BOTH names. The n_lookups == 0 path touches only
+        # `section6_lookup_records`, so a tiny stub file suffices.
+        class _NoLookupVdf:
+            def section6_lookup_records(self):
+                return []
+
+        spans = [
+            self._span(0, "a owner", 1, 1),
+            self._span(1, "z owner", 9, 1),
+            self._span(2, "m real", 5, 1),    # fits [a owner, z owner] -> recovered
+            self._span(3, "zzz ghost", 5, 1),  # sorts past z owner -> dropped
+        ]
+        di = vdf_xray.identify_descriptor_records(_NoLookupVdf(), spans)
+        self.assertIn(3, di.descriptor_indices, "ghost must be dropped with no lookups")
+        self.assertNotIn(2, di.descriptor_indices, "real owner must be recovered")
+
     def test_gate_abstains_when_owners_not_alphabetical(self):
         spans = [
             self._span(0, "z", 1, 1),

--- a/tools/test_vdf_xray.py
+++ b/tools/test_vdf_xray.py
@@ -1679,15 +1679,16 @@ class StandaloneLookupOnlyDescriptorTests(unittest.TestCase):
         self.assertTrue(diagnostics.standalone_drop_veto_fired)
         self.assertEqual(diagnostics.standalone_drop_vetoed_candidates, 4)
 
-    def test_residual_overlap_honest_drop_on_fixtures(self) -> None:
-        # Stage 1 correctness floor for GH #841. Ref.vdf (and every file whose
-        # overlaps the peel already resolves) has NO residual components, so
-        # the floor is a provable no-op there. SimService/Base.vdf's
+    def test_residual_overlap_recovery_on_fixtures(self) -> None:
+        # Stage 2 recovery for GH #841. Ref.vdf (and every file whose overlaps
+        # the peel already resolves) has NO residual components, so the whole
+        # re-resolution is a provable no-op there. SimService/Base.vdf's
         # stale-f[11] unsaved-variable records survive the peel still in
-        # owner-vs-owner conflict; every such span must be DROPPED (no ghost
-        # `age specific ...` columns, no OT slot claimed by two names), so the
-        # Python reader stops emitting BOTH names for a contested slot and
-        # matches the Rust reader.
+        # owner-vs-owner conflict; the re-resolution recovers every real owner
+        # (dropping only the ghosts) and, because every conflict is
+        # adjudicated, leaves NOTHING honest-dropped -- so the residual
+        # diagnostics come back empty, no ghost column is emitted, and no OT
+        # slot is claimed twice.
         ref = parse_fixture("test/xmutil_test_models/Ref.vdf")
         _, ref_diag = vdf_xray.extract_named_results_with_diagnostics(ref)
         self.assertEqual(ref_diag.residual_overlap, [])
@@ -1699,35 +1700,102 @@ class StandaloneLookupOnlyDescriptorTests(unittest.TestCase):
         if not (REPO_ROOT / relpaths[0]).exists():
             self.skipTest("third_party SimService fixtures not available")
 
+        # The EXACT 41 ghosts the re-resolution must drop on both fixtures
+        # (lowercased). Pinning the full set plus the exact emitted-column count
+        # below means a wrongly-recovered unlisted ghost cannot slip past.
+        ghosts = [
+            "age specific fertility distribution function",
+            "china future gdp growth rate",
+            "coal capacity utilisation in production table",
+            "coal fraction discoverable table",
+            "dice ipcc other rad forcing table",
+            "effect of technology on productivity of investment in coal production table",
+            "maize fraction table",
+            "nuclear generation efficiency table",
+            "oil substitutability effect on oil import",
+            "pc meat demand function",
+            "pc fish demand data",
+            "pc fish demand function",
+            "qdbtu to mb",
+            "row coal demand function",
+            "renewable energy consumer real price",
+            "renewable resource price per mbtu",
+            "wood value added per ton",
+            "c total population table",
+            "elasticity of fdi to fiscal pressure",
+            "electricity net export table",
+            "extra heavy table",
+            "forestry production in cubic meters",
+            "gas generation efficiency table",
+            "gas to liquids table",
+            "hydro electricity generation in bkwh table",
+            "meat value added per ton table",
+            "nuclear electricity demand in bkwh",
+            "overall carbon tax table",
+            "pc bushel domestic consumption non ethanol",
+            "petroleum generation efficiency table",
+            "private capital transfers over gdp table",
+            "private factor income table",
+            "private transfers table",
+            "relative china technology",
+            "renewable electricity price",
+            "renewable portfolio standard table",
+            "residential energy conservation",
+            "share of electricity for freight transportation",
+            "share of electricity for urban and commuter transportation",
+            "total fertility rate",
+            "value added agriculture products table",
+        ]
+        self.assertEqual(len(ghosts), 41)
+        reals = [
+            "Indicated China GDP",
+            "indicated per capita fish demand",
+            "indicated row Coal demand",
+            "industrial electricity demand in BKWH",
+        ]
         for relpath in relpaths:
             with self.subTest(relpath=relpath):
                 vdf = parse_fixture(relpath)
-                spans = vdf_xray.decoded_record_spans(vdf)
-                desc = vdf_xray.identify_descriptor_records(vdf, spans)
                 results, diag = vdf_xray.extract_named_results_with_diagnostics(vdf)
                 self.assertIsNotNone(results)
                 assert results is not None
 
-                # The residual diagnostics fire and name the #841 headline ghost.
-                self.assertTrue(diag.residual_overlap)
-                dropped_names = {
-                    spans[i].name
-                    for component in diag.residual_overlap
-                    for i in component.span_indices
-                }
-                self.assertIn(
-                    "AGE SPECIFIC FERTILITY DISTRIBUTION FUNCTION", dropped_names)
-                for component in diag.residual_overlap:
-                    self.assertTrue(component.contested_ots)
+                # Every conflict is adjudicated, so nothing is honest-dropped.
+                self.assertEqual(diag.residual_overlap, [])
 
-                # No ghost column emitted, and no OT slot claimed twice.
                 names = {result.name for result in results}
-                self.assertFalse(
-                    any(name.lower().startswith("age specific") for name in names))
+                lower = {name.lower() for name in names}
+                for ghost in ghosts:
+                    self.assertFalse(
+                        any(name == ghost or name.startswith(ghost + "[") for name in lower),
+                        f"ghost {ghost!r} must not be emitted")
+                for real in reals:
+                    self.assertTrue(
+                        real in names or any(n.startswith(real + "[") for n in names),
+                        f"real owner {real!r} must be recovered")
+
+                # OT-122 orphaned (its ghost `c total population table` dropped),
+                # Population fully recovered, no OT slot claimed twice.
                 ot_indices = [result.ot_index for result in results]
                 self.assertEqual(
                     len(ot_indices), len(set(ot_indices)),
                     "no OT slot may be claimed by two emitted columns")
+                # Exact emitted-column count: a wrongly-recovered ghost would push
+                # it to 1236, a wrongly-dropped real below 1235.
+                self.assertEqual(
+                    len(results), 1235,
+                    "exact emitted-column count changed (residual recovery regressed)")
+                self.assertEqual(
+                    sum(1 for name in names if name.startswith("Population[")), 164,
+                    "recovered Population must expose all 164 array elements")
+                oil = sorted(
+                    result.values[0]
+                    for result in results
+                    if result.name.lower().startswith("c identified oil reserve["))
+                self.assertEqual(len(oil), 2)
+                # Initial reserves are context-independent stock initial values.
+                self.assertAlmostEqual(oil[0], 7900.0, delta=0.01)
+                self.assertAlmostEqual(oil[1], 51000.0, delta=0.01)
 
     def test_simservice_stocks_are_not_dropped_as_lookup_only(self) -> None:
         # Regression for the SimService false positives: four real dynamic
@@ -2181,6 +2249,141 @@ class DataGridBitmapTests(unittest.TestCase):
         # only widens the stored f32s, so the pins are exact-equality.
         self.assertEqual(series[0], 0.6202020049095154)
         self.assertEqual(series[-1], 2.086980104446411)
+
+
+class ResolveResidualComponentsTests(unittest.TestCase):
+    """Stage 2 re-resolution ordering oracle (`resolve_residual_components`),
+    mirroring the Rust `resolve_residual_tests` module span-for-span so the two
+    readers stay in lockstep on synthetic traps as well as on the corpus."""
+
+    @staticmethod
+    def _span(rec_idx: int, name: str, start: int, length: int) -> vdf_xray.DecodedRecordSpan:
+        return vdf_xray.DecodedRecordSpan(
+            rec_idx=rec_idx, name_idx=rec_idx, name=name, start=start,
+            end=start + length, shape_code=0, sort_key=0, slot_ref=0,
+            group_id=0, has_sentinel=False, ot_codes=[])
+
+    def _dropped_names(self, res, spans):
+        return sorted(s.name for s in spans if s.rec_idx in res.dropped)
+
+    def test_empty_components_is_noop(self):
+        spans = [self._span(0, "a", 1, 1), self._span(1, "b", 2, 1)]
+        res = vdf_xray.resolve_residual_components(
+            spans, [], set(), vdf_xray.RESIDUAL_ORDERING_GATE)
+        self.assertFalse(res.dropped)
+        self.assertFalse(res.readmitted)
+        self.assertEqual(res.unresolved_components, [])
+
+    def test_run_boundary_prev_only_drops_wide_ghost(self):
+        spans = [
+            self._span(0, "c gas", 1, 1),
+            self._span(1, "agri", 30, 1),
+            self._span(2, "age ghost", 3, 4),
+            self._span(3, "c oil", 3, 1),
+            self._span(4, "c pig", 4, 1),
+            self._span(5, "c rat", 5, 1),
+            self._span(6, "c sun", 6, 1),
+        ]
+        comps = vdf_xray.residual_overlap_components(spans, set())
+        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0)
+        self.assertEqual(self._dropped_names(res, spans), ["age ghost"])
+        self.assertFalse(res.readmitted)
+        self.assertEqual(res.unresolved_components, [])
+
+    def test_recovered_anchor_bracket_resolves_scalar_pair(self):
+        spans = [
+            self._span(0, "tbl x lookup", 9, 2),
+            self._span(1, "ind a", 10, 1),
+            self._span(2, "ind b", 12, 1),
+            self._span(3, "cat food", 12, 1),
+            self._span(4, "tbl y lookup", 13, 2),
+            self._span(5, "ind c", 14, 1),
+            self._span(6, "a1", 11, 1),
+            self._span(7, "z1", 16, 1),
+        ]
+        comps = vdf_xray.residual_overlap_components(spans, set())
+        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0)
+        self.assertEqual(
+            self._dropped_names(res, spans),
+            ["cat food", "tbl x lookup", "tbl y lookup"])
+        self.assertEqual(res.unresolved_components, [])
+
+    def test_inconclusive_conflict_is_honest_dropped(self):
+        spans = [
+            self._span(0, "a", 1, 1),
+            self._span(1, "b", 9, 1),
+            self._span(2, "yyy", 5, 1),
+            self._span(3, "zzz", 5, 1),
+        ]
+        comps = vdf_xray.residual_overlap_components(spans, set())
+        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0)
+        self.assertEqual(self._dropped_names(res, spans), ["yyy", "zzz"])
+        self.assertEqual(len(res.unresolved_components), 1)
+        self.assertEqual(res.unresolved_components[0].contested_ots, [5])
+
+    def test_unpeeled_descriptor_is_readmitted_when_kept(self):
+        spans = [
+            self._span(0, "c gas", 1, 1),
+            self._span(1, "agri", 20, 1),
+            self._span(2, "age ghost", 8, 4),
+            self._span(3, "c pig", 9, 1),
+            self._span(4, "c rat", 10, 1),
+            self._span(5, "c sun", 11, 1),
+            self._span(6, "c oil", 7, 2),
+        ]
+        phase1 = {6}
+        comps = vdf_xray.residual_overlap_components(spans, phase1)
+        res = vdf_xray.resolve_residual_components(spans, comps, phase1, 0.0)
+        self.assertEqual(self._dropped_names(res, spans), ["age ghost"])
+        self.assertEqual(res.readmitted, {6})
+        self.assertEqual(res.unresolved_components, [])
+
+    def test_lexical_peel_drops_lookupish_names(self):
+        spans = [
+            self._span(0, "real var", 1, 1),
+            self._span(1, "real var2", 2, 1),
+            self._span(2, "foo lookup", 1, 2),
+        ]
+        comps = vdf_xray.residual_overlap_components(spans, set())
+        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.0)
+        self.assertEqual(self._dropped_names(res, spans), ["foo lookup"])
+        self.assertEqual(res.unresolved_components, [])
+
+    def test_chained_descriptor_is_not_transitively_unpeeled(self):
+        spans = [
+            self._span(0, "c gas", 1, 1),
+            self._span(1, "zz", 30, 1),
+            self._span(2, "age ghost", 5, 5),
+            self._span(3, "d1", 5, 1),
+            self._span(4, "d2", 6, 1),
+            self._span(5, "d3", 7, 1),
+            self._span(6, "d4", 8, 1),
+            self._span(7, "d oil", 9, 3),
+            self._span(8, "d tar", 11, 2),
+        ]
+        phase1 = {7, 8}
+        comps = vdf_xray.residual_overlap_components(spans, phase1)
+        res = vdf_xray.resolve_residual_components(spans, comps, phase1, 0.0)
+        self.assertEqual(self._dropped_names(res, spans), ["age ghost"])
+        self.assertEqual(res.readmitted, {7})
+        # d tar overlaps only an un-peeled descriptor, so it stays untouched.
+        self.assertNotIn(8, res.dropped)
+        self.assertNotIn(8, res.readmitted)
+        self.assertEqual(res.unresolved_components, [])
+
+    def test_gate_abstains_when_owners_not_alphabetical(self):
+        spans = [
+            self._span(0, "z", 1, 1),
+            self._span(1, "a", 2, 1),
+            self._span(2, "m", 3, 1),
+            self._span(3, "b", 4, 1),
+            self._span(4, "ghost", 10, 1),
+            self._span(5, "owner", 10, 1),
+        ]
+        comps = vdf_xray.residual_overlap_components(spans, set())
+        res = vdf_xray.resolve_residual_components(spans, comps, set(), 0.95)
+        self.assertEqual(self._dropped_names(res, spans), ["ghost", "owner"])
+        self.assertEqual(len(res.unresolved_components), 1)
 
 
 if __name__ == "__main__":

--- a/tools/vdf_xray.py
+++ b/tools/vdf_xray.py
@@ -1674,6 +1674,17 @@ def _recover_record_dimension_sets(vdf: VdfFile) -> list[RecoveredDimensionSet]:
             continue
         if len(ordered_indices) < 2:
             continue
+        # Deduplicate same-named complete anchors, keeping the first (a
+        # dimension appears once in the recovered set). This mirrors the Rust
+        # reader's `section5_dims.rs::complete_root_dimension_sets`; without it
+        # a duplicate-named complete anchor would leave two same-name entries
+        # here, and the cardinality-match label fallback below
+        # (`len(matches) == 1`) would then see two matches and drop to numeric
+        # labels while the deduped Rust reader emitted real ones -- a parity
+        # divergence. No corpus file has such duplicates (both readers stay in
+        # lockstep), so this is defense-in-depth that keeps them aligned.
+        if anchor.name.lower() in seen:
+            continue
 
         dims.append(RecoveredDimensionSet(
             name=anchor.name,
@@ -1816,6 +1827,21 @@ def _name_looks_lookupish(name: str) -> bool:
 
 
 @dataclass
+class ResidualOverlapComponent:
+    """
+    A residual OT-overlap component: two or more DIFFERENTLY-named decoded
+    spans that still claim a shared OT slot after descriptor peeling and the
+    standalone lookup-only drop. Stage 1 drops every span in the component
+    from emission (honest missing data over a silent alphabetical first-claim
+    win); the component is retained here so a later stage can re-resolve it.
+
+    Mirrors Rust `record_results.rs::ResidualOverlapComponent`.
+    """
+    span_indices: list[int]
+    contested_ots: list[int]
+
+
+@dataclass
 class DescriptorIdentification:
     """
     Result of identifying graphical-function descriptor records.
@@ -1824,11 +1850,18 @@ class DescriptorIdentification:
     when the standalone lookup-only drop's per-file coherence veto withheld
     candidates (SimService/Base.vdf is the canonical case) -- a silent veto
     would let a future file quietly resurrect ghost columns.
+
+    `residual_overlap_components` records the still-conflicted spans dropped by
+    the residual-overlap floor: every span in each component is added to
+    `descriptor_indices` and therefore NOT emitted, so no OT slot is resolved
+    by alphabetical emission order. Retained as data so a later re-resolution
+    stage can narrow the drop before falling back to this floor.
     """
     descriptor_indices: set[int]
     used_f10_fallback: bool
     standalone_drop_veto_fired: bool = False
     standalone_drop_vetoed_candidates: int = 0
+    residual_overlap_components: list[ResidualOverlapComponent] = field(default_factory=list)
 
 
 @dataclass
@@ -1997,11 +2030,24 @@ def identify_descriptor_records(
     )
     descriptor_indices.update(standalone.dropped)
 
+    # Residual-overlap floor. After peeling overlap-path descriptors and
+    # dropping standalone lookup-only tables, some differently-named spans can
+    # STILL claim a shared OT slot -- an owner-vs-owner conflict no structural
+    # signal resolved. Compute those components as data, then (Stage 1) drop
+    # every span in them so extraction never emits BOTH names for a contested
+    # slot. A later stage re-resolves a component before this drop. Mirrors the
+    # Rust reference (record_results.rs `residual_overlap_components`).
+    residual_components = residual_overlap_components(spans, descriptor_indices)
+    for component in residual_components:
+        for span_idx in component.span_indices:
+            descriptor_indices.add(spans[span_idx].rec_idx)
+
     return DescriptorIdentification(
         descriptor_indices=descriptor_indices,
         used_f10_fallback=used_f10_fallback,
         standalone_drop_veto_fired=standalone.veto_fired,
         standalone_drop_vetoed_candidates=standalone.vetoed_candidates,
+        residual_overlap_components=residual_components,
     )
 
 
@@ -2158,6 +2204,102 @@ def standalone_lookup_only_descriptors(
             vetoed_candidates=len(candidates),
         )
     return StandaloneDropOutcome(dropped=dropped)
+
+
+def residual_overlap_components(
+    spans: list[DecodedRecordSpan],
+    dropped: set[int],
+) -> list[ResidualOverlapComponent]:
+    """
+    Detect residual OT-overlap among the decoded spans that survive descriptor
+    peeling and the standalone lookup-only drop.
+
+    `identify_descriptor_records` resolves the owner/descriptor f[11] union for
+    the overlaps a structural signal can adjudicate (the lexical lookup-def
+    name test, the section-6 forward link). On the 2007-era SimService writer
+    that is not enough: it emits section-1 records for model variables that
+    were NOT saved in the run (data variables, lookup/table definitions,
+    supplementary vars), each carrying a stale f[11] (plausibly the variable's
+    slot in the full runtime array, while the file's OT holds only saved
+    variables). The stale f[11]-as-OT-start spans land on arbitrary saved
+    slots; most fail the `f11 < n_lookups` candidacy gate, so the overlap peel
+    can neither remove them nor detect that it failed, and the component exits
+    still conflicted (see docs/design/vdf.md "Residual OT-overlap").
+
+    Emitting both spans would let alphabetical column order silently pick the
+    OT owner and scatter one variable's data under another variable's name.
+    This returns the residual components; the caller drops every span in them.
+
+    Conflict is DIFFERENT-name only: two spans of the same name that overlap
+    are the ordinary same-variable duplicate the emitter's per-name dedup
+    already resolves (lowest start wins), not a cross-variable ownership
+    conflict. Every span sharing a genuinely-contested slot (one carrying two
+    distinct names) is pulled into the component and dropped, since the whole
+    slot is ambiguous. Mirrors Rust
+    `record_results.rs::residual_overlap_components`.
+    """
+    # slot -> surviving span indices claiming it.
+    by_slot: dict[int, list[int]] = {}
+    for i, span in enumerate(spans):
+        if span.rec_idx in dropped:
+            continue
+        for ot in range(span.start, span.end):
+            by_slot.setdefault(ot, []).append(i)
+
+    parent = list(range(len(spans)))
+
+    def find(x: int) -> int:
+        while parent[x] != x:
+            parent[x] = parent[parent[x]]
+            x = parent[x]
+        return x
+
+    def union(x: int, y: int) -> None:
+        px, py = find(x), find(y)
+        if px != py:
+            parent[px] = py
+
+    conflicted: set[int] = set()
+    contested_slot_reps: list[tuple[int, int]] = []  # (ot, rep span idx)
+    for ot, slot_spans in by_slot.items():
+        distinct_names = any(
+            spans[slot_spans[a]].name != spans[slot_spans[b]].name
+            for a in range(len(slot_spans))
+            for b in range(a + 1, len(slot_spans))
+        )
+        if not distinct_names:
+            continue
+        base = slot_spans[0]
+        for other in slot_spans:
+            union(base, other)
+            conflicted.add(other)
+        contested_slot_reps.append((ot, base))
+
+    if not conflicted:
+        return []
+
+    spans_by_root: dict[int, list[int]] = {}
+    for i in conflicted:
+        spans_by_root.setdefault(find(i), []).append(i)
+    ots_by_root: dict[int, list[int]] = {}
+    for ot, rep in contested_slot_reps:
+        ots_by_root.setdefault(find(rep), []).append(ot)
+
+    components: list[ResidualOverlapComponent] = []
+    for root, span_indices in spans_by_root.items():
+        span_indices.sort()
+        contested_ots = sorted(set(ots_by_root.get(root, [])))
+        components.append(ResidualOverlapComponent(
+            span_indices=span_indices,
+            contested_ots=contested_ots,
+        ))
+    # Deterministic order (dict iteration is insertion-ordered but the roots
+    # are not meaningful): by first contested OT, then by first span index.
+    components.sort(key=lambda c: (
+        c.contested_ots[0] if c.contested_ots else math.inf,
+        c.span_indices[0] if c.span_indices else math.inf,
+    ))
+    return components
 
 
 def _array_element_labels_for_span(
@@ -2487,6 +2629,14 @@ class NamedResultsDiagnostics:
     # Rust reader's `VdfData::unreconciled_ots`; empty on every tracked
     # corpus file (GH #842).
     bitmap_unreconciled_ots: list[int] = field(default_factory=list)
+    # Residual OT-overlap: differently-named decoded spans that still claim a
+    # shared OT slot after descriptor peeling and the standalone lookup-only
+    # drop. Every such span is DROPPED from emission (honest missing data over
+    # a silent alphabetical first-claim win). Empty on every tracked corpus
+    # file except the two SimService Base.vdf files. Mirrors the Rust reader's
+    # `DescriptorIdentification.residual_overlap_components` (span-index based;
+    # the name-resolved analogue is Rust `VdfFile::residual_overlap_diagnostics`).
+    residual_overlap: list[ResidualOverlapComponent] = field(default_factory=list)
 
 
 def extract_named_results_with_diagnostics(
@@ -2538,6 +2688,7 @@ def extract_named_results_with_diagnostics(
         desc_id.standalone_drop_vetoed_candidates
     )
     diagnostics.bitmap_unreconciled_ots = vdf.unreconciled_data_blocks()
+    diagnostics.residual_overlap = desc_id.residual_overlap_components
 
     owner_spans = [s for s in spans if s.rec_idx not in desc_id.descriptor_indices]
 

--- a/tools/vdf_xray.py
+++ b/tools/vdf_xray.py
@@ -1925,7 +1925,8 @@ def identify_descriptor_records(
         # same result the Rust reader's unconditional residual pass produces.
         residual_components = residual_overlap_components(spans, set())
         resolution = resolve_residual_components(
-            spans, residual_components, set(), RESIDUAL_ORDERING_GATE
+            spans, residual_components, set(), RESIDUAL_ORDERING_GATE,
+            RESIDUAL_ORDERING_MIN_PAIRS,
         )
         return DescriptorIdentification(
             descriptor_indices=set(resolution.dropped),
@@ -2061,7 +2062,8 @@ def identify_descriptor_records(
     phase1_descriptors = set(descriptor_indices)
     residual_components = residual_overlap_components(spans, descriptor_indices)
     resolution = resolve_residual_components(
-        spans, residual_components, phase1_descriptors, RESIDUAL_ORDERING_GATE
+        spans, residual_components, phase1_descriptors, RESIDUAL_ORDERING_GATE,
+        RESIDUAL_ORDERING_MIN_PAIRS,
     )
     descriptor_indices -= resolution.readmitted
     descriptor_indices |= resolution.dropped
@@ -2336,6 +2338,19 @@ def residual_overlap_components(
 # The bar is a principled "overwhelming majority", not tuned to any one file.
 RESIDUAL_ORDERING_GATE = 0.95
 
+# Minimum number of adjacent uncontested-owner pairs a file must have for the
+# ordering oracle to run. Below it the oracle abstains (the component
+# honest-drops with diagnostics), because a ratio measured over one or two pairs
+# carries no real evidence -- with fewer than two owners the ratio is vacuously
+# 1.0 and would pass the gate with zero measured support. The exact value is NOT
+# corpus-supported: any floor between 2 and ~800 is indistinguishable, since the
+# only component-bearing files (the two SimService Base.vdf) measure ~840 pairs.
+# It is cheap fail-safe insurance -- abstention costs only recovery, never
+# correctness -- and below ~20 pairs the 0.95 ratio already demands near-perfect
+# ordering; this floor just forbids the degenerate zero/one-pair case outright.
+# Mirrors Rust `record_results.rs::RESIDUAL_ORDERING_MIN_PAIRS`.
+RESIDUAL_ORDERING_MIN_PAIRS = 8
+
 
 @dataclass
 class ResidualResolution:
@@ -2453,6 +2468,7 @@ def resolve_residual_components(
     components: list[ResidualOverlapComponent],
     phase1_descriptors: set[int],
     gate_threshold: float,
+    min_pairs: int,
 ) -> ResidualResolution:
     """
     Re-resolve each residual-overlap component from scratch, recovering the real
@@ -2470,10 +2486,14 @@ def resolve_residual_components(
         an owner becomes an anchor for its neighbours, then
     (d) honest-drop anything still in conflict (surfaced on the diagnostics).
 
-    The whole procedure is gated per file: if the uncontested owners do not
-    exhibit the alphabetical-allocation invariant (`gate_threshold`), the oracle
+    The whole procedure is gated per file: the oracle runs only when the
+    uncontested owners supply at least `min_pairs` adjacent pairs AND exhibit the
+    alphabetical-allocation invariant (ratio >= `gate_threshold`). Otherwise it
     abstains and every residual span is honest-dropped (Stage 1 semantics), so a
-    file that does not follow the invariant is never mis-adjudicated.
+    file that does not follow the invariant -- or offers too little evidence to
+    tell -- is never mis-adjudicated. (Production passes `RESIDUAL_ORDERING_GATE`
+    / `RESIDUAL_ORDERING_MIN_PAIRS`; oracle-mechanics unit tests pass 0.0 / 0 to
+    open the gate, exactly as they already open the ratio side.)
 
     Mirrors Rust `record_results.rs::resolve_residual_components`.
     """
@@ -2492,9 +2512,12 @@ def resolve_residual_components(
     )
     uncontested_starts = [s.start for s in uncontested]
 
-    # Gate: abstain (honest-drop all) when the file does not exhibit the
-    # alphabetical invariant.
-    if _residual_alphabetical_consistency(uncontested) < gate_threshold:
+    # Gate: abstain (honest-drop all) when the file offers too few
+    # uncontested-owner pairs to measure, OR does not exhibit the alphabetical
+    # invariant. The pair-count check is FIRST so the vacuous <2-owner case
+    # (where the ratio is 1.0) can never pass on zero evidence.
+    n_pairs = max(len(uncontested) - 1, 0)
+    if n_pairs < min_pairs or _residual_alphabetical_consistency(uncontested) < gate_threshold:
         for c in components:
             for i in c.span_indices:
                 dropped.add(spans[i].rec_idx)

--- a/tools/vdf_xray.py
+++ b/tools/vdf_xray.py
@@ -16,6 +16,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import bisect
 from itertools import product
 import json
 import math
@@ -2030,24 +2031,29 @@ def identify_descriptor_records(
     )
     descriptor_indices.update(standalone.dropped)
 
-    # Residual-overlap floor. After peeling overlap-path descriptors and
+    # Residual-overlap re-resolution. After peeling overlap-path descriptors and
     # dropping standalone lookup-only tables, some differently-named spans can
     # STILL claim a shared OT slot -- an owner-vs-owner conflict no structural
-    # signal resolved. Compute those components as data, then (Stage 1) drop
-    # every span in them so extraction never emits BOTH names for a contested
-    # slot. A later stage re-resolves a component before this drop. Mirrors the
-    # Rust reference (record_results.rs `residual_overlap_components`).
+    # signal resolved. Compute those components as data, then re-resolve each
+    # from scratch (lexical peel of table names + the alphabetical-ordering
+    # oracle), recovering the real owners and dropping only the ghosts. Whatever
+    # the oracle cannot adjudicate is honest-dropped and surfaced on the
+    # diagnostics. Mirrors the Rust reference (record_results.rs
+    # `residual_overlap_components` + `resolve_residual_components`).
+    phase1_descriptors = set(descriptor_indices)
     residual_components = residual_overlap_components(spans, descriptor_indices)
-    for component in residual_components:
-        for span_idx in component.span_indices:
-            descriptor_indices.add(spans[span_idx].rec_idx)
+    resolution = resolve_residual_components(
+        spans, residual_components, phase1_descriptors, RESIDUAL_ORDERING_GATE
+    )
+    descriptor_indices -= resolution.readmitted
+    descriptor_indices |= resolution.dropped
 
     return DescriptorIdentification(
         descriptor_indices=descriptor_indices,
         used_f10_fallback=used_f10_fallback,
         standalone_drop_veto_fired=standalone.veto_fired,
         standalone_drop_vetoed_candidates=standalone.vetoed_candidates,
-        residual_overlap_components=residual_components,
+        residual_overlap_components=resolution.unresolved_components,
     )
 
 
@@ -2300,6 +2306,256 @@ def residual_overlap_components(
         c.span_indices[0] if c.span_indices else math.inf,
     ))
     return components
+
+
+# Minimum fraction of adjacent uncontested-owner pairs (sorted by OT) that must
+# be alphabetically ordered for the ordering oracle to run on a file. Vensim
+# allocates OT slots in case-insensitive alphabetical order within a run, so a
+# genuine run file's uncontested owners are overwhelmingly ordered (the four
+# probed corpus files measure 98.6-99.6%; the few percent of breaks are run
+# boundaries). A file below this bar does not exhibit the invariant, so the
+# oracle abstains and every residual span is honest-dropped (Stage 1 semantics).
+# The bar is a principled "overwhelming majority", not tuned to any one file.
+RESIDUAL_ORDERING_GATE = 0.95
+
+
+@dataclass
+class ResidualResolution:
+    """
+    Outcome of re-resolving the residual-overlap components.
+
+    `dropped` are record indices the re-resolution drops (ghosts + honest-drop
+    fallback). `readmitted` are record indices that phase 1 peeled but the
+    re-resolution recovered as real owners (e.g. `c Identified Oil Reserve`).
+    `unresolved_components` are the residual components' honest-dropped
+    remainder (the spans the oracle could not adjudicate), surfaced on the
+    diagnostics; empty when every component fully resolves. Mirrors Rust
+    `record_results.rs::ResidualResolution`.
+    """
+    dropped: set[int]
+    readmitted: set[int]
+    unresolved_components: list[ResidualOverlapComponent]
+
+
+def _residual_alphabetical_consistency(uncontested_by_ot: list[DecodedRecordSpan]) -> float:
+    """Fraction of adjacent OT-sorted uncontested-owner pairs that are
+    name-ordered -- the measured strength of Vensim's alphabetical OT
+    allocation on this file. 1.0 when there are fewer than two owners."""
+    if len(uncontested_by_ot) < 2:
+        return 1.0
+    ok = sum(
+        1 for a, b in zip(uncontested_by_ot, uncontested_by_ot[1:])
+        if _vensim_sort_key(a.name) <= _vensim_sort_key(b.name)
+    )
+    return ok / (len(uncontested_by_ot) - 1)
+
+
+def _ordering_ok(prev_key: Optional[str], next_key: Optional[str], name_key: str) -> bool:
+    """
+    Ordering verdict for a span given its prev/next uncontested-owner anchor
+    bracket (all args are case-insensitive sort keys).
+
+    An INVERTED bracket (`prev_key > next_key`) means a run boundary sits
+    between the two anchors, so the next side is unreliable and only the more
+    reliable prev side is tested (the cluster-A case, where the next anchor
+    `agricultural land in use` sorts before the real `c *` owners). Otherwise
+    the name must fall within `[prev, next]`.
+    """
+    if prev_key is not None and next_key is not None and prev_key > next_key:
+        return prev_key <= name_key
+    return (prev_key is None or prev_key <= name_key) and (
+        next_key is None or name_key <= next_key
+    )
+
+
+def _anchor_prev(starts: list[int], anchors: list[DecodedRecordSpan],
+                 start: int) -> Optional[DecodedRecordSpan]:
+    """Nearest anchor with OT start strictly before `start` (`anchors` sorted by
+    start, `starts` their start list)."""
+    j = bisect.bisect_left(starts, start) - 1
+    return anchors[j] if j >= 0 else None
+
+
+def _anchor_next(starts: list[int], anchors: list[DecodedRecordSpan],
+                 end: int) -> Optional[DecodedRecordSpan]:
+    """Nearest anchor with OT start at or after `end`."""
+    j = bisect.bisect_left(starts, end)
+    return anchors[j] if j < len(anchors) else None
+
+
+def _residual_span_is_owner(
+    span: DecodedRecordSpan,
+    recovered: list[DecodedRecordSpan],
+    recovered_starts: list[int],
+    uncontested: list[DecodedRecordSpan],
+    uncontested_starts: list[int],
+) -> bool:
+    """
+    Ordering-oracle verdict: does `span` sit where Vensim's alphabetical OT
+    allocation would put a real owner?
+
+    Anchors come in two tiers. When a RECOVERED real owner (a residual-component
+    span already confirmed this pass) brackets the span on BOTH sides, that
+    tier wins: recovered reals share the span's interleaved run, so they are the
+    reliable same-run evidence (this is what adjudicates `indicated per capita
+    fish demand` vs `China future GDP growth rate` at OT 127 -- the recovered
+    `Indicated China GDP`@123 / `indicated row Coal demand`@128 bracket, not the
+    nearest uncontested owner `cafe history`@124, which is a different run).
+    Otherwise the file's uncontested owners are the anchors.
+    """
+    name_key = _vensim_sort_key(span.name)
+    rp = _anchor_prev(recovered_starts, recovered, span.start)
+    rn = _anchor_next(recovered_starts, recovered, span.end)
+    if rp is not None and rn is not None:
+        return _ordering_ok(_vensim_sort_key(rp.name), _vensim_sort_key(rn.name), name_key)
+    up = _anchor_prev(uncontested_starts, uncontested, span.start)
+    un = _anchor_next(uncontested_starts, uncontested, span.end)
+    up_key = _vensim_sort_key(up.name) if up is not None else None
+    un_key = _vensim_sort_key(un.name) if un is not None else None
+    return _ordering_ok(up_key, un_key, name_key)
+
+
+def _spans_overlap(a: DecodedRecordSpan, b: DecodedRecordSpan) -> bool:
+    return not (a.end <= b.start or b.end <= a.start)
+
+
+def resolve_residual_components(
+    spans: list[DecodedRecordSpan],
+    components: list[ResidualOverlapComponent],
+    phase1_descriptors: set[int],
+    gate_threshold: float,
+) -> ResidualResolution:
+    """
+    Re-resolve each residual-overlap component from scratch, recovering the real
+    owners and dropping only the ghosts (stale-`f[11]` unsaved-variable records).
+
+    Per component (see docs/design/vdf.md "Residual OT-overlap"):
+    (a) discard the component's phase-1 overlap peels that spatially belong to
+        it (un-peel: any phase-1 descriptor overlapping a component span, e.g.
+        the wrongly f10-peeled `c Identified Oil Reserve`), then
+    (b) LEXICALLY peel spans whose names are lookupish (` lookup`/` table`/...),
+        WITHOUT the `f11 < n_lookups` gate -- a lookup definition is a table,
+        not a series, so its stale `f[11]` cannot forward-link, then
+    (c) adjudicate the remaining conflicts with the alphabetical-ordering oracle
+        (`_residual_span_is_owner`), iterating a fixpoint so a span confirmed as
+        an owner becomes an anchor for its neighbours, then
+    (d) honest-drop anything still in conflict (surfaced on the diagnostics).
+
+    The whole procedure is gated per file: if the uncontested owners do not
+    exhibit the alphabetical-allocation invariant (`gate_threshold`), the oracle
+    abstains and every residual span is honest-dropped (Stage 1 semantics), so a
+    file that does not follow the invariant is never mis-adjudicated.
+
+    Mirrors Rust `record_results.rs::resolve_residual_components`.
+    """
+    dropped: set[int] = set()
+    readmitted: set[int] = set()
+    if not components:
+        return ResidualResolution(dropped, readmitted, [])
+
+    comp_span_idx = {i for c in components for i in c.span_indices}
+    # Uncontested owners: the clean, non-conflicted owner partition -- the
+    # alphabetical reference.
+    uncontested = sorted(
+        (s for i, s in enumerate(spans)
+         if s.rec_idx not in phase1_descriptors and i not in comp_span_idx),
+        key=lambda s: s.start,
+    )
+    uncontested_starts = [s.start for s in uncontested]
+
+    # Gate: abstain (honest-drop all) when the file does not exhibit the
+    # alphabetical invariant.
+    if _residual_alphabetical_consistency(uncontested) < gate_threshold:
+        for c in components:
+            for i in c.span_indices:
+                dropped.add(spans[i].rec_idx)
+        return ResidualResolution(dropped, readmitted, list(components))
+
+    # Per-component active sets: component spans + un-peeled phase-1 descriptors
+    # overlapping any component span. A phase-1 descriptor is un-peeled (given a
+    # second chance) exactly when it collides with a component's spans.
+    comp_active: list[list[DecodedRecordSpan]] = []
+    unpeeled_recidx: set[int] = set()
+    for c in components:
+        active = [spans[i] for i in c.span_indices]
+        # Test un-peel candidacy against a SNAPSHOT of the original component
+        # spans, not the growing `active` list: a phase-1 descriptor is
+        # un-peeled iff it collides with an ORIGINAL component span, never
+        # merely with a previously-un-peeled descriptor (mirrors the Rust
+        # `component_spans` snapshot; keeps the two readers bit-identical on a
+        # chained-descriptor residual region).
+        component_spans = list(active)
+        for i, s in enumerate(spans):
+            if s.rec_idx in phase1_descriptors and any(
+                _spans_overlap(s, cs) for cs in component_spans
+            ):
+                active.append(s)
+                unpeeled_recidx.add(s.rec_idx)
+        comp_active.append(active)
+
+    # (a) lexical peel (drop lookupish table names).
+    for active in comp_active:
+        keep = []
+        for s in active:
+            if _name_looks_lookupish(s.name):
+                dropped.add(s.rec_idx)
+            else:
+                keep.append(s)
+        active[:] = keep
+
+    # (b)+(c) fixpoint: confirm non-overlapping spans as recovered owners, then
+    # drop the decisive ghosts, until no component changes.
+    recovered: list[DecodedRecordSpan] = []
+    changed = True
+    while changed:
+        changed = False
+        # Confirm any span no longer overlapping another active span.
+        for active in comp_active:
+            still = []
+            for s in active:
+                if any(t is not s and _spans_overlap(s, t) for t in active):
+                    still.append(s)
+                else:
+                    recovered.append(s)
+                    changed = True
+            active[:] = still
+        recovered.sort(key=lambda s: s.start)
+        recovered_starts = [s.start for s in recovered]
+        # Drop decisive ghosts: in a still-overlapping group with at least one
+        # ordering-consistent owner, drop the ordering-inconsistent spans.
+        for active in comp_active:
+            overl = [s for s in active if any(t is not s and _spans_overlap(s, t) for t in active)]
+            if not overl:
+                continue
+            owners = [s for s in overl
+                      if _residual_span_is_owner(s, recovered, recovered_starts,
+                                                 uncontested, uncontested_starts)]
+            ghosts = [s for s in overl if s not in owners]
+            if owners and ghosts:
+                for s in ghosts:
+                    dropped.add(s.rec_idx)
+                active[:] = [s for s in active if s not in ghosts]
+                changed = True
+
+    # (d) honest-drop the still-conflicted remainder; report it on diagnostics.
+    unresolved: list[ResidualOverlapComponent] = []
+    for c, active in zip(components, comp_active):
+        leftover = [s for s in active if any(t is not s and _spans_overlap(s, t) for t in active)]
+        if leftover:
+            leftover_idx = {id(s) for s in leftover}
+            span_indices = sorted(i for i in c.span_indices if id(spans[i]) in leftover_idx)
+            for s in leftover:
+                dropped.add(s.rec_idx)
+            contested = sorted({ot for a in leftover for b in leftover
+                                if a is not b and _spans_overlap(a, b)
+                                for ot in range(max(a.start, b.start), min(a.end, b.end))})
+            unresolved.append(ResidualOverlapComponent(
+                span_indices=span_indices, contested_ots=contested))
+
+    # Un-peeled phase-1 descriptors that were KEPT are readmitted as owners.
+    kept_recidx = {s.rec_idx for active in comp_active for s in active} | {s.rec_idx for s in recovered}
+    readmitted = {r for r in unpeeled_recidx if r in kept_recidx and r not in dropped}
+    return ResidualResolution(dropped, readmitted, unresolved)
 
 
 def _array_element_labels_for_span(

--- a/tools/vdf_xray.py
+++ b/tools/vdf_xray.py
@@ -2437,6 +2437,17 @@ def _spans_overlap(a: DecodedRecordSpan, b: DecodedRecordSpan) -> bool:
     return not (a.end <= b.start or b.end <= a.start)
 
 
+def _spans_conflict(a: DecodedRecordSpan, b: DecodedRecordSpan) -> bool:
+    """Genuine residual CONFLICT: overlapping extents AND different names.
+    Same-name overlaps are ordinary duplicate records for one variable that the
+    per-name emission dedup owns (keep-lowest-start) -- the same rule
+    `residual_overlap_components` uses to build the components. A name-blind
+    predicate here would honest-drop a same-name duplicate pair that a
+    differently-named ghost dragged into a component, losing the variable
+    entirely (GH #844). Mirrors Rust `record_results.rs::spans_conflict`."""
+    return _spans_overlap(a, b) and a.name != b.name
+
+
 def resolve_residual_components(
     spans: list[DecodedRecordSpan],
     components: list[ResidualOverlapComponent],
@@ -2498,14 +2509,15 @@ def resolve_residual_components(
         active = [spans[i] for i in c.span_indices]
         # Test un-peel candidacy against a SNAPSHOT of the original component
         # spans, not the growing `active` list: a phase-1 descriptor is
-        # un-peeled iff it collides with an ORIGINAL component span, never
-        # merely with a previously-un-peeled descriptor (mirrors the Rust
+        # un-peeled iff it cross-name-conflicts with an ORIGINAL component span,
+        # never merely with a previously-un-peeled descriptor (mirrors the Rust
         # `component_spans` snapshot; keeps the two readers bit-identical on a
-        # chained-descriptor residual region).
+        # chained-descriptor residual region). A same-name overlap is not a
+        # conflict, so it stays dropped -- its owner twin already represents it.
         component_spans = list(active)
         for i, s in enumerate(spans):
             if s.rec_idx in phase1_descriptors and any(
-                _spans_overlap(s, cs) for cs in component_spans
+                _spans_conflict(s, cs) for cs in component_spans
             ):
                 active.append(s)
                 unpeeled_recidx.add(s.rec_idx)
@@ -2527,11 +2539,13 @@ def resolve_residual_components(
     changed = True
     while changed:
         changed = False
-        # Confirm any span no longer overlapping another active span.
+        # Confirm any span no longer CONFLICTING with another active span (a
+        # same-name overlap is not a conflict, so a same-name duplicate pair
+        # confirms and survives once its differently-named ghost is dropped).
         for active in comp_active:
             still = []
             for s in active:
-                if any(t is not s and _spans_overlap(s, t) for t in active):
+                if any(t is not s and _spans_conflict(s, t) for t in active):
                     still.append(s)
                 else:
                     recovered.append(s)
@@ -2539,10 +2553,10 @@ def resolve_residual_components(
             active[:] = still
         recovered.sort(key=lambda s: s.start)
         recovered_starts = [s.start for s in recovered]
-        # Drop decisive ghosts: in a still-overlapping group with at least one
+        # Drop decisive ghosts: in a still-conflicting group with at least one
         # ordering-consistent owner, drop the ordering-inconsistent spans.
         for active in comp_active:
-            overl = [s for s in active if any(t is not s and _spans_overlap(s, t) for t in active)]
+            overl = [s for s in active if any(t is not s and _spans_conflict(s, t) for t in active)]
             if not overl:
                 continue
             owners = [s for s in overl
@@ -2558,14 +2572,14 @@ def resolve_residual_components(
     # (d) honest-drop the still-conflicted remainder; report it on diagnostics.
     unresolved: list[ResidualOverlapComponent] = []
     for c, active in zip(components, comp_active):
-        leftover = [s for s in active if any(t is not s and _spans_overlap(s, t) for t in active)]
+        leftover = [s for s in active if any(t is not s and _spans_conflict(s, t) for t in active)]
         if leftover:
             leftover_idx = {id(s) for s in leftover}
             span_indices = sorted(i for i in c.span_indices if id(spans[i]) in leftover_idx)
             for s in leftover:
                 dropped.add(s.rec_idx)
             contested = sorted({ot for a in leftover for b in leftover
-                                if a is not b and _spans_overlap(a, b)
+                                if a is not b and _spans_conflict(a, b)
                                 for ot in range(max(a.start, b.start), min(a.end, b.end))})
             unresolved.append(ResidualOverlapComponent(
                 span_indices=span_indices, contested_ots=contested))

--- a/tools/vdf_xray.py
+++ b/tools/vdf_xray.py
@@ -1915,7 +1915,25 @@ def identify_descriptor_records(
     """
     n_lookups = len(vdf.section6_lookup_records() or [])
     if n_lookups == 0:
-        return DescriptorIdentification(descriptor_indices=set(), used_f10_fallback=False)
+        # No lookup records to forward-link, so the overlap-path descriptor peel
+        # and the standalone lookup-only drop are no-ops -- but the residual
+        # pass is name/OT-based and MUST still run: a lookup-free file can carry
+        # the stale-f[11] owner-vs-owner conflict this guards against, and
+        # skipping it would emit duplicate columns for a contested slot (GH
+        # #844). phase-1 descriptors are empty here, so nothing is un-peeled and
+        # `descriptor_indices` is exactly the re-resolution's drop set -- the
+        # same result the Rust reader's unconditional residual pass produces.
+        residual_components = residual_overlap_components(spans, set())
+        resolution = resolve_residual_components(
+            spans, residual_components, set(), RESIDUAL_ORDERING_GATE
+        )
+        return DescriptorIdentification(
+            descriptor_indices=set(resolution.dropped),
+            used_f10_fallback=False,
+            standalone_drop_veto_fired=False,
+            standalone_drop_vetoed_candidates=0,
+            residual_overlap_components=resolution.unresolved_components,
+        )
 
     # Build OT-slot -> spans-claiming-it. Spans that overlap (share any OT slot
     # with another span) are descriptor-pair candidates. Note: descriptors
@@ -2886,10 +2904,14 @@ class NamedResultsDiagnostics:
     # corpus file (GH #842).
     bitmap_unreconciled_ots: list[int] = field(default_factory=list)
     # Residual OT-overlap: differently-named decoded spans that still claim a
-    # shared OT slot after descriptor peeling and the standalone lookup-only
-    # drop. Every such span is DROPPED from emission (honest missing data over
-    # a silent alphabetical first-claim win). Empty on every tracked corpus
-    # file except the two SimService Base.vdf files. Mirrors the Rust reader's
+    # shared OT slot after descriptor peeling, the standalone lookup-only drop,
+    # AND the residual-overlap re-resolution -- i.e. the conflicts the ordering
+    # oracle could not adjudicate and therefore honest-dropped (honest missing
+    # data over a silent alphabetical first-claim win). Empty across the whole
+    # tracked corpus, including the two SimService Base.vdf files whose
+    # stale-f[11] conflicts the oracle now fully recovers; non-empty only when
+    # the per-file gate fails or the oracle leaves a conflict unadjudicated.
+    # Mirrors the Rust reader's
     # `DescriptorIdentification.residual_overlap_components` (span-index based;
     # the name-resolved analogue is Rust `VdfFile::residual_overlap_diagnostics`).
     residual_overlap: list[ResidualOverlapComponent] = field(default_factory=list)


### PR DESCRIPTION
Fixes #841

## Problem

On 2007-era VDFs (`third_party/uib_sd/spring_2008/SimService_BUENO/.../Base.vdf` and its `ctxt0001` sibling), the overlap-path descriptor peel exits with 84 record spans still claiming overlapping OT slots, and the readers resolved those conflicts silently: the Rust reader by alphabetical first-claim-wins (emitting 82 ghost `AGE SPECIFIC FERTILITY DISTRIBUTION FUNCTION[k]` columns carrying other variables' data while dropping ~45 real series, including the issue's headline `c Identified Oil Reserve`), the Python xray by emitting duplicate columns for contested slots. The root cause is a file phenomenon the format doc did not describe: records for variables not saved in the run carry stale `f[11]` slot indices that land on saved variables' OT slots, and most fail the `f11 < n_lookups` descriptor-candidacy gate, so the peel could neither remove them nor detect that it had failed. The two SimService files are the only ones in the 141-file tracked corpus that exhibit residual overlap, and they sat outside the parity corpus, so the Rust/Python divergence was invisible to CI.

## Fix (two commits)

**Correctness floor (`vdf: honest-drop residual record-span overlap`).** Residual overlap components are computed as data after the peel; conflicted spans are dropped rather than silently mislabeled, surfaced on per-file diagnostics (`VdfFile::residual_overlap_diagnostics()`, xray `NamedResultsDiagnostics.residual_overlap`). The parity corpus now includes `spring_2008`, which also surfaced a pre-existing dimension-recovery divergence (Rust bailed when record-anchor and section-5 counts disagree; it now falls back to the same record-group recovery Python uses — byte-identical on Ref.vdf, no-op on every other corpus file).

**Recovery (`vdf: recover real owners from residual overlap components`).** Residual components are re-resolved instead of blanket-dropped: phase-1 peels that overlap a component are undone (a peel that failed to resolve its component was evidence-free), lexically lookupish names are peeled without the candidacy gate, and remaining conflicts are adjudicated by an ordering oracle built on Vensim's alphabetical OT allocation — bracketing by nearest uncontested owners, run-boundary detection via inverted brackets, recovered same-run anchors, iterated to a fixpoint. The oracle is gated per-file: it only runs when the file's own uncontested owners measure at least 0.95 adjacent-pair alphabetical consistency (SimService: 0.9964; corpus median 0.9869); anything inconclusive falls back to the honest drop. On both fixtures this drops the 41 stale-`f[11]` ghost records and recovers every real owner — `Population`'s 164 elements, both `c Identified Oil Reserve` series (51000 -> 8783.97, 7900 -> 2958.07), and the four contested scalars — leaving empty residual diagnostics.

## Non-obvious decisions

- **No model-guided crutch**: the fix is entirely model-free, like Vensim's own reader. The ordering invariant was previously a footnote in `docs/design/vdf.md` ("not a rule a reader needs"); it is now load-bearing but only under a measured per-file gate, never assumed universal.
- **No scalar objective can adjudicate these conflicts**: the fixtures contain both orientations (a ghost wide span over ~40 real narrow owners AND a real 164-wide `Population` under 36 internally-alphabetical ghost claimants), which is why the design uses anchor consistency rather than majority/coverage/conflict-degree rules. `Ref.vdf` contains both shapes at small scale inside components the existing peel already resolves — those paths are untouched.
- **Provable blast radius**: recovery triggers only on residual components, which exist only in the two SimService files; the other 139 corpus files are structurally unaffected (verified by corpus survey and the parity harness, which pins Rust and Python bit-identical including the un-peel snapshot semantics).

## Validation

- Full pre-commit battery green on both commits (fmt, clippy, cargo tests, TS, pysimlin).
- `parity_python_and_rust_vdf_extraction_agree` green with the extended corpus (name sets both directions + bitwise values).
- Fixture tests in both readers pin the exact 41-name dropped set and 1235-column total on both SimService files; synthetic unit tests pin the oracle's decision logic (run-boundary trap, internally-ordered-ghost trap, chained-descriptor un-peel scope, inconclusive-to-drop, gate abstention).
- C-LEARN comparator (`simulates_clearn`, release) green on the final tree.
- Both commits were adversarially reviewed by independent sessions; all material and minor findings addressed.