### PR TITLE
engine: root-cause and fix the silent LTM fragment-compile failures

### DIFF
--- a/notebooks/build_clearn_ltm_audit.py
+++ b/notebooks/build_clearn_ltm_audit.py
@@ -1,0 +1,1030 @@
+#!/usr/bin/env python3
+"""Build the C-LEARN Loops-That-Matter audit notebook.
+
+Constructs notebooks/clearn_ltm_audit.ipynb cell-by-cell via nbformat, then
+executes it (populating outputs) with nbclient. The executed .ipynb and its
+HTML render are generated artifacts (gitignored); this script is the source of
+truth, so the notebook can be regenerated against any engine build.
+
+Every number in the notebook is COMPUTED by a cell -- nothing is pasted in --
+so a regeneration against a newer engine either reproduces the findings or
+visibly contradicts them.
+
+Sibling generator: build_notebook.py builds the older `clearn_ltm_experience`
+notebook, written when GH #653 (pinned loops unscoreable at C-LEARN's scale)
+was still open; its central technique -- composing loop scores by hand from
+link scores -- is a workaround for a bug that is now fixed.
+
+Run from the pysimlin venv, synced with the `notebooks` extra. Invoke the venv
+interpreter DIRECTLY: `uv run` re-syncs the project as an editable install and
+replaces any wheel you installed.
+
+    cd src/pysimlin && uv sync --extra dev --extra notebooks
+    src/pysimlin/.venv/bin/python notebooks/build_clearn_ltm_audit.py
+"""
+
+from pathlib import Path
+
+import nbformat as nbf
+
+NOTEBOOKS_DIR = Path(__file__).resolve().parent
+NOTEBOOK_PATH = NOTEBOOKS_DIR / "clearn_ltm_audit.ipynb"
+
+nb = nbf.v4.new_notebook()
+nb.metadata["kernelspec"] = {
+    "display_name": "Python 3",
+    "language": "python",
+    "name": "python3",
+}
+
+cells: list = []
+
+
+def md(source: str) -> None:
+    cells.append(nbf.v4.new_markdown_cell(source.strip()))
+
+
+def code(source: str) -> None:
+    cells.append(nbf.v4.new_code_cell(source.strip()))
+
+
+# ---------------------------------------------------------------------------
+# 0. Provenance
+# ---------------------------------------------------------------------------
+
+md(
+    """
+# C-LEARN under Loops That Matter
+
+**An experience report: driving Simlin's LTM implementation through `pysimlin` on a
+real, large, arrayed climate-policy model.**
+
+C-LEARN v77 is a Vensim model of the global carbon cycle and climate coupled to an
+emissions-negotiation front end. It is a good stress test precisely because nobody
+built it for us: 911 variables, 24 stocks, subscripted over three climate-sensitivity
+scenarios and eight negotiating blocs, 1850-2100.
+
+This notebook does two things at once. It **uses** LTM to answer a real question --
+which feedback loops drive C-LEARN's behavior, and when -- and it **audits** LTM,
+checking each answer against an independent path before believing it. The audit
+sections are the ones labelled *Audit*; several of them found real defects, which are
+called out inline.
+"""
+)
+
+code(
+    """
+import platform
+import sys
+import time
+import warnings
+from collections import Counter
+from pathlib import Path
+
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+import simlin
+
+REPO = Path.cwd().parent if Path.cwd().name == "notebooks" else Path.cwd()
+MODEL_PATH = REPO / "test" / "xmutil_test_models" / "C-LEARN v77 for Vensim.mdl"
+SEP = "\\u205a"  # the reserved separator in LTM synthetic variable names
+
+print(f"pysimlin  {simlin.__version__}")
+print(f"python    {sys.version.split()[0]} on {platform.platform()}")
+print(f"model     {MODEL_PATH.name} ({MODEL_PATH.stat().st_size / 1e6:.2f} MB)")
+assert MODEL_PATH.exists(), MODEL_PATH
+"""
+)
+
+md(
+    """
+## 1. First contact
+
+Loading a 1.4 MB Vensim `.mdl` and simulating it is two calls. Note what each one
+costs -- LTM is not free, and knowing the ratio shapes how you use it.
+"""
+)
+
+code(
+    """
+timings = {}
+
+
+def timed(label, fn):
+    t0 = time.perf_counter()
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        out = fn()
+    timings[label] = time.perf_counter() - t0
+    for w in caught:
+        print(f"  [{w.category.__name__}] {w.message}")
+    return out
+
+
+model = timed("load .mdl", lambda: simlin.load(MODEL_PATH))
+
+stocks = model.get_var_names(type_mask=simlin.VARTYPE_STOCK)
+flows = model.get_var_names(type_mask=simlin.VARTYPE_FLOW)
+auxes = model.get_var_names(type_mask=simlin.VARTYPE_AUX)
+print(f"{len(model.get_var_names())} variables: "
+      f"{len(stocks)} stocks, {len(flows)} flows, {len(auxes)} aux")
+print(f"time: {model.time_spec}")
+"""
+)
+
+code(
+    """
+plain = timed("run, LTM off", lambda: model.run(analyze_loops=False))
+ltm = timed("run, LTM on", model.run)
+
+print(f"\\nresults: {plain.results.shape[0]} steps x {plain.results.shape[1]} columns")
+print(f"ltm_mode: plain={plain.ltm_mode!r}  ltm={ltm.ltm_mode!r}")
+print(f"run.loops: {len(ltm.loops)}")
+"""
+)
+
+md(
+    """
+That warning is the single most useful thing the API does here. C-LEARN's causal graph
+is far too large for exhaustive loop enumeration, so LTM silently switches to the
+strongest-path *discovery* heuristic -- and in discovery mode `run.loops` is empty by
+construction. Without the warning, "no feedback loops" and "too big to enumerate them"
+look identical.
+
+The cost ratio is worth internalising: LTM instrumentation makes the run roughly an
+order of magnitude more expensive. That is a dramatic improvement on where this model
+was two months ago (LTM on C-LEARN was infeasible, then ~8s), but it is still the
+reason `Model.analyze()` is opt-in rather than automatic.
+"""
+)
+
+code(
+    """
+pd.Series(timings).round(3).to_frame("seconds")
+"""
+)
+
+md(
+    """
+## 2. Loop discovery
+
+`Model.analyze()` runs the strongest-path heuristic. The result carries the loops, their
+per-step importance series, and -- crucially -- the **cycle partitions**.
+
+A partition is a set of stocks connected by feedback. Loop importance is normalized
+*within* a partition, so a score of 0.4 in one partition and 0.4 in another are not
+the same claim about the world. Almost every mistake in this notebook's audit sections
+comes from forgetting that.
+"""
+)
+
+code(
+    """
+analysis = timed("analyze()", model.analyze)
+
+print(f"loops={len(analysis.loops)}  partitions={len(analysis.partitions)}  "
+      f"periods={len(analysis.dominant_periods)}")
+print(f"truncated={analysis.truncated}  agg_recovery_truncated={analysis.agg_recovery_truncated}")
+print("polarity mix:", dict(Counter(str(x.polarity) for x in analysis.loops)))
+
+pd.DataFrame(
+    [
+        {
+            "partition": i,
+            "loops": p.loop_count,
+            "stocks": len(p.stocks),
+            "example stock": p.stocks[0] if p.stocks else "",
+        }
+        for i, p in enumerate(analysis.partitions)
+    ]
+).set_index("partition")
+"""
+)
+
+md(
+    """
+Neither flag is set, so this is a complete result rather than a budget-truncated one.
+
+The partition table reads the model's architecture straight off: three large partitions
+of 47 loops and 15 stocks each, then twelve single-loop partitions. The three large ones
+are C-LEARN's three climate-sensitivity scenarios (`deterministic`,
+`high_2xco2_sensitivity`, `low_2xco2_sensitivity`) -- the model runs three parallel
+worlds via a subscript, so every climate loop exists three times over. The twelve
+singletons are the isolated trace-gas decay loops (N2O, PFC, SF6, nine HFCs), each a
+stock draining through its own uptake flow, coupled to nothing.
+
+Let me verify the scenario claim rather than assume it.
+"""
+)
+
+code(
+    """
+def base(name):
+    return name.split("[")[0]
+
+
+big = [i for i, p in enumerate(analysis.partitions) if p.loop_count > 1]
+signatures = {
+    i: {tuple(sorted({base(v) for v in loop.variables}))
+        for loop in analysis.loops if loop.partition == i}
+    for i in big
+}
+ref = signatures[big[0]]
+for i in big[1:]:
+    print(f"P{big[0]} vs P{i}: identical loop structure = {signatures[i] == ref} "
+          f"({len(ref)} vs {len(signatures[i])} distinct variable-sets)")
+
+scenario = {}
+for i in big:
+    tags = {v.split("[")[1].split(",")[0].rstrip("]")
+            for loop in analysis.loops if loop.partition == i
+            for v in loop.variables if "[" in v}
+    scenario[i] = sorted(tags)
+print("\\nsubscript tags per large partition:")
+for i, tags in scenario.items():
+    print(f"  P{i}: {tags}")
+"""
+)
+
+md(
+    """
+Confirmed: the three large partitions carry byte-identical loop structure and are
+separated purely by the scenario subscript. So there is exactly **one** climate system
+to analyse, instantiated three times. From here on I work in the `deterministic`
+partition and treat the other two as a sensitivity check.
+"""
+)
+
+# ---------------------------------------------------------------------------
+# 3. The dominance story
+# ---------------------------------------------------------------------------
+
+md(
+    """
+## 3. What actually drives C-LEARN
+
+Now the real question. Within the deterministic scenario's partition, which loops carry
+the behavior, and how does that shift over 250 years?
+"""
+)
+
+code(
+    """
+det = next(i for i, p in enumerate(analysis.partitions)
+           if any("deterministic" in s for s in p.stocks))
+members = [x for x in analysis.loops if x.partition == det]
+n_steps = min(len(x.behavior_time_series) for x in members)
+years = np.linspace(model.time_spec.start, model.time_spec.stop, n_steps)
+
+ranked = sorted(members, key=lambda x: x.average_importance(), reverse=True)
+pd.DataFrame(
+    [
+        {
+            "id": x.id,
+            "pol": str(x.polarity),
+            "mean |share|": round(x.average_importance(), 4),
+            "peak |share|": round(x.max_importance(), 4),
+            "len": len(x.variables),
+            "cycle": " -> ".join(base(v) for v in x.variables[:5])
+            + (" ..." if len(x.variables) > 5 else ""),
+        }
+        for x in ranked[:10]
+    ]
+).set_index("id")
+"""
+)
+
+md(
+    """
+These are recognisable pieces of climate physics, which is the first real evidence that
+the machinery is working:
+
+- **b71** -- atmosphere-to-mixed-layer carbon flux. The ocean surface absorbs CO2, which
+  raises mixed-layer carbon, which raises the equilibrium partial pressure and throttles
+  further uptake. The dominant balancing loop for most of the run.
+- **b19** -- the 12-variable radiative loop: atmospheric carbon raises forcing, raises
+  heat in the atmosphere and upper ocean, raises temperature, which increases outgoing
+  radiation. Classic Planck feedback cooling.
+- **r17 / r16** -- the biomass-humus carbon sink, reinforcing: more atmospheric carbon
+  fertilises biomass, which returns carbon through humus decay.
+- **b43 / b45** -- deep-ocean diffusion, per layer.
+
+Now the time profile.
+"""
+)
+
+code(
+    """
+top = ranked[:6]
+share = np.vstack([x.behavior_time_series[:n_steps] for x in top])
+
+# C-LEARN's historical emissions inputs are yearly data, and every
+# flow-to-stock link score divides by a stock's acceleration -- so the raw
+# shares are genuinely spiky wherever the input data is. Plot the raw series
+# faintly and an 11-step centred rolling median on top: the smoothing is a
+# reading aid for a noisy INPUT, not a correction to the scores.
+smooth = (pd.DataFrame(share.T)
+          .rolling(11, center=True, min_periods=1)
+          .median()
+          .to_numpy().T)
+
+fig, (ax1, ax2) = plt.subplots(2, 1, figsize=(11, 8.5), sharex=True,
+                               gridspec_kw={"height_ratios": [2, 1]})
+
+for x, rawrow, smoothrow in zip(top, share, smooth):
+    line, = ax1.plot(years, smoothrow, lw=2.0, label=f"{x.id} ({x.polarity})")
+    ax1.plot(years, rawrow, lw=0.7, alpha=0.22, color=line.get_color())
+ax1.axhline(0, color="0.5", lw=0.8)
+ax1.set_ylabel("signed relative loop score")
+ax1.set_title("Loop dominance within the deterministic-scenario partition\\n"
+              "(bold: 11-step rolling median; faint: raw)")
+ax1.legend(ncol=6, fontsize=9, loc="upper center", framealpha=0.9)
+ax1.grid(alpha=0.25)
+
+results = plain.results
+temp_col = "temperature_change_from_preindustrial[deterministic]"
+assert temp_col in results.columns, temp_col
+ax2.plot(results.index, results[temp_col], color="crimson", lw=1.8)
+ax2.set_ylabel("temp change (degC)")
+ax2.set_xlabel("year")
+ax2.grid(alpha=0.25)
+fig.tight_layout()
+plt.show()
+"""
+)
+
+code(
+    """
+def leaders(step, k=3):
+    order = sorted(members, key=lambda x: abs(x.behavior_time_series[step]), reverse=True)
+    return ", ".join(f"{x.id}({x.behavior_time_series[step]:+.2f})" for x in order[:k])
+
+
+pd.DataFrame(
+    [{"year": y, "leading loops": leaders(int(np.argmin(np.abs(years - y))))}
+     for y in (1900, 1950, 2000, 2025, 2050, 2075, 2100)]
+).set_index("year")
+"""
+)
+
+md(
+    """
+The story LTM tells is coherent and physically sensible: **ocean surface uptake (b71)
+carries the balancing work through the industrial era and peaks around mid-century, then
+hands off to radiative cooling (b19), which is overwhelmingly dominant by 2100.** The
+biomass sink (r17) is the persistent reinforcing counterweight throughout.
+
+That handoff is the kind of insight LTM exists to produce, and you cannot read it off
+the stock-and-flow diagram.
+
+One caveat inherited from the model rather than the tool: C-LEARN's emissions inputs are
+piecewise data tables with slope changes at half-decade anchors. Every flow-to-stock link
+score divides by a stock's acceleration, so the whole score field reshuffles at each
+knee. Read these curves as trends, not step-by-step.
+"""
+)
+
+# ---------------------------------------------------------------------------
+# 4. Audit: dominant_periods
+# ---------------------------------------------------------------------------
+
+md(
+    """
+## 4. Audit: `dominant_periods` disagrees with `loops` in the same object
+
+The `Analysis` object also offers `dominant_periods`, which claims to name the loops
+that dominate each interval. It is the obvious thing to reach for. Here is what it says
+about the model we just analysed.
+"""
+)
+
+code(
+    """
+by_id = {x.id: x for x in analysis.loops}
+pd.DataFrame(
+    [
+        {
+            "start": p.start_time,
+            "end": p.end_time,
+            "loops": ", ".join(p.dominant_loops),
+            "cycle": "; ".join(" -> ".join(by_id[i].variables) for i in p.dominant_loops),
+        }
+        for p in analysis.dominant_periods
+    ]
+)
+"""
+)
+
+md(
+    """
+It reports that C-LEARN's behavior from 1851 to 1969 is explained by
+`n2o -> n2o_uptake`, and from 1992 to 2100 by `hfc[hfc125] -> hfc_uptake[hfc125]`.
+
+Those are two-variable trace-gas decay loops. They are not driving a climate model, and
+they are not what section 3 found. Something is wrong -- so let me find out what, rather
+than just distrusting the number.
+"""
+)
+
+code(
+    """
+singleton = {i for i, p in enumerate(analysis.partitions) if p.loop_count == 1}
+rows = []
+for x in analysis.loops:
+    if x.partition in singleton:
+        s = x.behavior_time_series
+        nz = s[np.isfinite(s) & (s != 0.0)]
+        rows.append({
+            "loop": x.id,
+            "partition": x.partition,
+            "active steps": len(nz),
+            "distinct |score| while active": np.unique(np.abs(nz)).round(12).tolist()[:3],
+        })
+pd.DataFrame(rows).set_index("loop")
+"""
+)
+
+md(
+    """
+There it is. Every one of the twelve singleton-partition loops has a relative score of
+**exactly 1.0** whenever it is active -- not approximately, exactly. That is arithmetic,
+not physics: the relative score is a loop's share of its partition's total activity, and
+a loop alone in its partition has 100% of it by definition.
+
+So ranking loops by `abs(behavior_time_series)` *across* partitions cannot do anything
+except put the trivial loops first. And the engine knows this -- `Analysis.loops` sorts
+those same twelve loops dead last, deliberately:
+"""
+)
+
+code(
+    """
+positions = [i for i, x in enumerate(analysis.loops) if x.partition in singleton]
+print(f"{len(analysis.loops)} loops in `analysis.loops`, competitive-first ranking")
+print(f"positions of the singleton-partition loops: {positions}")
+print(f"loops named by `analysis.dominant_periods`: "
+      f"{sorted({i for p in analysis.dominant_periods for i in p.dominant_loops})}")
+print()
+print("=> the two surfaces of the SAME Analysis object rank these loops")
+print("   at opposite ends: last by `loops`, first by `dominant_periods`.")
+"""
+)
+
+md(
+    """
+**Finding.** `Analysis.dominant_periods` (and `Run.dominant_periods`, which shares the
+flaw) is partition-blind. On any model with more than one cycle partition it is
+systematically biased toward whichever loops have the least competition, and on C-LEARN
+that makes it worthless -- it never mentions a single climate loop.
+
+This is not a tolerance or a tuning problem. A flat cross-partition dominance ranking is
+not well-defined, because the quantity being ranked is a within-partition share. The
+surface needs to either report periods per partition or say which partition it means.
+
+The workaround, which is what section 3 does, is to group by partition and rank inside
+one.
+"""
+)
+
+code(
+    """
+def dominant_periods_in_partition(loops, times, threshold=0.5):
+    \"\"\"Greedy dominance, scoped to ONE partition so the shares are comparable.\"\"\"
+    n = min(len(x.behavior_time_series) for x in loops)
+    sets, out = [], []
+    for step in range(n):
+        scored = sorted(((x.id, x.behavior_time_series[step]) for x in loops),
+                        key=lambda kv: abs(kv[1]), reverse=True)
+        chosen, total = [], 0.0
+        for lid, val in scored:
+            if not np.isfinite(val) or val == 0.0:
+                continue
+            chosen.append(lid)
+            total += abs(val)
+            if total >= threshold:
+                break
+        sets.append(frozenset(chosen))
+    start = 0
+    for step in range(1, n):
+        if sets[step] != sets[start]:
+            out.append((times[start], times[step - 1], tuple(sorted(sets[start]))))
+            start = step
+    out.append((times[start], times[n - 1], tuple(sorted(sets[start]))))
+    return [p for p in out if p[2]]
+
+
+scoped = dominant_periods_in_partition(members, years)
+print(f"{len(scoped)} periods within the deterministic partition "
+      f"(vs {len(analysis.dominant_periods)} model-wide)")
+pd.DataFrame(
+    [{"start": round(a), "end": round(b), "n loops": len(ids),
+      "loops": ", ".join(ids[:6]) + (" ..." if len(ids) > 6 else "")}
+     for a, b, ids in scoped[:12]]
+)
+"""
+)
+
+md(
+    """
+Partition-scoped, the answer is meaningful again -- and notice it needs *several* loops
+to reach half the activity, which is the honest picture for a system this coupled. The
+model-wide surface reached its threshold with one trivial loop every time.
+"""
+)
+
+# ---------------------------------------------------------------------------
+# 5. Audit: cross-validation
+# ---------------------------------------------------------------------------
+
+md(
+    """
+## 5. Audit: do the discovery numbers survive an independent check?
+
+Section 3's conclusions rest entirely on the strongest-path heuristic. Discovery is an
+approximation -- it searches for the strongest paths rather than enumerating every
+circuit -- so before believing it, I want the same loops scored by a different code path.
+
+Simlin has one: **pinning**. `set_loop_name` tells the engine to always instrument and
+score a named cycle, using the exhaustive per-loop scoring machinery rather than the
+discovery search. If the two agree, that is meaningful evidence; if they disagree, at
+least one is wrong.
+
+The first attempt fails, which is itself a finding.
+"""
+)
+
+code(
+    """
+pinned = simlin.load(MODEL_PATH)
+try:
+    with pinned.edit() as (_current, patch):
+        patch.set_loop_name(name="verbatim", variables=list(ranked[0].variables))
+    print("accepted")
+except simlin.SimlinRuntimeError as exc:
+    print(f"REJECTED: {exc}")
+    print(f"\\ndiscovery reported this cycle as: {list(ranked[0].variables)}")
+"""
+)
+
+md(
+    """
+**Finding.** On an arrayed model, discovery reports element-level names
+(`c_in_mixed_layer[deterministic]`) but `set_loop_name` only resolves plain idents, so a
+discovered loop cannot be handed back as a pin. Stripping the subscript is the only way
+through -- and it changes the meaning: you pin the whole apply-to-all family, not the
+element instance you found. For this cross-validation that is acceptable (the three
+scenarios are structurally identical), but "pin the loop discovery just showed me" is
+not expressible today.
+"""
+)
+
+code(
+    """
+def _run_pinned(m):
+    s = m.simulate(enable_ltm=True)
+    s.run_to_end()
+    return s
+
+
+targets = ranked[:5]
+pinned = simlin.load(MODEL_PATH)
+with pinned.edit() as (_current, patch):
+    for x in targets:
+        patch.set_loop_name(name=f"disc_{x.id}",
+                            variables=sorted({base(v) for v in x.variables}))
+
+psim = timed("pinned LTM run", lambda: _run_pinned(pinned))
+print(f"ltm_mode: {psim.get_ltm_mode()}")
+pd.DataFrame(
+    [{"pin id": x.id, "name": x.name, "structural polarity": str(x.polarity),
+      "vars": len(x.variables)}
+     for x in pinned.loops]
+).set_index("pin id")
+"""
+)
+
+md(
+    """
+The pins are registered and scored even though the model is in discovery mode -- that is
+exactly what pinning is for. Note the structural polarity column: mostly `U`
+(undetermined), because structural polarity is inferred from link signs and a Vensim
+import leaves many of those unknown. The *runtime* surface does better, because it
+classifies from the actual score series:
+"""
+)
+
+code(
+    """
+runtime = {x.id: x for x in psim.get_loops_runtime()}
+raw = {x.id: psim.get_series(f"${SEP}ltm{SEP}loop_score{SEP}{x.id}") for x in pinned.loops}
+disc_pol = {f"disc_{x.id}": str(x.polarity) for x in targets}
+
+rows = []
+for x in pinned.loops:
+    s = raw[x.id]
+    nz = s[np.isfinite(s) & (s != 0.0)]
+    sign = "all <= 0" if (nz <= 0).all() else ("all >= 0" if (nz >= 0).all() else "mixed")
+    rt = runtime.get(x.id)
+    rows.append({
+        "pin": x.id,
+        "structural": str(x.polarity),
+        "runtime": str(rt.polarity) if rt else "-",
+        "confidence": rt.polarity_confidence if rt else None,
+        "discovery": disc_pol.get(x.name),
+        "raw score sign": sign,
+    })
+pd.DataFrame(rows).set_index("pin")
+"""
+)
+
+md(
+    """
+Runtime polarity is correct on all five, at confidence 1.0, and agrees with discovery --
+including the four the structural pass could not determine. Now the numbers themselves.
+
+The pinned loops sit in one partition, so their relative scores are directly comparable;
+to compare against discovery I renormalize discovery's shares over the same five loops.
+"""
+)
+
+code(
+    """
+ids = [x.id for x in pinned.loops]
+stack = np.vstack([raw[i] for i in ids])
+denom = np.nansum(np.abs(stack), axis=0)
+with np.errstate(invalid="ignore", divide="ignore"):
+    rel_pin = np.where(denom > 0, stack / denom, 0.0)
+
+name_to_disc = {f"disc_{x.id}": x for x in targets}
+disc_for = {x.id: name_to_disc[x.name] for x in pinned.loops}
+dstack = np.vstack([disc_for[i].behavior_time_series[:rel_pin.shape[1]] for i in ids])
+d_denom = np.nansum(np.abs(dstack), axis=0)
+with np.errstate(invalid="ignore", divide="ignore"):
+    rel_disc = np.where(d_denom > 0, dstack / d_denom, 0.0)
+
+resid = np.nanmax(np.abs(rel_pin - rel_disc))
+print(f"max |pinned - discovery| over all 5 loops x {rel_pin.shape[1]} steps: {resid:.3e}")
+
+frames = []
+for y in (1900, 1950, 2000, 2050, 2100):
+    step = int(np.argmin(np.abs(years[: rel_pin.shape[1]] - y)))
+    frames.append(pd.DataFrame({
+        "year": y,
+        "loop": [disc_for[i].id for i in ids],
+        "pinned": rel_pin[:, step].round(4),
+        "discovery": rel_disc[:, step].round(4),
+    }))
+pd.concat(frames).set_index(["year", "loop"])
+"""
+)
+
+md(
+    """
+**The two paths agree to floating-point noise.** The exhaustive per-loop scoring
+machinery and the strongest-path discovery heuristic, which share almost none of their
+code, produce the same relative shares at every one of 251 timesteps.
+
+This is the strongest positive result in the notebook. Section 3's dominance story is not
+an artifact of the heuristic.
+"""
+)
+
+# ---------------------------------------------------------------------------
+# 6. Audit: link-score coverage
+# ---------------------------------------------------------------------------
+
+md(
+    """
+## 6. Audit: how much of the causal graph is actually scored?
+
+Loop scores are built from link scores. So: of C-LEARN's causal edges, how many carry a
+usable score? This turns out to be the question with the most uncomfortable answer, and
+the diagnostics that reveal it are easy to never see.
+"""
+)
+
+code(
+    """
+sim = model.simulate(enable_ltm=True)
+sim.run_to_end()
+
+links = sim.get_links()
+raw_links = sim.get_links(include_internal=True)
+scored = [x for x in links if x.has_score()]
+
+
+def live(link):
+    finite = link.score[np.isfinite(link.score)]
+    return finite.size > 0 and not np.all(finite == 0.0)
+
+
+live_links = [x for x in scored if live(x)]
+print(f"collapsed causal graph : {len(links)} edges "
+      f"(raw, with synthetic nodes: {len(raw_links)})")
+print(f"  with a score series  : {len(scored)} ({100*len(scored)/len(links):.0f}%)")
+print(f"  score not identically 0: {len(live_links)} ({100*len(live_links)/len(links):.0f}%)")
+print()
+print("link polarity coverage:", dict(Counter(str(x.polarity) for x in links)))
+"""
+)
+
+md(
+    """
+About a fifth of the graph carries a live link score, and three quarters of the edges
+have unknown polarity. Some of that is legitimate -- an edge from a constant genuinely
+has a zero score. But not all of it. The explanation is in the diagnostics, and there is
+a trap in how you get them.
+"""
+)
+
+code(
+    """
+fresh = simlin.load(MODEL_PATH)
+before = fresh.check()
+scratch = fresh.simulate(enable_ltm=True)
+scratch.run_to_end()
+after = fresh.check()
+print(f"model.check() before any LTM sim : {len(before)} issues")
+print(f"model.check() after an LTM sim   : {len(after)} issues")
+print(f"newly visible                    : {len(after) - len(before)}")
+"""
+)
+
+md(
+    """
+**Finding.** LTM's own diagnostics are invisible until you have created an LTM
+simulation on that project -- and `Model.run()` and `Model.analyze()`, which enable LTM
+internally, do not surface them. It is entirely possible to call `analyze()`, get 153
+confident-looking loops, and never learn that the engine emitted sixteen hundred
+warnings about the model you just analysed.
+"""
+)
+
+code(
+    """
+failed = [i for i in after if "failed to compile" in i.message]
+
+
+def form(msg):
+    for phrase in ("LTM synthetic variable", "LTM implicit helper"):
+        if phrase in msg:
+            return phrase
+    return "other"
+
+
+print(f"{len(failed)} fragments failed to compile:")
+for kind, n in Counter(form(i.message) for i in failed).most_common():
+    print(f"  {n:5d}  {kind}")
+
+print("\\nrepresentative message:\\n")
+print(failed[0].message[:330], "...")
+"""
+)
+
+md(
+    """
+Each of these is an LTM equation the engine generated and then could not compile. The
+variable keeps a layout slot but no bytecode, so it evaluates to a constant 0 -- which is
+why so much of the graph reads zero.
+
+The obvious next worry is that this quietly corrupts the loop analysis. So let me check
+whether any of the loops from section 3 run through a failing edge.
+"""
+)
+
+code(
+    """
+import re
+
+edge_re = re.compile(rf"link_score{SEP}(.+?)\\u2192(.+?)(?:{SEP}\\d+{SEP}\\w+)?$")
+failing_edges = set()
+for issue in failed:
+    if not issue.variable:
+        continue
+    m = edge_re.search(issue.variable)
+    if m:
+        failing_edges.add((base(m.group(1)), base(m.group(2))))
+
+print(f"distinct failing causal edges: {len(failing_edges)}")
+
+touched = 0
+for x in analysis.loops:
+    vs = [base(v) for v in x.variables]
+    pairs = {(vs[i], vs[(i + 1) % len(vs)]) for i in range(len(vs))}
+    if pairs & failing_edges:
+        touched += 1
+print(f"discovered loops traversing a failing edge: {touched} of {len(analysis.loops)}")
+
+targets_hit = Counter(t for _f, t in failing_edges)
+print("\\nwhere the failures concentrate (top targets):")
+for name, n in targets_hit.most_common(8):
+    print(f"  {n:4d}  {name}")
+"""
+)
+
+md(
+    """
+**This is the reassuring half.** Not one of the 153 discovered loops passes through a
+failing edge. The failures cluster in C-LEARN's emissions-target machinery --
+`sorted_target_*`, `projected_population_in_target_year`, `rs_co2eq_nonforest_emissions`
+-- which is the negotiation front end: heavily subscripted over the eight blocs, and
+largely feed-forward. There is no feedback there to lose.
+
+So the loop-dominance results in section 3 stand. What is lost is **link-level**
+attribution over a large, policy-relevant part of the model: if you wanted to ask "which
+lever moves the 2050 target most", that is exactly the subgraph LTM cannot currently
+answer for.
+
+Of the edges that *are* scored but read identically zero, how many are legitimate?
+"""
+)
+
+code(
+    """
+res = plain.results
+zero = [x for x in scored if not live(x)]
+
+
+def time_varying(name):
+    \"\"\"Does any ELEMENT of `name` move over time?
+
+    Reducing across an arrayed variable's columns would conflate scenario
+    spread with time variation, so measure per column.
+    \"\"\"
+    cols = [c for c in res.columns if c == name or c.startswith(name + "[")]
+    for c in cols:
+        v = res[c].to_numpy()
+        v = v[np.isfinite(v)]
+        if v.size and v.max() > v.min():
+            return True
+    return False
+
+
+const_src = sum(1 for x in zero if not time_varying(x.from_var))
+print(f"{len(zero)} scored edges read identically zero")
+print(f"  source is constant over the run (a zero score is correct): {const_src}")
+print(f"  source varies over the run (unexplained)                 : {len(zero) - const_src}")
+"""
+)
+
+md(
+    """
+The majority are legitimate. The remainder is a real residual worth chasing, but it is
+a tail, not the story.
+"""
+)
+
+# ---------------------------------------------------------------------------
+# 7. Audit: relative link ranking
+# ---------------------------------------------------------------------------
+
+md(
+    """
+## 7. Audit: ranking links by relative score
+
+Raw link scores are famously not comparable across targets -- they divide by the change
+in the target, so a near-constant target produces an enormous score. Simlin addresses
+this with a *relative* link score, normalized per target into `[-1, 1]`, and the API
+recommends ranking by it.
+
+Let me try that on the live links and see what floats to the top.
+"""
+)
+
+code(
+    """
+ranked_links = sorted(live_links,
+                      key=lambda x: abs(x.average_relative_score() or 0.0), reverse=True)
+fan_in = Counter(x.to_var for x in scored)
+
+pd.DataFrame(
+    [{"|mean rel|": round(abs(x.average_relative_score()), 4),
+      "inputs to target": fan_in[x.to_var],
+      "link": f"{x.from_var} -> {x.to_var}"}
+     for x in ranked_links[:12]]
+)
+"""
+)
+
+md(
+    """
+The same failure mode as section 4, one level down. A link into a target with exactly one
+scored input is 100% of that target's change **by construction**, so it scores ~1.0
+whether or not it matters. The relative score fixed raw scores' comparability problem and
+inherited a new degeneracy in its place.
+"""
+)
+
+code(
+    """
+solo = [x for x in ranked_links if fan_in[x.to_var] == 1]
+print(f"live links whose target has exactly one scored input: {len(solo)} of {len(live_links)}")
+print(f"of the top 100 by |mean relative score|, "
+      f"{sum(1 for x in ranked_links[:100] if fan_in[x.to_var] == 1)} are such links")
+
+competing = [x for x in ranked_links if fan_in[x.to_var] > 1]
+print("\\ntop links restricted to targets with real competition:")
+pd.DataFrame(
+    [{"|mean rel|": round(abs(x.average_relative_score()), 4),
+      "inputs": fan_in[x.to_var],
+      "link": f"{x.from_var} -> {x.to_var}"}
+     for x in competing[:10]]
+)
+"""
+)
+
+md(
+    """
+Restricting to contested targets helps but does not fully fix it -- a two-input target
+whose second input happens to be inert still reads 1.0. A genuinely global link ranking
+needs to weight each target by that target's own importance, which the relative score
+deliberately divides out.
+
+**Finding.** `Link.average_relative_score()` is the right metric for comparing the inputs
+*of one target*. It is not a global importance ranking, and the API previously
+recommended using it as one.
+"""
+)
+
+# ---------------------------------------------------------------------------
+# 8. Scorecard
+# ---------------------------------------------------------------------------
+
+md(
+    """
+## 8. Scorecard
+
+### What works well
+
+| | |
+|---|---|
+| **Speed** | A 911-variable arrayed Vensim model loads in ~30 ms and runs in under half a second; LTM instrumentation costs roughly 10x that. Two months ago LTM on this model was infeasible. |
+| **Discovery** | 153 loops across 15 partitions, untruncated, in ~3 s -- with per-step importance series and no tuning. |
+| **Cycle partitions** | The single best design decision in this API. They recovered C-LEARN's three-scenario architecture with zero input from me, and they are the key to reading every other number correctly. |
+| **Correctness where it counts** | Pinned scoring and discovery agree to floating-point noise across 5 loops x 251 steps. Runtime polarity classification is right at confidence 1.0 even where structural polarity is undetermined. |
+| **The results themselves** | A physically coherent story -- ocean uptake handing off to radiative cooling -- that is not visible from the model structure. |
+| **Honest degradation** | The discovery auto-flip warning turns a silently-empty loop list into an actionable message. More surfaces should behave like this. |
+
+### What doesn't
+
+| | Severity |
+|---|---|
+| `dominant_periods` is partition-blind, and contradicts `loops` in the same object. On C-LEARN it never names a climate loop. | **High** -- it is the surface a new user reaches for first, and it is confidently wrong. |
+| ~1,600 LTM fragments fail to compile, silently degrading to constant 0. Loops are unaffected; link-level attribution over the whole policy subgraph is not. | **High** |
+| Those diagnostics are unreachable unless you call `check()` *after* creating an LTM sim. `run()`/`analyze()` never surface them. | **High** -- it is what makes the previous row silent. |
+| Ranking links by relative score surfaces uncontested targets, which is the opposite of what is wanted. | Medium |
+| Discovery's element-level loop names are rejected by `set_loop_name`, so a discovered loop cannot be pinned. | Medium |
+| Per-element raw loop scores are unreachable; a bare read silently returns element 0 while every other surface reports an argmax-abs aggregate. | Medium |
+| `model.check()` repeats each unit warning once per array element. | Low |
+
+### Where to invest
+
+1. **Make within-partition normalization structural rather than advisory.** Three separate defects here -- `dominant_periods`, the link ranking, and lone-pin degeneracy -- are one root cause: LTM's relative measures are *shares within a group*, and every surface that ranks them globally is dominated by groups of size one. Ranking APIs should either take the group as a parameter or return grouped results, so a cross-group comparison is not expressible.
+
+2. **Close the fragment-compile gap.** 1,600 failures on one real model is a coverage statement about the augmentation layer, concentrated in arrayed per-element equations with dynamic-index or un-hoisted-reducer reads. A generated-corpus harness that asserts every emitted fragment compiles would turn this from a per-model surprise into a gate.
+
+3. **Surface LTM diagnostics on the path people use.** `Model.analyze()` and `Model.run()` should report the count of degraded fragments -- the same way the discovery auto-flip warning already works.
+
+4. **Make discovery output usable as input.** Element-level loop identity should round-trip into pinning, and per-element raw scores should be readable.
+
+### Notes on the tooling
+
+Building and installing was not smooth. `make build` in `src/pysimlin` was broken twice
+over -- it looked for `libsimlin` at the repo root instead of `src/libsimlin`, and then
+invoked `pip` inside a `uv`-managed virtualenv that has none. Both are fixed. Separately,
+`uv run` re-syncs the project as an editable install, silently replacing an installed
+wheel, so this notebook's generator invokes the venv interpreter directly.
+"""
+)
+
+code(
+    """
+print(f"pysimlin {simlin.__version__}")
+print(f"{len(analysis.loops)} loops / {len(analysis.partitions)} partitions discovered")
+print(f"{len(live_links)} of {len(links)} causal edges carry a live link score")
+print(f"{len(failed)} LTM fragments failed to compile "
+      f"({touched} discovered loops affected)")
+print(f"pinned-vs-discovery max residual: {resid:.3e}")
+"""
+)
+
+nb["cells"] = cells
+
+if __name__ == "__main__":
+    import nbformat
+    from nbclient import NotebookClient
+
+    NOTEBOOK_PATH.write_text(nbformat.writes(nb), encoding="utf-8")
+    print(f"wrote {NOTEBOOK_PATH} ({len(cells)} cells)")
+
+    client = NotebookClient(
+        nb,
+        timeout=1800,
+        kernel_name="python3",
+        resources={"metadata": {"path": str(NOTEBOOKS_DIR)}},
+    )
+    client.execute()
+    NOTEBOOK_PATH.write_text(nbformat.writes(nb), encoding="utf-8")
+    print(f"executed and saved {NOTEBOOK_PATH}")

--- a/notebooks/build_clearn_ltm_audit.py
+++ b/notebooks/build_clearn_ltm_audit.py
@@ -19,8 +19,12 @@ Run from the pysimlin venv, synced with the `notebooks` extra. Invoke the venv
 interpreter DIRECTLY: `uv run` re-syncs the project as an editable install and
 replaces any wheel you installed.
 
-    cd src/pysimlin && uv sync --extra dev --extra notebooks
+    (cd src/pysimlin && uv sync --extra dev --extra notebooks)
     src/pysimlin/.venv/bin/python notebooks/build_clearn_ltm_audit.py
+
+Both paths are relative to the REPOSITORY ROOT; the subshell keeps the `cd`
+from leaking into the second command, where it would resolve the interpreter
+as `src/pysimlin/src/pysimlin/.venv/...` and fail before the generator starts.
 """
 
 from pathlib import Path
@@ -972,7 +976,7 @@ md(
 | | Severity |
 |---|---|
 | `dominant_periods` is partition-blind, and contradicts `loops` in the same object. On C-LEARN it never names a climate loop. | **High** -- it is the surface a new user reaches for first, and it is confidently wrong. |
-| ~1,600 LTM fragments fail to compile, silently degrading to constant 0. Loops are unaffected; link-level attribution over the whole policy subgraph is not. | **High** |
+| LTM fragments fail to compile, silently degrading to constant 0 -- the count is whatever section 6 measured on this engine build. Loops are unaffected; link-level attribution over the whole policy subgraph is not. | **High** |
 | Those diagnostics are unreachable unless you call `check()` *after* creating an LTM sim. `run()`/`analyze()` never surface them. | **High** -- it is what makes the previous row silent. |
 | Ranking links by relative score surfaces uncontested targets, which is the opposite of what is wanted. | Medium |
 | Discovery's element-level loop names are rejected by `set_loop_name`, so a discovered loop cannot be pinned. | Medium |
@@ -983,7 +987,7 @@ md(
 
 1. **Make within-partition normalization structural rather than advisory.** Three separate defects here -- `dominant_periods`, the link ranking, and lone-pin degeneracy -- are one root cause: LTM's relative measures are *shares within a group*, and every surface that ranks them globally is dominated by groups of size one. Ranking APIs should either take the group as a parameter or return grouped results, so a cross-group comparison is not expressible.
 
-2. **Close the fragment-compile gap.** 1,600 failures on one real model is a coverage statement about the augmentation layer, concentrated in arrayed per-element equations with dynamic-index or un-hoisted-reducer reads. A generated-corpus harness that asserts every emitted fragment compiles would turn this from a per-model surprise into a gate.
+2. **Close the fragment-compile gap.** The failure count section 6 measured is a coverage statement about the augmentation layer, concentrated in arrayed per-element equations with dynamic-index or un-hoisted-reducer reads. A generated-corpus harness that asserts every emitted fragment compiles would turn this from a per-model surprise into a gate.
 
 3. **Surface LTM diagnostics on the path people use.** `Model.analyze()` and `Model.run()` should report the count of degraded fragments -- the same way the discovery auto-flip warning already works.
 

--- a/notebooks/verify_clearn_ltm_audit.py
+++ b/notebooks/verify_clearn_ltm_audit.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Sanity-check the executed C-LEARN LTM audit notebook.
+
+Fails loudly on any cell error, on an empty code cell, and on a missing
+headline figure -- a notebook that renders but computed nothing is exactly the
+failure mode a visual skim misses. Also dumps the outputs that carry the
+report's claims so they can be read without opening Jupyter, and saves the
+dominance figure beside the notebook for a quick look.
+"""
+
+import base64
+import sys
+from pathlib import Path
+
+import nbformat
+
+NOTEBOOKS_DIR = Path(__file__).resolve().parent
+NOTEBOOK = NOTEBOOKS_DIR / "clearn_ltm_audit.ipynb"
+
+nb = nbformat.read(NOTEBOOK, as_version=4)
+
+errors: list[str] = []
+code_cells = [c for c in nb.cells if c.cell_type == "code"]
+silent: list[int] = []
+figures = 0
+
+for i, cell in enumerate(code_cells):
+    outs = cell.get("outputs", [])
+    for out in outs:
+        if out.output_type == "error":
+            errors.append(f"cell {i}: {out.ename}: {out.evalue[:300]}")
+        if "image/png" in out.get("data", {}):
+            figures += 1
+    if not outs:
+        silent.append(i)
+
+print(f"cells: {len(nb.cells)} ({len(code_cells)} code), figures: {figures}")
+for e in errors:
+    print(f"ERROR {e}")
+if silent:
+    print(f"code cells with NO output: {silent}")
+
+# The claims the write-up rests on. Each is printed by a specific cell; if a
+# marker disappears the notebook stopped supporting its own conclusions.
+MARKERS = {
+    "identical loop structure": "three scenario partitions are structurally identical",
+    "positions of the singleton-partition loops": "the ranking contradiction",
+    "max |pinned - discovery|": "the pinned-vs-discovery cross-validation",
+    "fragments failed to compile": "the fragment-compile failure count",
+    "discovered loops traversing a failing edge": "loop results are uncontaminated",
+    "one scored input": "the relative-link-ranking degeneracy",
+}
+found = {k: False for k in MARKERS}
+for cell in code_cells:
+    for out in cell.get("outputs", []):
+        text = out.get("text", "") if out.output_type == "stream" else ""
+        for key in MARKERS:
+            if key in text:
+                found[key] = True
+
+print("\n--- headline outputs ---")
+for cell in code_cells:
+    for out in cell.get("outputs", []):
+        if out.output_type == "stream" and any(k in out.get("text", "") for k in MARKERS):
+            print(out["text"].rstrip())
+            print("-" * 70)
+
+missing = [MARKERS[k] for k, ok in found.items() if not ok]
+if missing:
+    print("\nMISSING evidence for:")
+    for m in missing:
+        print(f"  - {m}")
+
+for cell in code_cells:
+    if "gridspec_kw" in cell.source:
+        for out in cell.get("outputs", []):
+            if "image/png" in out.get("data", {}):
+                preview = NOTEBOOKS_DIR / "clearn_dominance.png"
+                preview.write_bytes(base64.b64decode(out["data"]["image/png"]))
+                print(f"\nsaved {preview}")
+
+if errors or missing or figures == 0:
+    sys.exit(1)
+print("\nOK")

--- a/notebooks/verify_clearn_ltm_audit.py
+++ b/notebooks/verify_clearn_ltm_audit.py
@@ -79,6 +79,6 @@ for cell in code_cells:
                 preview.write_bytes(base64.b64decode(out["data"]["image/png"]))
                 print(f"\nsaved {preview}")
 
-if errors or missing or figures == 0:
+if errors or missing or silent or figures == 0:
     sys.exit(1)
 print("\nOK")

--- a/src/pysimlin/scripts/build_wheels.py
+++ b/src/pysimlin/scripts/build_wheels.py
@@ -1,11 +1,16 @@
 #!/usr/bin/env python3
 """Build wheels for multiple platforms."""
 
+import json
+import os
 import platform
 import shutil
 import subprocess
 import sys
 from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+LIBSIMLIN_DIR = REPO_ROOT / "src" / "libsimlin"
 
 
 def get_platform_tag() -> str:
@@ -27,82 +32,76 @@ def get_platform_tag() -> str:
         raise RuntimeError(f"Unsupported platform: {system} {machine}")
 
 
+def cargo_target_dir() -> Path:
+    """Ask cargo where build artifacts land.
+
+    libsimlin is a workspace member, so its staticlib is written to the
+    *workspace* target directory, not `src/libsimlin/target/`. Deriving the
+    path by hand is how this script previously drifted out of sync with
+    reality; `cargo metadata` is authoritative and honors CARGO_TARGET_DIR
+    and any `build.target-dir` config.
+    """
+    proc = subprocess.run(
+        ["cargo", "metadata", "--format-version", "1", "--no-deps"],
+        cwd=LIBSIMLIN_DIR,
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return Path(json.loads(proc.stdout)["target_directory"])
+
+
 def build_libsimlin() -> Path:
-    """Build the libsimlin static library."""
+    """Build the libsimlin static library and return the path to it."""
     print("Building libsimlin...")
 
-    # Get the path to the libsimlin directory
-    project_root = Path(__file__).parent.parent.parent.parent
-    libsimlin_dir = project_root / "libsimlin"
-
-    # Build the library. The mimalloc feature swaps in mimalloc as the global
-    # allocator: the engine compile path is allocation-heavy and mimalloc roughly
-    # halves allocator time on native builds (docs/design/engine-performance.md).
-    subprocess.run(
-        ["cargo", "build", "--release", "--features", "mimalloc"], cwd=libsimlin_dir, check=True
-    )
-
-    # Return the path to the built library
-    target_dir = libsimlin_dir / "target" / "release"
-
     system = platform.system()
-    if system == "Darwin" or system == "Linux":
-        lib_path = target_dir / "libsimlin.a"
-    else:
+    if system not in ("Darwin", "Linux"):
         raise RuntimeError(f"Unsupported platform: {system}")
 
+    # The mimalloc feature swaps in mimalloc as the global allocator: the
+    # engine compile path is allocation-heavy and mimalloc roughly halves
+    # allocator time on native builds (docs/design/engine-performance.md).
+    subprocess.run(
+        ["cargo", "build", "--release", "--features", "mimalloc"], cwd=LIBSIMLIN_DIR, check=True
+    )
+
+    lib_path = cargo_target_dir() / "release" / "libsimlin.a"
     if not lib_path.exists():
         raise RuntimeError(f"Library not found at {lib_path}")
 
+    print(f"Built {lib_path}")
     return lib_path
 
 
-def copy_library_to_package(lib_path: Path) -> None:
-    """Copy the library to the package directory."""
-    print(f"Copying library from {lib_path}...")
+def build_wheel(lib_path: Path) -> None:
+    """Build the wheel for the current platform.
 
-    # Get the platform-specific directory
-    system = platform.system()
-    machine = platform.machine()
-
-    package_dir = Path(__file__).parent.parent
-
-    if system == "Darwin" and machine == "arm64":
-        lib_dir = package_dir / "lib" / "darwin_arm64"
-    elif system == "Linux":
-        if machine == "aarch64":
-            lib_dir = package_dir / "lib" / "linux_aarch64"
-        elif machine in ("x86_64", "amd64"):
-            lib_dir = package_dir / "lib" / "linux_x86_64"
-        else:
-            raise RuntimeError(f"Unsupported Linux architecture: {machine}")
-    else:
-        raise RuntimeError(f"Unsupported platform: {system} {machine}")
-
-    # Create the directory and copy the library
-    lib_dir.mkdir(parents=True, exist_ok=True)
-    dest_path = lib_dir / lib_path.name
-    shutil.copy2(lib_path, dest_path)
-    print(f"Library copied to {dest_path}")
-
-
-def build_wheel() -> None:
-    """Build the wheel for the current platform."""
+    ``lib_path`` is pinned into the CFFI link step via ``SIMLIN_STATIC_LIB``
+    so the wheel provably contains the staticlib this script just built,
+    rather than whatever ``_ffi_build``'s fallback search happens to find
+    first (GH #682).
+    """
     print("Building wheel...")
 
     package_dir = Path(__file__).parent.parent
 
-    # Clean up old builds
+    # Clean up old builds. `build/` in particular must go: setuptools skips
+    # recompiling the CFFI extension when its object files look current, which
+    # would relink nothing and ship a stale engine.
     for dir_name in ["build", "dist", "simlin.egg-info"]:
         dir_path = package_dir / dir_name
         if dir_path.exists():
             shutil.rmtree(dir_path)
 
-    # Build the wheel
+    # `python -m build`, not `pip wheel`: this script runs under `uv run`, and
+    # uv-managed virtualenvs have no pip. `build` is declared in the dev extra
+    # and provisions the pyproject build-system requires itself.
     subprocess.run(
-        [sys.executable, "-m", "pip", "wheel", ".", "--no-deps", "-w", "dist"],
+        [sys.executable, "-m", "build", "--wheel", "--outdir", "dist"],
         cwd=package_dir,
         check=True,
+        env={**os.environ, "SIMLIN_STATIC_LIB": str(lib_path)},
     )
 
     # Get the built wheel
@@ -136,14 +135,8 @@ def main() -> None:
     print("Building simlin Python package...")
     print(f"Platform: {platform.system()} {platform.machine()}")
 
-    # Build the library
     lib_path = build_libsimlin()
-
-    # Copy to package
-    copy_library_to_package(lib_path)
-
-    # Build the wheel
-    build_wheel()
+    build_wheel(lib_path)
 
     print("Build complete!")
 

--- a/src/pysimlin/simlin/__init__.py
+++ b/src/pysimlin/simlin/__init__.py
@@ -5,10 +5,18 @@ This package provides a Pythonic interface to the Simlin simulation engine,
 allowing you to load, run, and analyze system dynamics models.
 """
 
-__version__ = "0.1.0"
-
+from importlib.metadata import PackageNotFoundError
+from importlib.metadata import version as _dist_version
 from pathlib import Path
 from typing import Union
+
+try:
+    __version__ = _dist_version("pysimlin")
+except PackageNotFoundError:
+    # Imported from the source tree with no installed distribution (the
+    # in-place `setup.py build_ext` development path). There is no version to
+    # report, and inventing one is how this drifted before.
+    __version__ = "0.0.0+unknown"
 
 from .analysis import (
     Analysis,

--- a/src/pysimlin/simlin/_ffi_build.py
+++ b/src/pysimlin/simlin/_ffi_build.py
@@ -92,6 +92,16 @@ def _header_to_cdef(header_text: str) -> str:
 
 def _get_library_path() -> str:
     lib_name = "libsimlin.a"
+
+    # An explicit pin wins over the search below: a build driver that just ran
+    # cargo knows exactly which staticlib it produced, and guessing wrong here
+    # silently links a stale engine into the extension (GH #682).
+    pinned = os.environ.get("SIMLIN_STATIC_LIB")
+    if pinned:
+        if not Path(pinned).exists():
+            raise RuntimeError(f"SIMLIN_STATIC_LIB={pinned} does not exist")
+        return pinned
+
     # Common locations: native release, cross-target release, then debug
     workspace_target = repo_root / "target"
     candidates = [

--- a/src/pysimlin/simlin/analysis.py
+++ b/src/pysimlin/simlin/analysis.py
@@ -225,12 +225,25 @@ class Link:
     def average_relative_score(self) -> float | None:
         """Average the **relative** link score across all time steps.
 
-        This is the importance metric to rank links by: unlike
-        :meth:`average_score`, the relative score is normalized per target
-        into ``[-1, 1]`` and is comparable across the whole model (the
-        fraction of the target's change attributable to this input, GH #652).
-        Rank links by ``abs(link.average_relative_score() or 0.0)`` to find
-        the most important causal links.
+        Unlike :meth:`average_score`, the relative score is normalized per
+        target into ``[-1, 1]``: the fraction of the target's change
+        attributable to this input (GH #652). That makes it meaningful for
+        comparing the inputs *of one target* against each other.
+
+        .. warning::
+
+            **It is not a global importance ranking.** The normalization is
+            per target, so a link into a target with only ONE scored input
+            reads exactly ``±1`` at every step **by construction**, regardless
+            of whether that target matters. Sorting all links by
+            ``abs(average_relative_score())`` therefore floats the links with
+            no competition to the top. Observed on C-LEARN: 143 of 949 scored
+            links have a single-input target, and 58 of the global top 100 by
+            this metric are such links.
+
+            To rank links globally, first group by :attr:`to_var` and either
+            restrict to targets with more than one scored input or weight each
+            target by something that reflects its own importance.
 
         Returns ``None`` when there is no relative-score series, and ``NaN``
         when every step is ``NaN``; the reduction runs over the finite subset
@@ -447,7 +460,27 @@ class Analysis:
     index."""
 
     dominant_periods: tuple[DominantPeriod, ...]
-    """Intervals where a specific set of loops dominates behavior."""
+    """Intervals where a specific set of loops dominates behavior.
+
+    .. warning::
+
+        **Cross-partition, and therefore unreliable when ``partitions`` has
+        more than one entry.** The engine ranks loops for this surface by
+        ``abs(behavior_time_series)`` across the whole model, but that series
+        is a loop's share *within its own cycle partition* (see
+        :class:`Partition`), so the values are not comparable between
+        partitions. A loop ALONE in its partition reads exactly ``±1`` at every
+        active step **by construction**, which beats every loop that has real
+        competition -- so single-loop partitions win every timestep.
+
+        This contradicts :attr:`loops` in the same object, whose
+        "competitive-first" ranking deliberately sorts those same trivial loops
+        LAST. Observed on C-LEARN: ``loops`` ranks the 12 isolated gas-uptake
+        decay loops 141st-153rd of 153, while ``dominant_periods`` reports only
+        those loops as dominant across the entire 1850-2100 run.
+
+        For a model with one partition the surface is fine. Otherwise, group
+        :attr:`loops` by :attr:`Loop.partition` and rank within a partition."""
 
     truncated: bool = False
     """True when the `timeout` elapsed before discovery finished, so

--- a/src/pysimlin/simlin/model.py
+++ b/src/pysimlin/simlin/model.py
@@ -313,6 +313,14 @@ class ModelPatchBuilder:
         ``pin{n}`` id. ``variables`` lists the loop's member variables (order
         is irrelevant; the cycle is recovered from the causal graph).
 
+        ``variables`` must be plain variable idents. An element-subscripted
+        name (``"c_in_mixed_layer[deterministic]"``) is rejected with a
+        ``does_not_exist`` error -- and that is exactly the form
+        ``Analysis.loops`` reports on an arrayed model, so a discovered loop
+        cannot be handed back verbatim. Stripping the subscripts pins the whole
+        apply-to-all family rather than the single element instance discovery
+        found; pinning one element is not expressible today.
+
         .. note::
             A pinned loop occupies its own single-slot cycle partition.  When
             it is the only loop scored in that partition -- always so in
@@ -912,8 +920,16 @@ class Model:
         gracefully: a ``RuntimeWarning`` explains why, and the simulation
         reruns without loop analysis so results are still produced.
 
+        Only variables the engine lays out as overridable constants can be
+        overridden; a computed auxiliary, a flow, or a stock raises
+        ``SimlinRuntimeError`` ("not found in offsets map"). An arrayed
+        constant is addressed per element (``"decay_rate[north]"``) -- its bare
+        name is not a slot and is rejected. :meth:`Sim.get_var_names` lists
+        every addressable name.
+
         Args:
-            overrides: Override values for any model variables (by name)
+            overrides: Values for overridable constants, keyed by the name as
+                it appears in :meth:`Sim.get_var_names`
             analyze_loops: Whether to compute loop dominance analysis (LTM)
 
         Returns:

--- a/src/pysimlin/simlin/run.py
+++ b/src/pysimlin/simlin/run.py
@@ -198,6 +198,17 @@ class Run:
         Uses greedy algorithm to identify which loops explain the most
         variance in model behavior during each period.
 
+        .. warning::
+
+            Like :attr:`Analysis.dominant_periods`, this ranks loops by
+            ``abs(behavior_time_series)`` across the whole model, but that
+            series is a loop's share *within its own cycle partition*
+            (:attr:`Loop.partition`) and is not comparable between partitions.
+            A loop alone in its partition reads ``±1`` by construction and so
+            outranks every loop that has real competition. Trust this surface
+            only when the model has a single cycle partition; otherwise group
+            :attr:`loops` by partition and rank within one.
+
         Returns empty tuple if analyze_loops=False was used.
 
         Returns:

--- a/src/pysimlin/simlin/sim.py
+++ b/src/pysimlin/simlin/sim.py
@@ -461,6 +461,19 @@ class Sim:
             sit on stocks in the same SCC partition, they DO normalize against
             each other and the relative score is meaningful as usual.
 
+        .. warning::
+            **That raw-series read is element 0 only, on an ARRAYED loop.**
+            :meth:`get_series` resolves a name to one slot, and the synthetic's
+            base offset is the loop's first element; appending a subscript
+            (``...loop_score:pin1[boston]``) does not resolve, because the LTM
+            synthetics are absent from :meth:`get_var_names`. So on a loop with
+            :meth:`get_loop_element_count` above 1, the raw read reports a
+            DIFFERENT element than this method's own bare (argmax-abs
+            aggregate) result and than :attr:`Loop.behavior_time_series`, with
+            nothing to signal the mismatch. Check
+            :meth:`get_loop_element_count` before relying on a raw read, and
+            treat per-element raw scores as unavailable today.
+
         Args:
             loop_id: The identifier of the loop (e.g. ``"r1"``).
             element: For arrayed (Apply-to-All) loops, the specific

--- a/src/pysimlin/tests/test_api.py
+++ b/src/pysimlin/tests/test_api.py
@@ -1,5 +1,6 @@
 """Tests for the top-level pysimlin API."""
 
+import importlib.metadata as importlib_metadata
 from pathlib import Path
 
 import pandas as pd
@@ -7,6 +8,24 @@ import pytest
 
 import simlin
 from simlin import Model, Project, Run
+
+
+class TestPackageVersion:
+    """``simlin.__version__`` must report the installed distribution.
+
+    It was a hardcoded ``"0.1.0"`` that had not moved in dozens of releases,
+    so every bug report carrying it named a version that does not exist.
+    """
+
+    def test_version_matches_installed_distribution(self) -> None:
+        try:
+            expected = importlib_metadata.version("pysimlin")
+        except importlib_metadata.PackageNotFoundError:
+            pytest.skip("pysimlin is not installed as a distribution")
+        assert simlin.__version__ == expected
+
+    def test_version_is_not_the_stale_literal(self) -> None:
+        assert simlin.__version__ != "0.1.0"
 
 
 class TestLoadFunction:

--- a/src/simlin-engine/examples/ltm_fragment_failures.rs
+++ b/src/simlin-engine/examples/ltm_fragment_failures.rs
@@ -1,0 +1,819 @@
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+//! Root-cause harness for LTM synthetic fragments that fail to compile.
+//!
+//! `model_ltm_fragment_diagnostics` reports *that* a generated LTM equation
+//! did not compile, but not why: the three failure points inside
+//! `compile_ltm_equation_fragment` (parse errors, the `Var::new` lowering
+//! `Err`, and codegen returning `None`) all collapse to one `Option::None`.
+//! With ~1,600 failures on a single real model, "which construct is broken"
+//! is not answerable from the warning text alone.
+//!
+//! This harness joins the failure list back to the generated equation each
+//! failing variable carries, buckets the equations by the construct they
+//! contain, and prints representative equation text per bucket -- so a small
+//! number of root causes can be told apart from a long tail.
+//!
+//! Usage:
+//!   cargo run --release -p simlin-engine --example ltm_fragment_failures
+//!   LTM_FAIL_MODEL=path/to/model.mdl cargo run --release ... --example ltm_fragment_failures
+//!   LTM_FAIL_SHOW=8 ...   # representative equations printed per bucket
+//!   LTM_FAIL_BUCKET=agg-subscript ...   # dump every equation in one bucket
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use simlin_engine::db::{
+    LtmEquation, LtmSyntheticVar, SimlinDb, model_ltm_variables, set_project_ltm_enabled,
+    sync_from_datamodel_incremental,
+};
+use simlin_engine::open_vensim;
+
+/// The generated equation text for a synthetic variable, one entry per arm
+/// (a scalar equation has exactly one).
+fn arm_texts(equation: &LtmEquation) -> Vec<String> {
+    match equation {
+        LtmEquation::Scalar(arm) => vec![arm.text.clone()],
+        LtmEquation::ApplyToAll(_, arm) => vec![arm.text.clone()],
+        LtmEquation::Arrayed {
+            elements, default, ..
+        } => elements
+            .iter()
+            .map(|(elem, arm)| format!("[{elem}] {}", arm.text))
+            .chain(default.as_ref().map(|d| format!("[default] {}", d.text)))
+            .collect(),
+    }
+}
+
+/// Bucket a failing variable by the construct its generated equation contains.
+///
+/// Ordered most-specific first: a single equation can exhibit several of
+/// these, and the first matching label is the one worth reporting.
+fn bucket(name: &str, texts: &[String]) -> &'static str {
+    let all = texts.join(" ");
+
+    // A reference to a name that is itself an LTM synthetic (the nested `$:`
+    // prefix) means one generated equation reads another generated variable.
+    let nested_synthetic = name.matches("$\u{205a}").count() > 1
+        || name.starts_with("$\u{205a}$\u{205a}")
+        || (name.contains("\u{205a}ltm\u{205a}") && name.matches('$').count() > 1);
+
+    if name.ends_with("\u{205a}arg0") || name.ends_with("\u{205a}arg1") {
+        return "implicit-helper: captured builtin argument";
+    }
+    if nested_synthetic {
+        return "name embeds another synthetic (module-instance endpoint)";
+    }
+    if all.contains("\u{205a}ltm\u{205a}agg\u{205a}") {
+        return "reads a synthetic aggregate node";
+    }
+    if all.contains("smth") || all.contains("delay") || all.contains("trend") {
+        return "equation contains a SMOOTH/DELAY/TREND call";
+    }
+    if all.contains("lookup(") {
+        return "equation contains a LOOKUP";
+    }
+    if all.contains("previous(") && all.contains('[') {
+        return "subscripted PREVIOUS";
+    }
+    if all.contains('[') {
+        return "subscripted reference";
+    }
+    "other"
+}
+
+/// Every `name[i1,i2,...]` subscript in `text`, as the raw index lists.
+fn subscripts(text: &str) -> Vec<Vec<String>> {
+    let bytes: Vec<char> = text.chars().collect();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == '[' {
+            let mut depth = 1;
+            let mut j = i + 1;
+            let mut inner = String::new();
+            while j < bytes.len() && depth > 0 {
+                match bytes[j] {
+                    '[' => {
+                        depth += 1;
+                        inner.push('[');
+                    }
+                    ']' => {
+                        depth -= 1;
+                        if depth > 0 {
+                            inner.push(']');
+                        }
+                    }
+                    c => inner.push(c),
+                }
+                j += 1;
+            }
+            out.push(inner.split(',').map(|s| s.trim().to_string()).collect());
+            i = j;
+        } else {
+            i += 1;
+        }
+    }
+    out
+}
+
+/// How a single subscript index is spelled.
+///
+/// The distinction that matters: a per-element link-score partial is a SCALAR
+/// fragment, so every index must select one element. An index left as a bare
+/// DIMENSION name still denotes the whole axis and cannot compile there --
+/// that is the shape this harness is looking for.
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
+enum IndexKind {
+    /// `dim·elem` -- explicitly qualified, always unambiguous.
+    QualifiedElement,
+    /// a bare element name of some dimension
+    BareElement,
+    /// a bare DIMENSION name: selects the whole axis
+    BareDimension,
+    /// a literal position
+    Numeric,
+    /// `@2`, arithmetic, a variable read -- resolved at compile or run time
+    Expression,
+}
+
+struct DimTables {
+    dims: std::collections::BTreeSet<String>,
+    elements: std::collections::BTreeSet<String>,
+}
+
+fn classify_index(idx: &str, tables: &DimTables) -> IndexKind {
+    let lower = idx.to_lowercase();
+    if idx.contains('\u{00B7}') {
+        return IndexKind::QualifiedElement;
+    }
+    if lower.parse::<f64>().is_ok() {
+        return IndexKind::Numeric;
+    }
+    if tables.dims.contains(&lower) {
+        return IndexKind::BareDimension;
+    }
+    if tables.elements.contains(&lower) {
+        return IndexKind::BareElement;
+    }
+    IndexKind::Expression
+}
+
+/// Classify the *endpoint shape* of a link-score name: what kind of thing sits
+/// on each side of the arrow. This is orthogonal to `bucket` -- it describes
+/// the edge rather than the equation body.
+fn endpoint_shape(name: &str) -> &'static str {
+    let Some(rest) = name.split("link_score\u{205a}").nth(1) else {
+        return "not a link score";
+    };
+    let Some((from, to)) = rest.split_once('\u{2192}') else {
+        return "no arrow in name";
+    };
+    let synth = |s: &str| s.starts_with('$');
+    let sub = |s: &str| s.contains('[');
+    match (synth(from), synth(to), sub(from), sub(to)) {
+        (true, true, _, _) => "synthetic -> synthetic",
+        (true, false, _, true) => "synthetic -> arrayed var",
+        (true, false, _, false) => "synthetic -> scalar var",
+        (false, true, true, _) => "arrayed var -> synthetic",
+        (false, true, false, _) => "scalar var -> synthetic",
+        (false, false, true, true) => "arrayed -> arrayed",
+        (false, false, true, false) => "arrayed -> scalar",
+        (false, false, false, true) => "scalar -> arrayed",
+        (false, false, false, false) => "scalar -> scalar",
+    }
+}
+
+fn main() {
+    let model_path = std::env::var("LTM_FAIL_MODEL")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| {
+            PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+                .join("../../test/xmutil_test_models/C-LEARN v77 for Vensim.mdl")
+        });
+    let show: usize = std::env::var("LTM_FAIL_SHOW")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4);
+    let dump_bucket = std::env::var("LTM_FAIL_BUCKET").ok();
+
+    let contents = std::fs::read_to_string(&model_path).expect("read model");
+    let datamodel = open_vensim(&contents).expect("import vensim model");
+    println!("model: {}", model_path.display());
+
+    let mut db = SimlinDb::default();
+    let sync = sync_from_datamodel_incremental(&mut db, &datamodel, None);
+    set_project_ltm_enabled(&mut db, sync.project, true);
+
+    let main_name = datamodel
+        .models
+        .iter()
+        .find(|m| m.name == "main")
+        .map(|m| m.name.clone())
+        .unwrap_or_else(|| datamodel.models[0].name.clone());
+    let source_model = sync.models[main_name.as_str()].source_model;
+
+    let ltm = model_ltm_variables(&db, source_model, sync.project);
+    println!("ltm mode: {:?}", ltm.mode);
+    println!("synthetic LTM variables emitted: {}", ltm.vars.len());
+
+    // The failure set, harvested exactly as a consumer sees it: the
+    // accumulated warnings from a whole-project diagnostic pass.
+    let diagnostics = simlin_engine::db::collect_all_diagnostics(&db, sync.project);
+    let mut failed_names: Vec<String> = Vec::new();
+    let mut reasons: BTreeMap<String, String> = BTreeMap::new();
+    for d in &diagnostics {
+        let msg = match &d.error {
+            simlin_engine::db::DiagnosticError::Assembly(m) => m,
+            _ => continue,
+        };
+        if msg.contains("failed to compile")
+            && let Some(v) = &d.variable
+        {
+            failed_names.push(v.clone());
+            if let Some(r) = msg.split("Reason").nth(1) {
+                reasons.insert(
+                    v.clone(),
+                    r.trim_start_matches([':', ' ']).trim().to_string(),
+                );
+            }
+        }
+    }
+    failed_names.sort();
+    failed_names.dedup();
+    println!(
+        "fragments reported as failing to compile: {}",
+        failed_names.len()
+    );
+
+    // --- The actual compiler reasons ---------------------------------------
+    //
+    // Normalize each reason to its shape (variable names and offsets differ
+    // per fragment) so the distinct root causes are countable.
+    fn reason_shape(r: &str) -> String {
+        // `SimulationError{code: <per-fragment detail>}` -> `... {code}`; the
+        // detail is a variable name and would make every fragment its own
+        // bucket.
+        if let Some(open) = r.find('{')
+            && let Some(colon) = r[open..].find(':')
+        {
+            let head = &r[..open];
+            let code = &r[open + 1..open + colon];
+            let detail = r[open + colon + 1..]
+                .trim_end_matches(['}', '.', ' '])
+                .trim();
+            return format!("{head}{{{code}}}: {detail}");
+        }
+        // `<Code> at <start>..<end>` -- the byte span is per-fragment noise.
+        if let Some(at) = r.find(" at ") {
+            return r[..at].to_string();
+        }
+        r.to_string()
+    }
+
+    println!("\n=== compiler reasons, by shape ===");
+    let mut reason_counts: BTreeMap<String, (usize, Vec<String>)> = BTreeMap::new();
+    for (name, r) in &reasons {
+        let e = reason_counts
+            .entry(reason_shape(r))
+            .or_insert((0, Vec::new()));
+        e.0 += 1;
+        if e.1.len() < 3 {
+            e.1.push(format!("{name}\n        -> {r}"));
+        }
+    }
+    let mut reason_rows: Vec<_> = reason_counts.iter().collect();
+    reason_rows.sort_by_key(|(_, (n, _))| std::cmp::Reverse(*n));
+    for (shape, (n, examples)) in &reason_rows {
+        println!("\n  {n:6}  {shape}");
+        for e in examples {
+            println!("      {e}");
+        }
+    }
+    println!(
+        "\n  fragments with NO reason captured: {}",
+        failed_names.len() - reasons.len()
+    );
+
+    // Do the five distinct errors correspond to five distinct bugs, or are
+    // some of them the same defect surfacing at different compiler stages?
+    // Cross-tabulate each reason against two structural facts:
+    //   * is this an element-pinned (scalarized) partial? -- a `[elem]` in the
+    //     name, which is what `compile_ltm_synthetic_fragment` routes through
+    //     the direct per-element compile;
+    //   * does either endpoint name an implicit module INSTANCE (an expanded
+    //     SMOOTH/DELAY), which is what makes the source a `module·port` read.
+    println!("\n=== reason x structure ===");
+    println!(
+        "  {:<46} {:>7} {:>11} {:>9} {:>8} {:>9}",
+        "reason", "n", "element-pin", "instance", "LOOKUP", "vector-op"
+    );
+    let eqn_text: BTreeMap<&str, String> = ltm
+        .vars
+        .iter()
+        .map(|v| (v.name.as_str(), arm_texts(&v.equation).join(" ")))
+        .collect();
+    let mut cross: BTreeMap<String, (usize, usize, usize, usize, usize)> = BTreeMap::new();
+    for (name, r) in &reasons {
+        let shape = reason_shape(r);
+        // The element pin lives on the TARGET side of the arrow (the source
+        // side's bracket marks a per-source-element score instead).
+        let element_pinned = name
+            .split("link_score\u{205a}")
+            .nth(1)
+            .and_then(|rest| rest.split('\u{2192}').nth(1))
+            .is_some_and(|to| to.contains('['))
+            || name.contains("]\u{205a}");
+        let instance_endpoint = name
+            .split("link_score\u{205a}")
+            .nth(1)
+            .map(|rest| {
+                rest.split('\u{2192}')
+                    .any(|side| side.starts_with('$') && side.contains('\u{205a}'))
+            })
+            .unwrap_or(false);
+        // Which construct does the equation carry? A LOOKUP's table argument
+        // is the known GH #984 gap (a graphical-function holder is absent from
+        // the dependency dims, so its axis can never be resolved to pin the
+        // index); the array-producing vector builtins are a separate shape.
+        let body = eqn_text.get(name.as_str()).cloned().unwrap_or_default();
+        let has_lookup = body.contains("lookup(");
+        let has_vector_op = [
+            "vector_elm_map",
+            "vector_sort_order",
+            "rank(",
+            "vector_select",
+        ]
+        .iter()
+        .any(|k| body.contains(k));
+
+        let e = cross.entry(shape).or_insert((0, 0, 0, 0, 0));
+        e.0 += 1;
+        if element_pinned {
+            e.1 += 1;
+        }
+        if instance_endpoint {
+            e.2 += 1;
+        }
+        if has_lookup {
+            e.3 += 1;
+        }
+        if has_vector_op {
+            e.4 += 1;
+        }
+    }
+    let mut cross_rows: Vec<_> = cross.into_iter().collect();
+    cross_rows.sort_by_key(|(_, (n, _, _, _, _))| std::cmp::Reverse(*n));
+    for (shape, (n, pinned, inst, lookup, vecop)) in &cross_rows {
+        let short: String = shape.chars().take(46).collect();
+        println!("  {short:<46} {n:>7} {pinned:>11} {inst:>9} {lookup:>8} {vecop:>9}");
+    }
+
+    let by_name: BTreeMap<&str, &LtmSyntheticVar> =
+        ltm.vars.iter().map(|v| (v.name.as_str(), v)).collect();
+
+    // A failing name that is NOT in `ltm.vars` is an implicit helper (the
+    // `model_ltm_implicit_var_info` leg of the diagnostic pass), which carries
+    // no equation of its own here.
+    let mut buckets: BTreeMap<&'static str, Vec<(String, Vec<String>)>> = BTreeMap::new();
+    let mut shapes: BTreeMap<&'static str, usize> = BTreeMap::new();
+    let mut helper_only = 0usize;
+
+    for name in &failed_names {
+        shapes
+            .entry(endpoint_shape(name))
+            .and_modify(|n| *n += 1)
+            .or_insert(1);
+        match by_name.get(name.as_str()) {
+            Some(var) => {
+                let texts = arm_texts(&var.equation);
+                buckets
+                    .entry(bucket(name, &texts))
+                    .or_default()
+                    .push((name.clone(), texts));
+            }
+            None => {
+                helper_only += 1;
+                buckets
+                    .entry(bucket(name, &[]))
+                    .or_default()
+                    .push((name.clone(), vec!["<implicit helper: no equation>".into()]));
+            }
+        }
+    }
+
+    println!("  of which are implicit helpers (no synthetic equation): {helper_only}");
+
+    println!("\n=== failing edges by endpoint shape ===");
+    let mut shape_rows: Vec<_> = shapes.into_iter().collect();
+    shape_rows.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+    for (shape, n) in shape_rows {
+        println!("  {n:6}  {shape}");
+    }
+
+    println!("\n=== failing fragments by construct ===");
+    let mut bucket_rows: Vec<_> = buckets.iter().collect();
+    bucket_rows.sort_by_key(|(_, v)| std::cmp::Reverse(v.len()));
+    for (label, entries) in &bucket_rows {
+        println!("  {:6}  {}", entries.len(), label);
+    }
+
+    for (label, entries) in &bucket_rows {
+        println!("\n--- {} ({} fragments) ---", label, entries.len());
+        let limit = if dump_bucket.as_deref() == Some(*label) {
+            entries.len()
+        } else {
+            show
+        };
+        for (name, texts) in entries.iter().take(limit) {
+            println!("  name: {name}");
+            for t in texts.iter().take(3) {
+                let shown: String = t.chars().take(400).collect();
+                println!("    eqn: {shown}");
+            }
+            if texts.len() > 3 {
+                println!("    ... {} more arms", texts.len() - 3);
+            }
+        }
+    }
+
+    // --- The hypothesis test -----------------------------------------------
+    //
+    // A per-element link-score partial is a scalar fragment. If a subscript
+    // index in one is left as a bare DIMENSION name it still denotes the whole
+    // axis, which cannot compile in scalar context. Count how many failures
+    // exhibit that, and -- the control -- how many SUCCEEDING fragments do.
+    let mut tables = DimTables {
+        dims: Default::default(),
+        elements: Default::default(),
+    };
+    for dim in &datamodel.dimensions {
+        tables.dims.insert(dim.name.to_lowercase());
+        if let simlin_engine::datamodel::DimensionElements::Named(names) = &dim.elements {
+            for elem in names {
+                tables.elements.insert(elem.to_lowercase());
+            }
+        }
+    }
+    println!(
+        "\n=== dimension tables: {} dimensions, {} element names ===",
+        tables.dims.len(),
+        tables.elements.len()
+    );
+
+    let failed_set: std::collections::BTreeSet<&str> =
+        failed_names.iter().map(|s| s.as_str()).collect();
+
+    let mut fail_with_bare_dim = 0usize;
+    let mut fail_without = 0usize;
+    let mut ok_with_bare_dim = 0usize;
+    let mut ok_without = 0usize;
+    let mut bare_dim_examples: Vec<String> = Vec::new();
+    let mut fail_no_bare_dim_examples: Vec<(String, String)> = Vec::new();
+
+    for var in &ltm.vars {
+        let texts = arm_texts(&var.equation);
+        let mut offenders: Vec<(String, Vec<String>)> = Vec::new();
+        for t in &texts {
+            for sub in subscripts(t) {
+                if sub
+                    .iter()
+                    .any(|idx| classify_index(idx, &tables) == IndexKind::BareDimension)
+                {
+                    offenders.push((t.clone(), sub));
+                }
+            }
+        }
+        let has_bare_dim = !offenders.is_empty();
+        let failed = failed_set.contains(var.name.as_str());
+        match (failed, has_bare_dim) {
+            (true, true) => {
+                fail_with_bare_dim += 1;
+                if bare_dim_examples.len() < 6 {
+                    let (_t, sub) = &offenders[0];
+                    bare_dim_examples
+                        .push(format!("{}   offending index list: {:?}", var.name, sub));
+                }
+            }
+            (true, false) => {
+                fail_without += 1;
+                if fail_no_bare_dim_examples.len() < 6 {
+                    fail_no_bare_dim_examples.push((
+                        var.name.clone(),
+                        texts
+                            .first()
+                            .cloned()
+                            .unwrap_or_default()
+                            .chars()
+                            .take(300)
+                            .collect(),
+                    ));
+                }
+            }
+            (false, true) => ok_with_bare_dim += 1,
+            (false, false) => ok_without += 1,
+        }
+    }
+
+    println!("\n=== does a bare dimension-name subscript predict failure? ===");
+    println!(
+        "  (over the {} synthetic vars that carry an equation)",
+        ltm.vars.len()
+    );
+    println!("                       | FAILED | compiled");
+    println!("  bare dim-name index  | {fail_with_bare_dim:6} | {ok_with_bare_dim:8}");
+    println!("  none                 | {fail_without:6} | {ok_without:8}");
+    println!("\n  examples of a FAILING fragment with a bare dimension-name index:");
+    for e in &bare_dim_examples {
+        println!("    {e}");
+    }
+    println!("\n  examples of a FAILING fragment WITHOUT one (needs its own explanation):");
+    for (n, t) in &fail_no_bare_dim_examples {
+        println!("    {n}\n      {t}");
+    }
+
+    // A bare dimension name is only ILLEGAL in a scalar fragment; in an
+    // ApplyToAll equation over that same dimension it is the ordinary
+    // same-element spelling. Refine by equation variant.
+    println!("\n=== refined: bare dimension-name index, split by equation variant ===");
+    println!("  variant      bare-dim?   FAILED   compiled");
+    let mut refined: BTreeMap<(&'static str, bool), (usize, usize)> = BTreeMap::new();
+    for var in &ltm.vars {
+        let variant = match &var.equation {
+            LtmEquation::Scalar(_) => "Scalar",
+            LtmEquation::ApplyToAll(..) => "ApplyToAll",
+            LtmEquation::Arrayed { .. } => "Arrayed",
+        };
+        let texts = arm_texts(&var.equation);
+        let has_bare = texts.iter().any(|t| {
+            subscripts(t).iter().any(|sub| {
+                sub.iter()
+                    .any(|idx| classify_index(idx, &tables) == IndexKind::BareDimension)
+            })
+        });
+        let entry = refined.entry((variant, has_bare)).or_insert((0, 0));
+        if failed_set.contains(var.name.as_str()) {
+            entry.0 += 1;
+        } else {
+            entry.1 += 1;
+        }
+    }
+    for ((variant, has_bare), (f, ok)) in &refined {
+        println!("  {variant:<12} {:<11} {f:6}   {ok:8}", has_bare);
+    }
+
+    // Are the failing implicit helpers independent causes, or consequences of
+    // a parent link score that already failed? A helper is named
+    // `$:<parent>:<n>:arg<k>[:<elem>]`; recover the parent and check.
+    println!("\n=== are the 606 failing implicit helpers consequences of a failing parent? ===");
+    let mut helper_parent_failed = 0usize;
+    let mut helper_parent_ok = 0usize;
+    let mut helper_parent_unknown = 0usize;
+    let mut orphan_examples: Vec<String> = Vec::new();
+    for name in &failed_names {
+        if by_name.contains_key(name.as_str()) {
+            continue; // has its own equation: not a helper
+        }
+        // Strip the leading synthesis marker and the trailing `:<n>:arg<k>[:<elem>]`.
+        let inner = name.strip_prefix("$\u{205a}").unwrap_or(name);
+        let parts: Vec<&str> = inner.split('\u{205a}').collect();
+        let mut parent: Option<String> = None;
+        for cut in (1..parts.len()).rev() {
+            let cand = parts[..cut].join("\u{205a}");
+            if by_name.contains_key(cand.as_str()) {
+                parent = Some(cand);
+                break;
+            }
+        }
+        match parent {
+            Some(p) if failed_set.contains(p.as_str()) => helper_parent_failed += 1,
+            Some(p) => {
+                helper_parent_ok += 1;
+                if orphan_examples.len() < 6 {
+                    orphan_examples.push(format!("{name}\n      parent COMPILED: {p}"));
+                }
+            }
+            None => {
+                helper_parent_unknown += 1;
+                if orphan_examples.len() < 6 {
+                    orphan_examples.push(format!(
+                        "{name}\n      parent not found among synthetic vars"
+                    ));
+                }
+            }
+        }
+    }
+    println!("  helper failed AND its parent link score also failed : {helper_parent_failed}");
+    println!("  helper failed but its parent COMPILED               : {helper_parent_ok}");
+    println!("  helper failed, parent not identifiable             : {helper_parent_unknown}");
+    if !orphan_examples.is_empty() {
+        println!("\n  helpers not explained by a failing parent:");
+        for e in &orphan_examples {
+            println!("    {e}");
+        }
+    }
+
+    // Cluster 2: link scores whose endpoint is an implicit module INSTANCE
+    // (an expanded SMOOTH/DELAY), referenced as `"$:...:smth1:...·port"`.
+    println!(
+        "\n=== cluster: an endpoint is an implicit module instance (expanded SMOOTH/DELAY) ==="
+    );
+    let mut mod_fail = 0usize;
+    let mut mod_ok = 0usize;
+    let mut nonmod_fail = 0usize;
+    let mut nonmod_ok = 0usize;
+    for var in &ltm.vars {
+        let endpoint_is_instance = var
+            .name
+            .split("link_score\u{205a}")
+            .nth(1)
+            .map(|rest| {
+                rest.split('\u{2192}')
+                    .any(|side| side.starts_with('$') && side.contains("\u{205a}"))
+            })
+            .unwrap_or(false);
+        let failed = failed_set.contains(var.name.as_str());
+        match (endpoint_is_instance, failed) {
+            (true, true) => mod_fail += 1,
+            (true, false) => mod_ok += 1,
+            (false, true) => nonmod_fail += 1,
+            (false, false) => nonmod_ok += 1,
+        }
+    }
+    println!("                            FAILED   compiled");
+    println!("  endpoint is an instance   {mod_fail:6}   {mod_ok:8}");
+    println!("  neither endpoint is       {nonmod_fail:6}   {nonmod_ok:8}");
+
+    // Cause B's exact mechanism. `builtins_visitor::is_module_backed_ident`
+    // splits a `module·port` reference on the middle dot and asks whether the
+    // BASE is a known module ident; if it is, PREVIOUS() is rewritten through
+    // a scalar capture helper, and if it is not, PREVIOUS() gets a reference
+    // codegen cannot take. So: are the module bases these failing equations
+    // reference actually present in the implicit-module table?
+    println!("\n=== cause B: are the referenced module bases known as modules? ===");
+    let implicit = simlin_engine::db::model_implicit_var_info(&db, source_model, sync.project);
+    let implicit_modules: std::collections::BTreeSet<&str> = implicit
+        .iter()
+        .filter(|(_, m)| m.is_module)
+        .map(|(n, _)| n.as_str())
+        .collect();
+    let explicit_modules: std::collections::BTreeSet<String> = source_model
+        .variables(&db)
+        .iter()
+        .filter(|(_, sv)| sv.kind(&db) == simlin_engine::db::SourceVariableKind::Module)
+        .map(|(n, _)| n.to_string())
+        .collect();
+    println!(
+        "  implicit module instances: {}   explicit module variables: {}",
+        implicit_modules.len(),
+        explicit_modules.len()
+    );
+
+    let mut base_known = 0usize;
+    let mut base_unknown = 0usize;
+    let mut unknown_examples: Vec<String> = Vec::new();
+    for (name, r) in &reasons {
+        if !r.contains("PREVIOUS requires a variable reference") {
+            continue;
+        }
+        let body = eqn_text.get(name.as_str()).cloned().unwrap_or_default();
+        // Every `·`-bearing quoted ident in the body.
+        for tok in body.split('"').skip(1).step_by(2) {
+            if let Some((base, _port)) = tok.split_once('\u{00B7}') {
+                if implicit_modules.contains(base) || explicit_modules.contains(base) {
+                    base_known += 1;
+                } else {
+                    base_unknown += 1;
+                    if unknown_examples.len() < 5 {
+                        unknown_examples.push(base.to_string());
+                    }
+                }
+                break;
+            }
+        }
+    }
+    println!("  module·port references whose BASE is a known module   : {base_known}");
+    println!("  module·port references whose BASE is NOT known        : {base_unknown}");
+    if !unknown_examples.is_empty() {
+        println!("  unknown bases (sample):");
+        for e in &unknown_examples {
+            println!("    {e}");
+        }
+        println!("  nearest known implicit module instances (sample):");
+        for m in implicit_modules.iter().take(5) {
+            println!("    {m}");
+        }
+    }
+
+    // Did the PREVIOUS helper rewrite actually fire for the cause-B parents?
+    // If it did, a capture aux exists whose `ltm_parent_name` is the failing
+    // link score, and the defect is downstream of the rewrite; if it did not,
+    // the defect is the rewrite's own decision.
+    println!("\n=== cause B: was a capture helper synthesized for the failing parent? ===");
+    let ltm_implicit =
+        simlin_engine::db::model_ltm_implicit_var_info(&db, source_model, sync.project);
+    let mut helpers_by_parent: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for (hname, meta) in ltm_implicit.iter() {
+        helpers_by_parent
+            .entry(meta.ltm_parent_name.as_str())
+            .or_default()
+            .push(hname.as_str());
+    }
+    let mut with_helper = 0usize;
+    let mut without_helper = 0usize;
+    let mut helper_also_failed = 0usize;
+    let mut sample: Vec<String> = Vec::new();
+    for (name, r) in &reasons {
+        if !r.contains("PREVIOUS requires a variable reference") {
+            continue;
+        }
+        match helpers_by_parent.get(name.as_str()) {
+            Some(hs) => {
+                with_helper += 1;
+                if hs.iter().any(|h| failed_set.contains(*h)) {
+                    helper_also_failed += 1;
+                }
+                if sample.len() < 3 {
+                    sample.push(format!("{name}\n        helpers: {hs:?}"));
+                }
+            }
+            None => {
+                without_helper += 1;
+                if sample.len() < 3 {
+                    sample.push(format!("{name}\n        NO capture helper synthesized"));
+                }
+            }
+        }
+    }
+    println!("  cause-B parents WITH a capture helper   : {with_helper}");
+    println!("     ...whose helper ALSO failed to compile: {helper_also_failed}");
+    println!("  cause-B parents WITHOUT one             : {without_helper}");
+    for s in &sample {
+        println!("    {s}");
+    }
+
+    // Is each failure the generated link score itself, or the capture helper
+    // synthesized while parsing it? They are different defects with different
+    // fixes, and the reason alone does not distinguish them.
+    println!("\n=== reason x (link score vs capture helper) ===");
+    let mut kind_split: BTreeMap<String, (usize, usize)> = BTreeMap::new();
+    for (name, r) in &reasons {
+        let e = kind_split.entry(reason_shape(r)).or_insert((0, 0));
+        if ltm_implicit.contains_key(name.as_str()) {
+            e.1 += 1;
+        } else {
+            e.0 += 1;
+        }
+    }
+    let mut ks: Vec<_> = kind_split.into_iter().collect();
+    ks.sort_by_key(|(_, (a, b))| std::cmp::Reverse(a + b));
+    println!("  {:<50} {:>11} {:>8}", "reason", "link score", "helper");
+    for (shape, (score, helper)) in &ks {
+        let short: String = shape.chars().take(50).collect();
+        println!("  {short:<50} {score:>11} {helper:>8}");
+    }
+
+    // Which target variables absorb the failures, and what shape are they?
+    println!("\n=== failing link-score targets, by the target's own equation shape ===");
+    let source_vars = source_model.variables(&db);
+    let mut target_kinds: BTreeMap<&'static str, usize> = BTreeMap::new();
+    let mut example_targets: BTreeMap<&'static str, Vec<String>> = BTreeMap::new();
+    for name in &failed_names {
+        let Some(rest) = name.split("link_score\u{205a}").nth(1) else {
+            continue;
+        };
+        let Some((_from, to)) = rest.split_once('\u{2192}') else {
+            continue;
+        };
+        let to_base = to.split('[').next().unwrap_or(to);
+        let to_base = to_base.split('\u{205a}').next().unwrap_or(to_base);
+        let kind = match source_vars.get(to_base) {
+            None => "target not a model variable",
+            Some(sv) => match sv.equation(&db) {
+                simlin_engine::datamodel::Equation::Scalar(..) => "target: Scalar equation",
+                simlin_engine::datamodel::Equation::ApplyToAll(..) => "target: ApplyToAll equation",
+                simlin_engine::datamodel::Equation::Arrayed(..) => {
+                    "target: Arrayed (per-element) equation"
+                }
+            },
+        };
+        target_kinds
+            .entry(kind)
+            .and_modify(|n| *n += 1)
+            .or_insert(1);
+        let ex = example_targets.entry(kind).or_default();
+        if ex.len() < 6 && !ex.iter().any(|e| e == to_base) {
+            ex.push(to_base.to_string());
+        }
+    }
+    let mut kind_rows: Vec<_> = target_kinds.into_iter().collect();
+    kind_rows.sort_by_key(|(_, n)| std::cmp::Reverse(*n));
+    for (kind, n) in kind_rows {
+        println!("  {n:6}  {kind}");
+        if let Some(ex) = example_targets.get(kind) {
+            println!("          e.g. {}", ex.join(", "));
+        }
+    }
+}

--- a/src/simlin-engine/examples/ltm_fragment_failures.rs
+++ b/src/simlin-engine/examples/ltm_fragment_failures.rs
@@ -221,17 +221,33 @@ fn main() {
 
     // The failure set, harvested exactly as a consumer sees it: the
     // accumulated warnings from a whole-project diagnostic pass.
+    //
+    // `collect_all_diagnostics` covers EVERY model in the project, while `ltm`
+    // above is the analyzed model's alone -- and a project carries the spliced
+    // stdlib SMOOTH/DELAY templates as models of their own. Keying failures by
+    // variable name without checking the model would let a sub-model failure
+    // be counted as this model's, and -- because the join against `ltm.vars`
+    // would then miss -- misclassified as an implicit helper. Same-named
+    // variables in different models would collide outright. Filter first, and
+    // report what was dropped rather than discarding it silently, since a
+    // non-empty drop means the analyzed model is not the whole story.
     let diagnostics = simlin_engine::db::collect_all_diagnostics(&db, sync.project);
     let mut failed_names: Vec<String> = Vec::new();
     let mut reasons: BTreeMap<String, String> = BTreeMap::new();
+    let mut other_model_failures: BTreeMap<String, usize> = BTreeMap::new();
     for d in &diagnostics {
         let msg = match &d.error {
             simlin_engine::db::DiagnosticError::Assembly(m) => m,
             _ => continue,
         };
-        if msg.contains("failed to compile")
-            && let Some(v) = &d.variable
-        {
+        if !msg.contains("failed to compile") {
+            continue;
+        }
+        if d.model != main_name {
+            *other_model_failures.entry(d.model.clone()).or_insert(0) += 1;
+            continue;
+        }
+        if let Some(v) = &d.variable {
             failed_names.push(v.clone());
             if let Some(r) = msg.split("Reason").nth(1) {
                 reasons.insert(
@@ -247,6 +263,15 @@ fn main() {
         "fragments reported as failing to compile: {}",
         failed_names.len()
     );
+    if other_model_failures.is_empty() {
+        println!("  (no failures in other project models)");
+    } else {
+        let total: usize = other_model_failures.values().sum();
+        println!("  EXCLUDED -- {total} failure(s) in other project models, by model:");
+        for (model, n) in &other_model_failures {
+            println!("    {n:6}  {model}");
+        }
+    }
 
     // --- The actual compiler reasons ---------------------------------------
     //

--- a/src/simlin-engine/examples/ltm_fragment_failures.rs
+++ b/src/simlin-engine/examples/ltm_fragment_failures.rs
@@ -231,6 +231,23 @@ fn main() {
     // variables in different models would collide outright. Filter first, and
     // report what was dropped rather than discarding it silently, since a
     // non-empty drop means the analyzed model is not the whole story.
+    //
+    // A diagnostic can also carry an EMPTY model name -- `collect_all_diagnostics`
+    // emits the project-level unit and macro-registry errors before its per-model
+    // loop. Those are excluded and counted here too rather than falling through
+    // as this model's; none of them match "failed to compile" today, so the
+    // handling is deliberate rather than load-bearing.
+    //
+    // On C-LEARN the excluded set is empty, which is why no figure this harness
+    // has produced was distorted. That is a property of the corpus, not of the
+    // harness: 9 non-main models carry 162 LTM synthetics between them (the
+    // spliced stdlib SMOOTH/DELAY/TREND/NPV templates plus the RAMP FROM TO,
+    // SAMPLE UNTIL and SSHAPE macros), and they simply all compile. The moment
+    // one of them gains a failing fragment, the unfiltered version would have
+    // charged it to this model AND -- missing the join below -- dropped it into
+    // the implicit-helper bucket, which is the population the "no failing helper
+    // under a compiling parent" invariant is read from. This filter is a
+    // tripwire against that, not a correction to anything already reported.
     let diagnostics = simlin_engine::db::collect_all_diagnostics(&db, sync.project);
     let mut failed_names: Vec<String> = Vec::new();
     let mut reasons: BTreeMap<String, String> = BTreeMap::new();

--- a/src/simlin-engine/src/builtins_visitor.rs
+++ b/src/simlin-engine/src/builtins_visitor.rs
@@ -400,6 +400,22 @@ impl<'a> BuiltinVisitor<'a> {
     /// Module variables and qualified module outputs (`module·output`) must
     /// be treated as module-backed so PREVIOUS/INIT can synthesize scalar
     /// helper args before compiling to intrinsic opcodes.
+    ///
+    /// The `·` split runs on the RAW ident, so a fully-quoted composite --
+    /// `"module·port"`, which is what `ltm_augment::quote_ident` emits for every
+    /// module-output reference in a generated LTM equation -- misses: the raw text
+    /// keeps its quotes, the base is `"module` (an unclosed quote that
+    /// `canonicalize` passes through verbatim), and the module lookup fails. That
+    /// miss is INERT, not a latent bug: `canonicalize` strips a balanced quoted
+    /// part, so the whole ident still resolves through `Context::var_ref` to the
+    /// module instance's slot, codegen's `static_slot` accepts the resulting
+    /// `Expr::Var`, and the emitted `LoadPrev` reads exactly the slot a capture
+    /// helper would have. The helper path is needed only for a reference codegen
+    /// cannot take a fixed slot for -- an ARRAYED module output port, which no
+    /// model in the corpus produces. Splitting the canonical form instead would be
+    /// a one-token change; it is not made because it buys no observable behavior
+    /// and the quoted spelling is itself pinned by
+    /// `ltm_augment_tests::quote_ident_needs_both_of_its_conjuncts`.
     fn is_module_backed_ident(&self, ident: &RawIdent) -> bool {
         let canonical = Ident::new(&canonicalize(ident.as_str()));
         if self.is_known_module_ident(&canonical) {

--- a/src/simlin-engine/src/compiler/dimensions.rs
+++ b/src/simlin-engine/src/compiler/dimensions.rs
@@ -19,8 +19,30 @@ use crate::dimensions::{Dimension, DimensionsContext};
 ///   inserted last;
 /// - the allocation is ONE-TO-ONE: each active axis is consumed at most once
 ///   (`used`), so two dependency axes that could each match the same active axis
-///   are given different ones in declaration order. Searching per dependency axis
-///   independently lets both claim the first match.
+///   are given different ones. Searching per dependency axis independently lets
+///   both claim the first match.
+///
+///   Which of the two gets it is decided by MATCH STRENGTH, not by declaration
+///   order: the three passes are staged flat -- every name match across all
+///   dependency axes, then every mapping match, then every size match -- so a
+///   stronger match always outranks a weaker one no matter which axis is
+///   declared first. Order only breaks ties WITHIN a pass. Running the passes
+///   per dimension instead made declaration order decisive, which is GH #996
+///   (see the FIRST PASS comment in the body), and both
+///   `a_mapping_match_does_not_steal_a_later_name_match` and
+///   `a_size_match_does_not_steal_a_later_mapping_match` pin the corrected rule.
+///   This is the same flat staging the sibling `match_dimensions_with_mapping`
+///   uses; the two functions state one precedence rule and must not drift.
+///
+///   Restaging is inert for the COMPILER path on the corpus: computing the old
+///   allocation alongside the new one at every call and flagging disagreement
+///   found zero across 7,617 calls / 53 distinct shapes (lib + integration), and
+///   556 / 4 while compiling C-LEARN with LTM. Treat that as empirical, not as
+///   proof -- the corpus is a WEAK instrument here. 18 of the 20 lib shapes are
+///   exact identity name matches, and only one reaches the mapping branch at all,
+///   with a single active axis where no reordering is possible. The shapes that
+///   could distinguish the orders are barely exercised, so "no disagreement" is
+///   mostly a statement about the corpus.
 ///
 /// Both were live silent-wrong-row defects in the LTM per-element projection
 /// (P2-1 / P2-2 of the whole-branch review) precisely because that projection
@@ -37,15 +59,35 @@ pub(crate) fn allocate_implicit_axes_partial(
     active_dims: &[Dimension],
     dimensions_ctx: &DimensionsContext,
 ) -> Vec<Option<usize>> {
-    let mut alloc: Vec<Option<usize>> = Vec::with_capacity(dims.len());
+    let mut alloc: Vec<Option<usize>> = vec![None; dims.len()];
 
     // Track which active dimensions have been used.
     let mut used: Vec<bool> = vec![false; active_dims.len()];
 
-    for dim in dims.iter() {
-        // FIRST PASS: Try to find an exact name match anywhere in unused active dims.
-        // This prevents size-based fallback from grabbing the wrong dimension when
-        // the correct name match exists later in the list.
+    // The three passes are STAGED FLAT: every exact name match across all
+    // dependency dimensions, then every mapping match, then every size match.
+    // That is what makes the documented precedence name > mapping > size hold
+    // for the WHOLE allocation rather than only within one dimension's turn,
+    // and it is the structure the sibling `match_dimensions_with_mapping` in
+    // this file already used.
+    //
+    // Run per dimension instead, an earlier axis consumes -- through a weaker
+    // match -- the active axis a later one matches more strongly, and since
+    // `used` is one-to-one the later axis is then left unresolved. That is
+    // GH #996. On C-LEARN it hit TWO production shapes, not one:
+    // `aggregated_definition[cop, aggregated_regions]` read under an
+    // `[aggregated_regions]` target and `[cop, semi_agg]` under `[semi_agg]` --
+    // both because the target's own dimension declares an element map ONTO
+    // `cop`, so `cop` (declared first) took the slot by MAPPING before the
+    // name-matching axis was considered. Each allocated `[Some(0), None]`, the
+    // LTM pin table dropped the dep, and 135 link scores were declined.
+    //
+    // The FIRST PASS's original comment already stated this rule for the SIZE
+    // fallback ("prevents size-based fallback from grabbing the wrong dimension
+    // when the correct name match exists later in the list"); the mapping pass
+    // was added afterwards, between name and size, and reintroduced for mappings
+    // the hazard that comment was written against.
+    for (dim_idx, dim) in dims.iter().enumerate() {
         let name_match_idx = active_dims.iter().enumerate().find_map(|(i, candidate)| {
             if !used[i] && candidate.name() == dim.name() {
                 Some(i)
@@ -55,8 +97,13 @@ pub(crate) fn allocate_implicit_axes_partial(
         });
 
         if let Some(idx) = name_match_idx {
-            alloc.push(Some(idx));
+            alloc[dim_idx] = Some(idx);
             used[idx] = true;
+        }
+    }
+
+    for (dim_idx, dim) in dims.iter().enumerate() {
+        if alloc[dim_idx].is_some() {
             continue;
         }
 
@@ -96,8 +143,13 @@ pub(crate) fn allocate_implicit_axes_partial(
         };
 
         if let Some(idx) = mapping_match_idx {
-            alloc.push(Some(idx));
+            alloc[dim_idx] = Some(idx);
             used[idx] = true;
+        }
+    }
+
+    for (dim_idx, dim) in dims.iter().enumerate() {
+        if alloc[dim_idx].is_some() {
             continue;
         }
 
@@ -128,8 +180,8 @@ pub(crate) fn allocate_implicit_axes_partial(
             None
         };
 
-        alloc.push(size_match_idx);
         if let Some(idx) = size_match_idx {
+            alloc[dim_idx] = Some(idx);
             used[idx] = true;
         }
     }
@@ -336,6 +388,127 @@ mod tests {
                 mappings: vec![],
             },
         )
+    }
+
+    /// GH #996: a NAME match must win globally, not lose to an earlier
+    /// dimension's MAPPING match just because that dimension is processed first.
+    ///
+    /// The hand-built input is exactly what production supplies. Instrumenting
+    /// `ltm_augment_post_transform::dep_element_pins` and running C-LEARN
+    /// (`test/xmutil_test_models/C-LEARN v77 for Vensim.mdl`) dumped, for the
+    /// `rs_ff_co2_ff_aggregated[developed_countries]` link score:
+    ///
+    /// ```text
+    /// dep=aggregated_definition
+    /// dep_dims=["cop","aggregated_regions"]  target_dims=["aggregated_regions"]
+    /// target_elems=["developed_countries"]
+    /// elems=[None, None]  axes=[]  complete=false
+    /// ```
+    ///
+    /// `Aggregated Regions` declares an explicit element map onto `COP`, so
+    /// `cop` -- processed FIRST -- matched the single active slot through the
+    /// mapping pass's reverse branch (`has_mapping_to(aggregated_regions, cop)`),
+    /// and `aggregated_regions`, which matches that slot BY NAME, found it taken.
+    /// Both axes resolved to `None`, `dep_element_pins` dropped the dep, its
+    /// dimension-name subscript survived into a scalar fragment, and 135 C-LEARN
+    /// link scores were declined.
+    ///
+    /// The first pass's own comment already states this rule for the SIZE
+    /// fallback ("prevents size-based fallback from grabbing the wrong dimension
+    /// when the correct name match exists later in the list"); the mapping pass
+    /// was added afterwards and reintroduced the hazard it was written against.
+    #[test]
+    fn a_mapping_match_does_not_steal_a_later_name_match() {
+        use crate::datamodel;
+
+        let cop = datamodel::Dimension::named(
+            "COP".to_string(),
+            vec!["c1".to_string(), "c2".to_string()],
+        );
+        let mut agg = datamodel::Dimension::named(
+            "Aggregated Regions".to_string(),
+            vec!["r1".to_string(), "r2".to_string()],
+        );
+        // Many-to-one, exactly C-LEARN's shape: the map is what makes the
+        // reverse mapping branch fire for `cop`.
+        agg.mappings = vec![datamodel::DimensionMapping {
+            target: "COP".to_string(),
+            element_map: vec![
+                ("r1".to_string(), "c1".to_string()),
+                ("r2".to_string(), "c2".to_string()),
+            ],
+        }];
+        let ctx = crate::dimensions::DimensionsContext::from(&[cop, agg]);
+        let cop_d = ctx
+            .get(&CanonicalDimensionName::from_raw("COP"))
+            .expect("cop")
+            .clone();
+        let agg_d = ctx
+            .get(&CanonicalDimensionName::from_raw("Aggregated Regions"))
+            .expect("agg")
+            .clone();
+
+        // The dep is declared [COP, Aggregated Regions]; the target iterates
+        // Aggregated Regions alone. Only axis 1 corresponds, and it does so BY
+        // NAME -- axis 0 must not consume the slot through its mapping.
+        assert_eq!(
+            allocate_implicit_axes_partial(
+                &[cop_d.clone(), agg_d.clone()],
+                std::slice::from_ref(&agg_d),
+                &ctx
+            ),
+            vec![None, Some(0)],
+            "the name-matching axis must get the slot; a mapping match on an \
+             earlier axis must not consume it first"
+        );
+
+        // Control: with the name-matching axis FIRST the old order already
+        // worked, so this pins that the fix did not simply invert a preference.
+        assert_eq!(
+            allocate_implicit_axes_partial(
+                &[agg_d.clone(), cop_d],
+                std::slice::from_ref(&agg_d),
+                &ctx
+            ),
+            vec![Some(0), None],
+            "declaration order must not change which axis wins"
+        );
+    }
+
+    /// The same precedence, one rung down: a SIZE match on an earlier axis must
+    /// not consume the slot a later axis matches by MAPPING.
+    ///
+    /// This is why all three passes are staged flat rather than two. Hoisting
+    /// only the name pass fixes `name > {mapping, size}` and leaves
+    /// `mapping > size` per-dimension, so this shape still mis-allocated:
+    /// an indexed dep axis grabs the sole indexed active axis by SIZE before the
+    /// axis that maps onto it is ever considered. Not observed in any model --
+    /// it takes two indexed dimensions of equal size plus a mapping -- but the
+    /// rule the function documents is `name > mapping > size`, and a rule that
+    /// holds for two of its three rungs is one a reader cannot rely on.
+    #[test]
+    fn a_size_match_does_not_steal_a_later_mapping_match() {
+        use crate::datamodel;
+
+        let ia = datamodel::Dimension::indexed("IA".to_string(), 2);
+        let ib = datamodel::Dimension::indexed("IB".to_string(), 2);
+        let mut y =
+            datamodel::Dimension::named("Y".to_string(), vec!["y1".to_string(), "y2".to_string()]);
+        y.set_maps_to("IA".to_string());
+        let ctx = crate::dimensions::DimensionsContext::from(&[ia, ib, y]);
+        let get = |n: &str| {
+            ctx.get(&CanonicalDimensionName::from_raw(n))
+                .unwrap_or_else(|| panic!("{n}"))
+                .clone()
+        };
+        let (ia_d, ib_d, y_d) = (get("IA"), get("IB"), get("Y"));
+
+        assert_eq!(
+            allocate_implicit_axes_partial(&[ib_d, y_d], std::slice::from_ref(&ia_d), &ctx),
+            vec![None, Some(0)],
+            "the mapping-matching axis must get the slot; a size match on an \
+             earlier axis must not consume it first"
+        );
     }
 
     #[test]

--- a/src/simlin-engine/src/db/assemble.rs
+++ b/src/simlin-engine/src/db/assemble.rs
@@ -764,10 +764,26 @@ pub(crate) fn compile_phase_to_per_var_bytecodes(
     base: &crate::compiler::ModuleCtx<'_>,
     exprs: &[crate::compiler::Expr],
 ) -> Option<crate::compiler::symbolic::PerVarBytecodes> {
+    compile_phase_to_per_var_bytecodes_reporting(base, exprs).ok()
+}
+
+/// [`compile_phase_to_per_var_bytecodes`], keeping the emit error instead of
+/// discarding it.
+///
+/// The `Option`-returning form above is what every production emitter wants:
+/// a fragment that will not emit is dropped and the caller carries on. But a
+/// *diagnostic* caller needs to say which construct codegen refused, and
+/// `.ok()?` erased that -- which is why ~1,600 dropped fragments on one real
+/// model reported no cause at all. Behavior is unchanged; only the error's
+/// visibility is.
+pub(crate) fn compile_phase_to_per_var_bytecodes_reporting(
+    base: &crate::compiler::ModuleCtx<'_>,
+    exprs: &[crate::compiler::Expr],
+) -> Result<crate::compiler::symbolic::PerVarBytecodes, String> {
     use crate::compiler::symbolic::PerVarBytecodes;
 
     if exprs.is_empty() {
-        return None;
+        return Err("nothing to emit: the phase lowered to zero expressions".to_string());
     }
 
     // Extract temp sizes from expressions
@@ -791,9 +807,11 @@ pub(crate) fn compile_phase_to_per_var_bytecodes(
         ..*base
     };
 
-    let compiled = emit_ctx.compile().ok()?;
+    let compiled = emit_ctx
+        .compile()
+        .map_err(|err| format!("codegen rejected the lowered expressions: {err}"))?;
 
-    Some(PerVarBytecodes {
+    Ok(PerVarBytecodes {
         symbolic: compiled.compiled_flows,
         graphical_functions: compiled.graphical_functions,
         module_decls: compiled.module_decls,
@@ -1505,6 +1523,7 @@ pub fn assemble_module<'db>(
                 project,
                 dep_graph,
                 module_input_names,
+                None,
             );
             if let Some(result) = im_fragment {
                 // Same layout check as for main LTM vars above.

--- a/src/simlin-engine/src/db/diagnostic_tests.rs
+++ b/src/simlin-engine/src/db/diagnostic_tests.rs
@@ -3035,3 +3035,185 @@ fn variable_error_fields_are_the_lowering_channel() {
         "the recorded lowering error must reach collect_all_diagnostics; got: {diags:?}"
     );
 }
+
+// ---- Codegen rejection is attributable (Option 0) ----
+
+/// An ordinary, hand-written apply-to-all equation that LOWERS cleanly but
+/// that CODEGEN refuses must produce a per-variable diagnostic naming the
+/// variable and carrying codegen's reason.
+///
+/// The shape: an array-valued operand of an array builtin must be a *view*
+/// over storage (`codegen::walk_expr_as_view` accepts only
+/// `StaticSubscript | TempArray | Var | Subscript`). `PREVIOUS(vals[d])` is an
+/// `Expr::App`, so `VECTOR SORT ORDER(PREVIOUS(vals[d]), 1)` reaches codegen
+/// intact and is rejected with `Cannot push view for expression type
+/// Discriminant(7)`. Nothing about this equation involves LTM -- it is the
+/// same defect 244 LTM fragments on C-LEARN hit, reached from a model a user
+/// can type.
+///
+/// Before this was wired up the failure was INVISIBLE: `compile_phase` is
+/// `compile_phase_to_per_var_bytecodes(..)`, which is `.ok()` over the
+/// reporting form, so a codegen `Err` was discarded. `collect_all_diagnostics`
+/// returned nothing at all and the only user-facing signal was
+/// `assemble_module`'s unattributed
+/// `NotSimulatable: failed to compile fragments for variables: out`. That is
+/// the exact failure mode `compiler::check_stock_updates_are_emittable`'s
+/// rustdoc says that guard exists to avoid, and it was live for every codegen
+/// rejection.
+///
+/// Asserting merely that compilation FAILS would have passed before the
+/// change; the assertions below are on the diagnostic's attribution and
+/// reason, which is what actually moved.
+#[test]
+fn codegen_rejection_of_an_ordinary_variable_names_the_variable_and_its_reason() {
+    let project = crate::test_common::TestProject::new("codegen_reject")
+        .named_dimension("d", &["e1", "e2", "e3"])
+        .array_aux("vals[d]", "10")
+        .array_aux("out[d]", "VECTOR SORT ORDER(PREVIOUS(vals[d]), 1)")
+        .build_datamodel();
+
+    let db = SimlinDb::default();
+    let sync = sync_from_datamodel(&db, &project);
+    let diags = collect_all_diagnostics(&db, sync.project);
+
+    let attributed: Vec<&Diagnostic> = diags
+        .iter()
+        .filter(|d| d.variable.as_deref() == Some("out"))
+        .collect();
+
+    assert!(
+        !attributed.is_empty(),
+        "a codegen rejection must produce a diagnostic naming 'out'; got: {diags:?}"
+    );
+
+    let carries_reason = attributed.iter().any(|d| {
+        d.severity == DiagnosticSeverity::Error
+            && matches!(&d.error, DiagnosticError::Assembly(msg) if msg.contains("codegen"))
+    });
+    assert!(
+        carries_reason,
+        "the diagnostic for 'out' must be an Error carrying codegen's reason; got: {attributed:?}"
+    );
+
+    // The reason must be codegen's actual message, not a generic stand-in:
+    // that is the difference between "something failed" and "this construct
+    // was refused", and it is the whole point of the reporting form.
+    let names_construct = attributed.iter().any(
+        |d| matches!(&d.error, DiagnosticError::Assembly(msg) if msg.contains("Cannot push view")),
+    );
+    assert!(
+        names_construct,
+        "the reason must name the refused construct; got: {attributed:?}"
+    );
+
+    // The variable must be named in the MESSAGE, not only in the `variable`
+    // field. `errors.rs`'s `Assembly` arm renders `message` as "assembly
+    // {severity} in model '{model}': {msg}" and never interpolates
+    // `diag.variable`, and the CLI prints only `message` -- so a field-only
+    // assertion passes while the surface a user reads names nothing. Asserting
+    // the quoted form keeps it from matching an incidental substring.
+    let message_names_variable = attributed
+        .iter()
+        .any(|d| matches!(&d.error, DiagnosticError::Assembly(msg) if msg.contains("'out'")));
+    assert!(
+        message_names_variable,
+        "the message text must name the variable, not just the `variable` field; got: {attributed:?}"
+    );
+}
+
+/// The negative control for the two tests around it: a model that compiles
+/// cleanly must gain NO diagnostic from this path.
+///
+/// Without it, "a codegen rejection is reported" is satisfied just as well by
+/// reporting unconditionally, which would be a far worse regression than the
+/// silence it replaced. The whole-corpus form of this property -- a sweep
+/// diffing every `collect_all_diagnostics` row across the `test/` corpus, with
+/// and without the change -- is what actually established the blast radius:
+/// the added rows land only on models that already fail to compile. This is
+/// the cheap unit-level guard for the same direction.
+#[test]
+fn a_model_that_compiles_gains_no_codegen_diagnostic() {
+    let project = crate::test_common::TestProject::new("codegen_ok")
+        .named_dimension("d", &["e1", "e2", "e3"])
+        .array_aux("vals[d]", "10")
+        // The same builtin, with the operand shape codegen accepts.
+        .array_aux("out[d]", "VECTOR SORT ORDER(vals[d], 1)")
+        .aux("total", "SUM(out[*])", None)
+        .build_datamodel();
+
+    let db = SimlinDb::default();
+    let sync = sync_from_datamodel(&db, &project);
+    let diags = collect_all_diagnostics(&db, sync.project);
+
+    let assembly: Vec<&Diagnostic> = diags
+        .iter()
+        .filter(|d| matches!(&d.error, DiagnosticError::Assembly(_)))
+        .collect();
+    assert!(
+        assembly.is_empty(),
+        "a compiling model must gain no Assembly diagnostic; got: {assembly:?}"
+    );
+}
+
+/// The same rule for the INITIALS phase.
+///
+/// `compile_var_fragment` calls `compile_phase` at three sites -- initials,
+/// flows, stocks -- and each discards its codegen `Err` independently, so one
+/// wired-up site says nothing about the others. The test above covers flows
+/// (the phase all 244 C-LEARN LTM fragments take); this one covers initials
+/// via an arrayed stock whose INITIAL equation carries the same refused shape.
+///
+/// The stocks phase is deliberately NOT covered, and its call site admits TWO
+/// kinds of variable -- `(is_stock || is_module) && membership.stocks` -- so
+/// both arms need their own reason rather than one standing in for the other:
+///
+/// * a STOCK's stock-phase expression is always the `Expr::AssignNext`
+///   synthesized by `build_stock_update_expr`, and
+///   `compiler::check_stock_updates_are_emittable` rejects a non-`Op2` update
+///   at LOWERING -- which routes through `accumulate_var_compile_error`, the
+///   path that already worked. Provoking a codegen `Err` here would require
+///   defeating that guard first.
+/// * a MODULE's is the `Expr::EvalModule` built by `Var::new`'s
+///   `Variable::Module` arm, whose arguments are each a plain `Expr::Var`
+///   (`Expr::Var(ctx.get_ref(&mi.src)?, ..)`; an unresolvable `src` fails at
+///   lowering, not here). Codegen's `EvalModule` arm walks those arguments and
+///   pushes a declaration, and its `Expr::Var` arm just emits `LoadVar` and
+///   cannot fail. The one other shape a module-kind variable can lower to --
+///   `Var::new`'s input-override prefix, `AssignCurr(dst, ModuleInput(i))`,
+///   when the module's own ident is a module input -- is infallible in codegen
+///   for the same reason. Neither reaches an error path.
+///
+/// Both arms are therefore unreachable TODAY rather than uncovered by
+/// oversight, and each becomes reachable independently: the stock arm if the
+/// lowering guard is relaxed (a `non_negative` clamp, GH #545), the module arm
+/// if module inputs ever lower to something richer than a bare reference. The
+/// wiring itself is shared -- all three sites call the same `compile_phase`
+/// closure -- so the two covered phases exercise the mechanism.
+#[test]
+fn codegen_rejection_in_the_initials_phase_is_attributable_too() {
+    let project = crate::test_common::TestProject::new("codegen_reject_init")
+        .named_dimension("d", &["e1", "e2", "e3"])
+        .array_aux("vals[d]", "10")
+        .array_stock(
+            "lvl[d]",
+            "VECTOR SORT ORDER(PREVIOUS(vals[d]), 1)",
+            &[],
+            &[],
+            None,
+        )
+        .build_datamodel();
+
+    let db = SimlinDb::default();
+    let sync = sync_from_datamodel(&db, &project);
+    let diags = collect_all_diagnostics(&db, sync.project);
+
+    let carries_reason = diags.iter().any(|d| {
+        d.variable.as_deref() == Some("lvl")
+            && d.severity == DiagnosticSeverity::Error
+            && matches!(&d.error, DiagnosticError::Assembly(msg) if msg.contains("codegen"))
+    });
+    assert!(
+        carries_reason,
+        "an initials-phase codegen rejection must name 'lvl' and carry its reason; got: {diags:?}"
+    );
+}

--- a/src/simlin-engine/src/db/element_graph_tests.rs
+++ b/src/simlin-engine/src/db/element_graph_tests.rs
@@ -1823,15 +1823,27 @@ fn element_graph_mapped_diagonal_with_broadcast_dim() {
 /// from which `x` element's value each `target` element equals) -- the LTM
 /// contract is "more edges than necessary, never fewer".
 ///
-/// Today the engine's executed A2A lowering resolves mapped references
-/// POSITIONALLY, ignoring the explicit element map (target[s1] = x[a], the
-/// map notwithstanding; see GH #753 for the related different-cardinality
-/// compile failure), so a map-following diagonal would DROP the true
-/// positionally-read edges -- which is why `mapped_element_correspondence`
-/// declines explicit element maps (conservative broadcast). The test
-/// derives the implied edges from the run itself, so it keeps passing if
-/// the engine later honors element maps in execution and the element-map
-/// diagonal is re-enabled.
+/// On THIS fixture's spelling the executed A2A lowering resolves the
+/// reference POSITIONALLY, ignoring the explicit element map (target[s1] =
+/// x[a], the map notwithstanding), so a map-following diagonal would DROP
+/// the true positionally-read edges -- which is why
+/// `mapped_element_correspondence` declines explicit element maps
+/// (conservative broadcast). Removing that decline reds this test by
+/// dropping the `x[a] -> target[s1]` edge, the direction the LTM contract
+/// forbids.
+///
+/// The qualifier is load-bearing and was missing: this claim is NOT
+/// universal. `x[State]` spells the dimension the equation ITERATES, which
+/// `ast::expr3` folds to an ordinal that indexes `x`'s storage raw; a
+/// subscript naming a NON-active dimension instead reaches
+/// `translate_via_mapping` and DOES follow the element map. Both spellings
+/// are real and both ship -- see `DimensionsContext::mapped_element_correspondence`
+/// for the fork, the Vensim `Ref.vdf` evidence that map-following is correct
+/// where it happens, and why the decline stays anyway. This fixture builds
+/// only the positional spelling, so it constrains only that half.
+///
+/// The test derives the implied edges from the run itself, so it keeps
+/// passing if execution on this spelling later changes.
 #[test]
 fn element_graph_mapped_element_map_edges_superset_of_simulation_reads() {
     let project = TestProject::new("mapped_element_map_parity")

--- a/src/simlin-engine/src/db/fragment_char_tests.rs
+++ b/src/simlin-engine/src/db/fragment_char_tests.rs
@@ -581,6 +581,7 @@ fn collect_model_fragments(
                 project,
                 dep_graph,
                 &owned_inputs,
+                None,
             ) {
                 push(&mut out, FragmentKind::LtmImplicit, &result);
             }

--- a/src/simlin-engine/src/db/fragment_compile.rs
+++ b/src/simlin-engine/src/db/fragment_compile.rs
@@ -189,9 +189,11 @@ pub fn compile_var_fragment<'db>(
     let is_module_input = inputs.contains(&var_ident_canonical);
 
     // The phase-invariant emission context, built once per variable and
-    // borrowed by every phase (up to three). All three fragment emitters --
-    // this one, the implicit-helper one, and both LTM ones -- go through the
-    // same `compile_phase_to_per_var_bytecodes`.
+    // borrowed by every phase (up to three). All the fragment emitters --
+    // this one, the implicit-helper one, and both LTM ones -- share one
+    // emission tail; this one reaches it through the reporting twin
+    // (`compile_phase_to_per_var_bytecodes_reporting`) so it can attribute a
+    // codegen rejection, while the others take the `Option` form.
     let base_ctx = fragment_emit_ctx(
         &model_name_ident,
         &inputs,
@@ -200,8 +202,76 @@ pub fn compile_var_fragment<'db>(
         converted_dims,
         dim_context,
     );
+    // Emit one phase, and make a CODEGEN rejection attributable.
+    //
+    // Lowering failures already accumulate (`accumulate_var_compile_error`
+    // below), but a codegen `Err` used to be discarded by
+    // `compile_phase_to_per_var_bytecodes`'s `.ok()`. The variable then kept
+    // its layout slot with no bytecode and the only signal was
+    // `assemble_module`'s batch `failed to compile fragments for variables:
+    // <names>` -- no reason, no severity, and nothing in
+    // `collect_all_diagnostics` at all. That is the failure mode
+    // `compiler::check_stock_updates_are_emittable`'s rustdoc describes, and
+    // it was live for every codegen rejection: an ordinary hand-written
+    // `out[d] = VECTOR SORT ORDER(PREVIOUS(vals[d]), 1)` reported zero
+    // diagnostics while failing the build.
+    //
+    // The reason rides `DiagnosticError::Assembly`, not `Equation`, because
+    // `EquationError` is `{start, end, code}` with no message field -- see the
+    // KNOWN LOSS note on `accumulate_var_compile_error`. `Assembly` carries a
+    // String, which is what lets the refused construct be named at all.
+    //
+    // The variable name is embedded in that String even though the
+    // `Diagnostic` also carries it in `variable`. Structured consumers read
+    // the field, but `errors.rs`'s `Assembly` arm formats `message` as
+    // "assembly {severity} in model '{model}': {msg}" and does NOT interpolate
+    // `diag.variable` -- and the CLI prints only `message`. So on the surface a
+    // user actually reads, the field alone names nothing; a bare reason would
+    // leave the variable identified only by `assemble_module`'s separate batch
+    // line. The LTM leg solves it the same way, by putting the name in the
+    // string (`db/ltm/compile.rs`'s "LTM synthetic variable '{}' failed to
+    // compile").
+    //
+    // An EMPTY phase is not a failure and is filtered before asking: a
+    // standalone lookup-only table lowers to zero expressions by design
+    // (`compiler::Var::new`'s `is_table_only` arm), so reporting the
+    // reporting form's "nothing to emit" arm would turn a static table into
+    // an error. Today `var_runlist_membership` already keeps such a variable
+    // out of every runlist, so this is defense rather than a live filter.
+    //
+    // Severity is `Error`, unlike the LTM leg's `Warning`, and the asymmetry
+    // is the difference between the two situations: a dropped LTM fragment
+    // degrades an analysis overlay while the model still simulates, whereas a
+    // dropped ORDINARY fragment means `assemble_module` fails the build. The
+    // blast radius was measured rather than argued: a sweep diffing every
+    // `collect_all_diagnostics` row across the whole `test/` corpus, with and
+    // without this hunk, found the added rows land ONLY on projects that
+    // already fail to compile -- no project that compiles gains an error.
+    // That shape is what the severity rests on, and unlike a row count it
+    // stays true as the corpus grows. (`DiagnosticError::Assembly` maps to
+    // `FormattedErrorKind::Simulation`, which `FormattedErrors::push` does not
+    // count toward `has_model_errors`/`has_variable_errors`, so the CLI's
+    // redundant-`NotSimulatable` suppression is unaffected either way.)
     let compile_phase = |exprs: &[crate::compiler::Expr]| -> Option<PerVarBytecodes> {
-        compile_phase_to_per_var_bytecodes(&base_ctx, exprs)
+        if exprs.is_empty() {
+            return None;
+        }
+        match crate::db::assemble::compile_phase_to_per_var_bytecodes_reporting(&base_ctx, exprs) {
+            Ok(bytecodes) => Some(bytecodes),
+            Err(reason) => {
+                let ident = var.ident(db);
+                CompilationDiagnostic(Diagnostic {
+                    model: model.name(db).clone(),
+                    variable: Some(ident.clone()),
+                    error: DiagnosticError::Assembly(format!(
+                        "variable '{ident}' failed to compile: {reason}"
+                    )),
+                    severity: DiagnosticSeverity::Error,
+                })
+                .accumulate(db);
+                None
+            }
+        }
     };
 
     // Accumulate a diagnostic when per-variable compilation (Var::new)

--- a/src/simlin-engine/src/db/ltm/compile.rs
+++ b/src/simlin-engine/src/db/ltm/compile.rs
@@ -100,7 +100,7 @@ pub fn compile_ltm_var_fragment(
     };
 
     let equation = scalarize_ltm_equation(lsv.equation.clone());
-    compile_ltm_equation_fragment(db, &lsv.name, &equation, model, project)
+    compile_ltm_equation_fragment(db, &lsv.name, &equation, model, project, None)
 }
 
 // How many times `link_score_equation_text_shaped`'s body has run on this
@@ -873,12 +873,22 @@ fn lower_ltm_variable(
 /// `Scalar` equation gets 1 slot; an `ApplyToAll`/`Arrayed` equation
 /// gets `product(dim_lengths)` slots and is compiled with the A2A /
 /// per-element expansion the compiler applies to those variants.
+///
+/// `why`, when supplied, receives a human-readable reason on failure. The
+/// three ways this function can fail -- a parse error in the generated text,
+/// a lowering `Err` from `compiler::Var::new`, and codegen declining to emit
+/// -- otherwise all collapse into the same `None`/`flow_bytecodes: None`, so a
+/// caller reporting the failure could say only *that* it happened. That cost
+/// was concrete: ~1,600 failures on one real model with no way to tell which
+/// construct was responsible short of instrumenting this function by hand.
+/// Callers that only want the fragment pass `None` and pay nothing.
 pub(crate) fn compile_ltm_equation_fragment(
     db: &dyn Db,
     var_name: &str,
     equation: &LtmEquation,
     model: SourceModel,
     project: SourceProject,
+    mut why: Option<&mut Option<String>>,
 ) -> Option<VarFragmentResult> {
     use crate::compiler::symbolic::{CompiledVarFragment, PerVarBytecodes};
 
@@ -907,6 +917,16 @@ pub(crate) fn compile_ltm_equation_fragment(
         .equation_errors()
         .is_some_and(|e| !e.is_empty())
     {
+        if let Some(slot) = why.as_deref_mut() {
+            let errs = parsed.variable.equation_errors().unwrap_or_default();
+            *slot = Some(format!(
+                "the generated equation did not parse: {}",
+                errs.iter()
+                    .map(|e| format!("{:?} at {}..{}", e.code, e.start, e.end))
+                    .collect::<Vec<_>>()
+                    .join("; ")
+            ));
+        }
         return None;
     }
 
@@ -1635,8 +1655,47 @@ pub(crate) fn compile_ltm_equation_fragment(
 
     // LTM vars are always flow-phase only (scalar auxes, not stocks)
     let flow_bytecodes = match build_var(false) {
-        Ok(var_result) => compile_phase(&var_result.ast),
-        Err(_) => None,
+        Ok(var_result) => {
+            if why.is_some() {
+                match crate::db::assemble::compile_phase_to_per_var_bytecodes_reporting(
+                    &base_ctx,
+                    &var_result.ast,
+                ) {
+                    Ok(bytecodes) => Some(bytecodes),
+                    Err(err) => {
+                        if let Some(slot) = why.as_deref_mut() {
+                            *slot = Some(err);
+                        }
+                        None
+                    }
+                }
+            } else {
+                compile_phase(&var_result.ast)
+            }
+        }
+        Err(err) => {
+            if let Some(slot) = why {
+                // A lowering `Err` of `empty_equation` is usually a MASK: the
+                // variable reached `Var::new` with no AST because the earlier
+                // scope-lowering rejected the equation and left `ast: None`.
+                // Report that upstream rejection when it is there, since
+                // "empty equation" describes a formula we printed in full.
+                let lowered_errs = lowered.equation_errors().unwrap_or_default();
+                *slot = Some(if lowered_errs.is_empty() {
+                    format!("could not be lowered: {err}")
+                } else {
+                    format!(
+                        "could not be lowered: {}",
+                        lowered_errs
+                            .iter()
+                            .map(|e| format!("{:?} at {}..{}", e.code, e.start, e.end))
+                            .collect::<Vec<_>>()
+                            .join("; ")
+                    )
+                });
+            }
+            None
+        }
     };
 
     Some(VarFragmentResult {
@@ -1699,8 +1758,9 @@ pub(crate) fn compile_ltm_synthetic_fragment(
     // substitutions are applied later in `model_ltm_variables`), so
     // for anything that carries those it would produce the wrong (or
     // a degenerate) fragment.
-    let compile_direct =
-        || compile_ltm_equation_fragment(db, &ltm_var.name, &ltm_var.equation, model, project);
+    let compile_direct = || {
+        compile_ltm_equation_fragment(db, &ltm_var.name, &ltm_var.equation, model, project, None)
+    };
     const LINK_SCORE_PREFIX: &str = "$\u{205A}ltm\u{205A}link_score\u{205A}";
     if ltm_var.name.starts_with(LINK_SCORE_PREFIX) {
         if ltm_var.dimensions.is_empty() {
@@ -1864,13 +1924,39 @@ pub fn model_ltm_fragment_diagnostics(db: &dyn Db, model: SourceModel, project: 
         if compiled_ok {
             continue;
         }
+        // Recover WHY. `compile_ltm_synthetic_fragment` discards the reason
+        // (it has three failure legs and one `None`), so re-run the direct
+        // compile with the reason slot wired up. For every variable that took
+        // the `compile_direct` branch above -- which is every element-pinned
+        // equation, i.e. all of the arrayed-model failures this was written
+        // for -- that is the identical call. For one that took the
+        // salsa-cached `(from, to)` branch the re-derived equation can differ,
+        // so the reason is reported as indicative rather than as the failure.
+        let mut reason: Option<String> = None;
+        let direct_agrees = compile_ltm_equation_fragment(
+            db,
+            &ltm_var.name,
+            &ltm_var.equation,
+            model,
+            project,
+            Some(&mut reason),
+        )
+        .is_none_or(|r| r.fragment.flow_bytecodes.is_none());
+        let detail = match (&reason, direct_agrees) {
+            (Some(r), true) => format!(" Reason: {r}."),
+            (Some(r), false) => format!(
+                " Reason (from recompiling its own equation, which DOES compile -- \
+                 the cached re-derived equation is what failed): {r}."
+            ),
+            (None, _) => String::new(),
+        };
         let msg = format!(
             "LTM synthetic variable '{}' failed to compile; it keeps a \
              layout slot but no bytecode, so it evaluates to a constant 0. \
              Any loop or link score derived from it is silently degraded. \
              This usually means the LTM augmentation layer emitted an \
-             equation the compiler rejected.",
-            ltm_var.name,
+             equation the compiler rejected.{}",
+            ltm_var.name, detail,
         );
         CompilationDiagnostic(Diagnostic {
             model: model.name(db).clone(),
@@ -1916,7 +2002,16 @@ pub fn model_ltm_fragment_diagnostics(db: &dyn Db, model: SourceModel, project: 
     implicit_names.sort();
     for im_name in implicit_names {
         let meta = &ltm_implicit[im_name];
-        let fragment = compile_ltm_implicit_var_fragment(db, meta, model, project, dep_graph, &[]);
+        let mut helper_reason: Option<String> = None;
+        let fragment = compile_ltm_implicit_var_fragment(
+            db,
+            meta,
+            model,
+            project,
+            dep_graph,
+            &[],
+            Some(&mut helper_reason),
+        );
         // The helper's value-bearing phase must have produced bytecode:
         // `compile_ltm_implicit_var_fragment` returns `Some` even when every
         // phase failed (each phase is compiled independently and a failed one
@@ -1942,13 +2037,17 @@ pub fn model_ltm_fragment_diagnostics(db: &dyn Db, model: SourceModel, project: 
         if compiled_ok {
             continue;
         }
+        let helper_detail = match &helper_reason {
+            Some(r) => format!(" Reason: {r}."),
+            None => String::new(),
+        };
         let msg = format!(
             "LTM implicit helper '{}' (synthesized while parsing LTM variable \
              '{}') failed to compile; it keeps a layout slot but no bytecode, \
              so it evaluates to a constant 0. Every link or loop score that \
              reads it is silently degraded. This usually means the LTM \
-             augmentation layer emitted an equation the compiler rejected.",
-            im_name, meta.ltm_parent_name,
+             augmentation layer emitted an equation the compiler rejected.{}",
+            im_name, meta.ltm_parent_name, helper_detail,
         );
         CompilationDiagnostic(Diagnostic {
             model: model.name(db).clone(),
@@ -1976,6 +2075,7 @@ pub(crate) fn compile_ltm_implicit_var_fragment(
     project: SourceProject,
     _dep_graph: &ModelDepGraphResult,
     module_input_names: &[String],
+    mut why: Option<&mut Option<String>>,
 ) -> Option<VarFragmentResult> {
     use crate::compiler::symbolic::{CompiledVarFragment, PerVarBytecodes};
 
@@ -2568,10 +2668,47 @@ pub(crate) fn compile_ltm_implicit_var_fragment(
         Err(_) => None,
     };
 
+    // Only the value-bearing phase's reason is captured: that is the phase
+    // `model_ltm_fragment_diagnostics` gates on, so it is the one whose
+    // failure turns the helper into a silent constant 0.
     let flow_bytecodes = if !meta.is_stock {
         match build_var(false) {
-            Ok(var_result) => compile_phase(&var_result.ast),
-            Err(_) => None,
+            Ok(var_result) => {
+                if why.is_some() {
+                    match crate::db::assemble::compile_phase_to_per_var_bytecodes_reporting(
+                        &base_ctx,
+                        &var_result.ast,
+                    ) {
+                        Ok(bytecodes) => Some(bytecodes),
+                        Err(err) => {
+                            if let Some(slot) = why.as_deref_mut() {
+                                *slot = Some(err);
+                            }
+                            None
+                        }
+                    }
+                } else {
+                    compile_phase(&var_result.ast)
+                }
+            }
+            Err(err) => {
+                if let Some(slot) = why {
+                    let lowered_errs = lowered.equation_errors().unwrap_or_default();
+                    *slot = Some(if lowered_errs.is_empty() {
+                        format!("could not be lowered: {err}")
+                    } else {
+                        format!(
+                            "could not be lowered: {}",
+                            lowered_errs
+                                .iter()
+                                .map(|e| format!("{:?} at {}..{}", e.code, e.start, e.end))
+                                .collect::<Vec<_>>()
+                                .join("; ")
+                        )
+                    });
+                }
+                None
+            }
         }
     } else {
         None

--- a/src/simlin-engine/src/db/ltm/link_scores.rs
+++ b/src/simlin-engine/src/db/ltm/link_scores.rs
@@ -40,14 +40,54 @@ use super::parse::{ltm_equation_dimensions, retarget_ltm_equation_dims};
 /// per-element emitter excludes the live source, whose pinning is the wrap's
 /// job); whether it can actually be pinned AT a given element is the
 /// projection's answer, not this filter's.
+///
+/// `tables` carries the equation's `LOOKUP` TABLE holders, which are NOT in
+/// `deps` and must still be pinned (GH #984). A graphical-function holder is
+/// deliberately absent from the dependency set -- `classify_dependencies` puts
+/// it in `referenced_tables` and keeps it out of `all` (GH #606) so a table
+/// reference creates no runlist-ordering or causal edge -- and pinning is a
+/// COMPILABILITY obligation, not an attribution one: `tbl[region]` reaching a
+/// scalar fragment with its dimension-name index intact does not lower
+/// (`DimensionInScalarContext`), so the whole link score is dropped. Widening
+/// only the PIN candidates keeps the two obligations separate: the holder gets
+/// its index pinned while still earning no causal edge and no score.
+///
+/// The table HEAD is never frozen, but NOT because this set stays narrow --
+/// that causal claim was here and is false. The head is protected structurally,
+/// by `wrap_non_matching_in_previous`'s `LOOKUP` arm: it routes argument 0 to
+/// `freeze_lookup_table_indices`, which rewrites INDICES and leaves the ident
+/// alone REGARDLESS of `other_deps`. Verified by widening the wrap's dep set
+/// with `referenced_tables` and re-running: series bit-identical, whole suite
+/// green. (Freezing it would indeed fail -- a table-only variable has no value
+/// slot, so `LOOKUP(PREVIOUS(tbl), x)` is `DoesNotExist` -- but nothing here is
+/// what prevents it.) Keeping the sets apart is an ATTRIBUTION decision, stated
+/// above: a table cannot vary, so it must earn no edge. Recorded precisely
+/// because the false version told the next reader that a future widening of the
+/// dep set would be dangerous, when it is merely wrong for a different reason.
+///
+/// What this does NOT establish: that a table argument is always pinnable this
+/// way. Every one of C-LEARN's 413 occurrences is the IDENTITY shape -- the
+/// holder's declared axis IS the dimension the index spells, and the target
+/// iterates it -- so the projection is the identity and no dimension mapping is
+/// consulted. That is a measured property of one corpus, not of the language: a
+/// model reading a table declared over a DIFFERENT axis than the target iterates
+/// needs the mapped element correspondence, which
+/// `DimensionsContext::mapped_element_correspondence` declines for an explicit
+/// element map. Such a reference lands in `dep_element_pins`' incomplete arm and
+/// keeps today's loud drop.
 fn pinnable_arrayed_deps(
     db: &dyn Db,
     source_vars: &HashMap<String, SourceVariable>,
     project: SourceProject,
     deps: &HashSet<Ident<Canonical>>,
+    tables: &std::collections::BTreeSet<String>,
     keep: impl Fn(&Ident<Canonical>) -> bool,
 ) -> Vec<(Ident<Canonical>, Vec<crate::dimensions::Dimension>)> {
     let mut pinnable: Vec<(Ident<Canonical>, Vec<crate::dimensions::Dimension>)> = deps
+        .iter()
+        .cloned()
+        .chain(tables.iter().map(|t| Ident::new(t)))
+        .collect::<HashSet<_>>()
         .iter()
         .filter(|d| keep(d))
         .filter_map(|d| {
@@ -1302,8 +1342,12 @@ pub(super) fn try_scalar_to_arrayed_link_scores(
     // (Scalar deps stay bare; the target self-reference is pinned implicitly
     // via the subscripted `to[elem]` in the guard form built by
     // `generate_scalar_to_element_equation`.)
-    let pinnable_deps = |deps: &HashSet<Ident<Canonical>>| {
-        pinnable_arrayed_deps(db, source_vars, project, deps, |_| true)
+    // `tables` is threaded alongside `deps` because a LOOKUP table holder is
+    // absent from the dep set by construction but still needs its index pinned
+    // -- see `pinnable_arrayed_deps`.
+    let pinnable_deps = |deps: &HashSet<Ident<Canonical>>,
+                         tables: &std::collections::BTreeSet<String>| {
+        pinnable_arrayed_deps(db, source_vars, project, deps, tables, |_| true)
     };
 
     let dim_element_lists: Vec<Vec<String>> = to_dims
@@ -1413,6 +1457,31 @@ pub(super) fn try_scalar_to_arrayed_link_scores(
             // right link-score value (no sensitivity).
             "0".to_string()
         };
+        // COMPLETENESS: a scalar per-element partial must select ONE element at
+        // every subscript. An index left as a bare DIMENSION name denotes the
+        // whole axis, so it cannot lower -- and when it sits inside a frozen
+        // subtree `builtins_visitor` hoists it into a `PREVIOUS`-capture helper
+        // that fails on its own WHILE THIS SCORE STILL COMPILES, because the
+        // score only references the helper's slot. The result is not an absent
+        // score but a present one reading part of its own equation as a constant
+        // 0, under a warning worded for something else.
+        //
+        // "No score, warned" beats a wrong score, so decline the edge on the same
+        // `PartialEquationError` contract the GH #311 parse failure and the
+        // GH #743 unfreezable partial use: loops through it drop with a warning.
+        //
+        // Checked on the FINISHED text, not predicted from the pin table. A dep
+        // the table cannot cover may still need no pin -- `source[idx]` resolves
+        // through its own runtime index -- so declining whenever a dep is
+        // unpinnable rejects edges that score correctly. Only a surviving
+        // dimension-name index actually breaks.
+        if let Some(offender) = crate::ltm_augment::unresolvable_dimension_index(&equation, dim_ctx)
+        {
+            let err =
+                crate::ltm_augment::PartialEquationError::unprojectable_dep(&offender, element);
+            emit_ltm_partial_equation_warning(db, model, &name, &err);
+            return None;
+        }
         Some(LtmSyntheticVar {
             name,
             equation: LtmEquation::scalar(equation),
@@ -1440,8 +1509,9 @@ pub(super) fn try_scalar_to_arrayed_link_scores(
         // pin PROJECTION varies per element, and that is `build_var`'s job.
         Ast::ApplyToAll(_, expr) => {
             let elem_eqn = crate::patch::expr2_to_expr0(expr);
-            let elem_deps = crate::variable::identifier_set(ast, target_ast_dims, None);
-            let pinnable = pinnable_deps(&elem_deps);
+            let elem_dep_class = crate::variable::classify_dependencies(ast, target_ast_dims, None);
+            let elem_deps = elem_dep_class.all.clone();
+            let pinnable = pinnable_deps(&elem_deps, &elem_dep_class.referenced_tables);
             for element in &elements {
                 match build_var(element, Some(&elem_eqn), &elem_deps, &pinnable) {
                     Some(v) => cross_vars.push(v),
@@ -1459,24 +1529,32 @@ pub(super) fn try_scalar_to_arrayed_link_scores(
             for element in &elements {
                 let canonical_elem = crate::common::CanonicalElementName::from_raw(element);
                 let slot = per_elem.get(&canonical_elem).or(default_expr.as_ref());
-                let (elem_eqn, elem_deps): (Option<crate::ast::Expr0>, HashSet<Ident<Canonical>>) =
-                    match slot {
-                        Some(expr) => (
+                #[allow(clippy::type_complexity)]
+                let (elem_eqn, elem_deps, elem_tables): (
+                    Option<crate::ast::Expr0>,
+                    HashSet<Ident<Canonical>>,
+                    std::collections::BTreeSet<String>,
+                ) = match slot {
+                    Some(expr) => {
+                        let class = crate::variable::classify_dependencies(
+                            &Ast::Scalar(expr.clone()),
+                            target_ast_dims,
+                            None,
+                        );
+                        (
                             Some(crate::patch::expr2_to_expr0(expr)),
-                            crate::variable::identifier_set(
-                                &Ast::Scalar(expr.clone()),
-                                target_ast_dims,
-                                None,
-                            ),
-                        ),
-                        // No slot and no default: the target has a hole at
-                        // this element. A zero equation is the right
-                        // link-score value (no sensitivity), matching the
-                        // historical placeholder behaviour for un-derivable
-                        // partials.
-                        None => (None, HashSet::new()),
-                    };
-                let pinnable = pinnable_deps(&elem_deps);
+                            class.all,
+                            class.referenced_tables,
+                        )
+                    }
+                    // No slot and no default: the target has a hole at
+                    // this element. A zero equation is the right
+                    // link-score value (no sensitivity), matching the
+                    // historical placeholder behaviour for un-derivable
+                    // partials.
+                    None => (None, HashSet::new(), Default::default()),
+                };
+                let pinnable = pinnable_deps(&elem_deps, &elem_tables);
                 match build_var(element, elem_eqn.as_ref(), &elem_deps, &pinnable) {
                     Some(v) => cross_vars.push(v),
                     None => {
@@ -1948,6 +2026,17 @@ pub(crate) fn ltm_partial_equation_warning_message(
              variable is skipped rather than emitted with a silently-stubbed helper \
              (which would poison the score with a plausible-looking wrong constant \
              -- GH #743)."
+        ),
+        PartialEquationErrorKind::UnprojectableDep => format!(
+            "LTM link-score variable '{variable_name}' could not be generated: the \
+             arrayed dependency '{equation_text}' (dep@element) cannot be projected \
+             onto that target element, so the per-element partial has no correct \
+             subscript for it. The variable is skipped -- and dependent loop scores \
+             dropped -- rather than emitted with the dep's dimension-name subscript \
+             left in a scalar fragment, which compiles to a helper that reads a \
+             constant 0 while the score itself still compiles (a wrong number, not \
+             an absent one). The reachable cause is a dep read across an EXPLICIT \
+             element map, which `mapped_element_correspondence` declines."
         ),
         PartialEquationErrorKind::BareReducerFeeder => format!(
             "LTM link-score variable '{variable_name}' could not be generated: \
@@ -2541,8 +2630,11 @@ fn emit_per_element_link_scores(
     // over its OWN declared dimensions (mirroring
     // `try_scalar_to_arrayed_link_scores`); the source itself is excluded --
     // its occurrences are pinned per-row by the wrap's own row lowering.
-    let pinnable_deps = |deps: &HashSet<Ident<Canonical>>| {
-        pinnable_arrayed_deps(db, source_vars, project, deps, |d| d.as_str() != from)
+    let pinnable_deps = |deps: &HashSet<Ident<Canonical>>,
+                         tables: &std::collections::BTreeSet<String>| {
+        pinnable_arrayed_deps(db, source_vars, project, deps, tables, |d| {
+            d.as_str() != from
+        })
     };
 
     let to_dim_element_lists: Vec<Vec<String>> = to_dims
@@ -2555,8 +2647,9 @@ fn emit_per_element_link_scores(
     // per-slot for Arrayed -- mirroring `try_scalar_to_arrayed_link_scores`).
     let a2a_parts: Option<ElemEqnParts> = if let Ast::ApplyToAll(_, expr) = ast {
         let eqn = crate::patch::expr2_to_expr0(expr);
-        let deps = crate::variable::identifier_set(ast, target_ast_dims, None);
-        let pinnable = pinnable_deps(&deps);
+        let class = crate::variable::classify_dependencies(ast, target_ast_dims, None);
+        let deps = class.all.clone();
+        let pinnable = pinnable_deps(&deps, &class.referenced_tables);
         Some((eqn, deps, pinnable))
     } else {
         None
@@ -2617,12 +2710,13 @@ fn emit_per_element_link_scores(
                 match slot {
                     Some(expr) => {
                         let eqn = crate::patch::expr2_to_expr0(expr);
-                        let deps = crate::variable::identifier_set(
+                        let class = crate::variable::classify_dependencies(
                             &Ast::Scalar(expr.clone()),
                             target_ast_dims,
                             None,
                         );
-                        let pinnable = pinnable_deps(&deps);
+                        let deps = class.all.clone();
+                        let pinnable = pinnable_deps(&deps, &class.referenced_tables);
                         Some((eqn, deps, pinnable))
                     }
                     // No slot, no default: a hole -- this element has no
@@ -2702,13 +2796,30 @@ fn emit_per_element_link_scores(
                 gf_table_ref.as_deref(),
                 &occ,
             ) {
-                Ok(equation) => edge_vars.push(LtmSyntheticVar {
-                    name,
-                    equation: LtmEquation::scalar(equation),
-                    dimensions: vec![], // scalar -- one variable per (row, element)
-                    // bracketed name -> routed direct by `assemble_module`.
-                    compile_directly: false,
-                }),
+                Ok(equation) => {
+                    // Same completeness check as the scalar-to-element emitter
+                    // (see its COMPLETENESS comment): a surviving dimension-name
+                    // index cannot lower, and it becomes a `PREVIOUS`-capture
+                    // helper that dies while THIS score still compiles.
+                    if let Some(offender) =
+                        crate::ltm_augment::unresolvable_dimension_index(&equation, dim_ctx)
+                    {
+                        let err = crate::ltm_augment::PartialEquationError::unprojectable_dep(
+                            &offender, element,
+                        );
+                        if unscoreable_edges.insert((from.to_string(), to.to_string())) {
+                            emit_ltm_partial_equation_warning(db, model, &name, &err);
+                        }
+                        return true;
+                    }
+                    edge_vars.push(LtmSyntheticVar {
+                        name,
+                        equation: LtmEquation::scalar(equation),
+                        dimensions: vec![], // scalar -- one variable per (row, element)
+                        // bracketed name -> routed direct by `assemble_module`.
+                        compile_directly: false,
+                    })
+                }
                 Err(err) => {
                     // One doomed (row, e) dooms the edge (GH #780; fn doc);
                     // warn only on first recording (#758 convention).
@@ -3361,7 +3472,12 @@ pub(super) fn emit_agg_to_target_link_scores(
     for other_agg in reducer_subst.values() {
         all_deps.insert(Ident::<Canonical>::new(other_agg));
     }
-    let pinnable_deps = pinnable_arrayed_deps(db, source_vars, project, &all_deps, |_| true);
+    let table_holders =
+        crate::variable::classify_dependencies(ast, target_ast_dims, None).referenced_tables;
+    let pinnable_deps =
+        pinnable_arrayed_deps(db, source_vars, project, &all_deps, &table_holders, |_| {
+            true
+        });
     // An arrayed agg (`result_dims` non-empty) is element-pinned in the
     // per-target-element equation too: `$⁚ltm⁚agg⁚0` → `$⁚ltm⁚agg⁚0[<slot>]`.
     // But NOT via `pinnable_deps`: that projection needs a variable's DECLARED
@@ -3678,13 +3794,32 @@ pub(super) fn emit_agg_to_target_link_scores(
                     // (the wrap's agg lookups all miss). A2A body is slot 0.
                     &slot_occurrences.for_slot(slot_map.slot_for(element)),
                 ) {
-                    Ok(equation) => edge_vars.push(LtmSyntheticVar {
-                        name,
-                        equation: LtmEquation::scalar(equation),
-                        dimensions: vec![],
-                        // synthetic agg on `from` + bracketed `to` -> routed direct.
-                        compile_directly: false,
-                    }),
+                    Ok(equation) => {
+                        // Same completeness check as the scalar-to-element
+                        // emitter (see its COMPLETENESS comment): a surviving
+                        // dimension-name index cannot lower, and it becomes a
+                        // `PREVIOUS`-capture helper that dies while THIS score
+                        // still compiles.
+                        if let Some(offender) = crate::ltm_augment::unresolvable_dimension_index(
+                            &equation,
+                            project_dimensions_context(db, project),
+                        ) {
+                            let err = crate::ltm_augment::PartialEquationError::unprojectable_dep(
+                                &offender, element,
+                            );
+                            if unscoreable_edges.insert((agg.name.clone(), to.to_string())) {
+                                emit_ltm_partial_equation_warning(db, model, &name, &err);
+                            }
+                            return;
+                        }
+                        edge_vars.push(LtmSyntheticVar {
+                            name,
+                            equation: LtmEquation::scalar(equation),
+                            dimensions: vec![],
+                            // synthetic agg on `from` + bracketed `to` -> routed direct.
+                            compile_directly: false,
+                        })
+                    }
                     Err(err) => {
                         // One doomed element dooms the edge; drop the
                         // already-built per-element vars (`edge_vars` never
@@ -3766,13 +3901,32 @@ pub(super) fn emit_agg_to_target_link_scores(
                     element
                 );
                 match equation {
-                    Ok(equation) => edge_vars.push(LtmSyntheticVar {
-                        name,
-                        equation: LtmEquation::scalar(equation),
-                        dimensions: vec![],
-                        // synthetic agg on `from` + bracketed `to` -> routed direct.
-                        compile_directly: false,
-                    }),
+                    Ok(equation) => {
+                        // Same completeness check as the scalar-to-element
+                        // emitter (see its COMPLETENESS comment): a surviving
+                        // dimension-name index cannot lower, and it becomes a
+                        // `PREVIOUS`-capture helper that dies while THIS score
+                        // still compiles.
+                        if let Some(offender) = crate::ltm_augment::unresolvable_dimension_index(
+                            &equation,
+                            project_dimensions_context(db, project),
+                        ) {
+                            let err = crate::ltm_augment::PartialEquationError::unprojectable_dep(
+                                &offender, element,
+                            );
+                            if unscoreable_edges.insert((agg.name.clone(), to.to_string())) {
+                                emit_ltm_partial_equation_warning(db, model, &name, &err);
+                            }
+                            return;
+                        }
+                        edge_vars.push(LtmSyntheticVar {
+                            name,
+                            equation: LtmEquation::scalar(equation),
+                            dimensions: vec![],
+                            // synthetic agg on `from` + bracketed `to` -> routed direct.
+                            compile_directly: false,
+                        })
+                    }
                     Err(err) => {
                         // One doomed element dooms the edge; drop the
                         // already-built per-element vars (`edge_vars` never

--- a/src/simlin-engine/src/db/ltm_tests.rs
+++ b/src/simlin-engine/src/db/ltm_tests.rs
@@ -1565,3 +1565,363 @@ fn an_unrelated_equation_edit_does_not_regenerate_every_link_score() {
          lowered form) where a per-variable one would do."
     );
 }
+
+/// An arrayed dep the per-element pin table cannot cover must make the edge
+/// decline LOUDLY, not produce a score computed around a hole.
+///
+/// The shape: `target[cop]` reads `aggregated[agg]`, where `agg` maps to `cop`
+/// through an EXPLICIT element map. `mapped_element_correspondence` declines an
+/// explicit map (the execution split is documented there), so
+/// `dep_element_pins` can project no axis of `aggregated` onto a `cop` element
+/// and the dep is absent from the pin table entirely.
+///
+/// What that produced before this guard: the dimension-name subscript survived
+/// into the scalar partial, `builtins_visitor` hoisted it into a
+/// `PREVIOUS`-capture helper, the helper failed to lower
+/// (`DimensionInScalarContext`) -- and the PARENT still compiled, because it
+/// merely references the helper's slot. So the link score existed, was read by
+/// every loop through it, and evaluated one branch of its own equation as a
+/// constant 0. A wrong number wearing a warning meant for something else.
+///
+/// "No score, warned" beats a wrong score: the edge is now recorded in
+/// `unscoreable_edges` and no `LtmSyntheticVar` is emitted for it, so loops
+/// through it drop rather than reporting a number computed around the hole.
+/// This is the same contract the GH #311 parse failure and the GH #743
+/// unfreezable partial already use.
+#[test]
+fn an_uncoverable_arrayed_dep_declines_the_edge_loudly() {
+    use salsa::Setter;
+
+    let project = TestProject::new("unpinnable_dep")
+        .with_sim_time(0.0, 3.0, 1.0)
+        .named_dimension("cop", &["c1", "c2"])
+        .named_dimension_with_element_mapping(
+            "agg",
+            &["a1", "a2"],
+            "cop",
+            &[("a1", "c2"), ("a2", "c1")],
+        )
+        .array_aux("aggregated[agg]", "TIME * 2")
+        .aux("switch", "1 + SUM(level[*]) * 0.01", None)
+        .array_stock("level[cop]", "1", &["growth"], &[], None)
+        .array_flow("growth[cop]", "target[cop] * 0.1", None)
+        .array_aux(
+            "target[cop]",
+            "if switch > 1.05 then aggregated[agg] else level[cop]",
+        )
+        .build_datamodel();
+
+    let mut db = SimlinDb::default();
+    let source_project = sync_from_datamodel(&db, &project).project;
+    source_project.set_ltm_enabled(&mut db).to(true);
+    let source_model = sync_from_datamodel(&db, &project).models["main"].source;
+
+    let ltm = crate::db::model_ltm_variables(&db, source_model, source_project);
+    let emitted: Vec<&String> = ltm
+        .vars
+        .iter()
+        .map(|v| &v.name)
+        .filter(|n| n.contains("link_score\u{205A}switch\u{2192}target"))
+        .collect();
+    assert!(
+        emitted.is_empty(),
+        "the switch->target edge cannot be scored (its `aggregated[agg]` dep is \
+         unpinnable), so NO link score may be emitted for it; got: {emitted:?}"
+    );
+
+    // The decline must be LOUD, and it must be the only thing left: a helper
+    // that fails while its parent compiles is exactly the silent zero this
+    // guard exists to remove.
+    let diags = crate::db::collect_all_diagnostics(&db, source_project);
+    let silently_degraded: Vec<&String> = diags
+        .iter()
+        .filter_map(|d| match &d.error {
+            crate::db::DiagnosticError::Assembly(m) if m.contains("silently degraded") => {
+                d.variable.as_ref()
+            }
+            _ => None,
+        })
+        .collect();
+    assert!(
+        silently_degraded.is_empty(),
+        "no fragment may be left reading a constant 0 under a compiling parent; \
+         got: {silently_degraded:?}"
+    );
+    // The decline must be LOUD and must be THIS decline: `!diags.is_empty()` is
+    // satisfied by any diagnostic at all, including one from an unrelated defect.
+    assert!(
+        diags.iter().any(|d| match &d.error {
+            crate::db::DiagnosticError::Assembly(m) =>
+                m.contains("cannot be projected onto that target element")
+                    && m.contains("switch\u{2192}target"),
+            _ => false,
+        }),
+        "the switch->target decline must carry the unprojectable-dep warning; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (&d.variable, &d.error))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// A `LOOKUP` table argument's dimension-name index must be element-pinned in a
+/// per-element scalar partial, exactly as every other arrayed dep of that target
+/// already is.
+///
+/// The gap (GH #984): a graphical-function holder is deliberately absent from
+/// the DEPENDENCY GRAPH -- `classify_dependencies` records it in
+/// `referenced_tables` and keeps it out of `all` (GH #606) so a table reference
+/// creates no runlist or causal edge -- and `pinnable_arrayed_deps` built the
+/// per-element pin table from that same dep set. So `tbl[region]` reached the
+/// scalar fragment with its dimension-name index intact, the fragment did not
+/// lower (`DimensionInScalarContext`), and the link score was dropped with a
+/// warning. The holder's DECLARED dimensions were never the problem: they sit on
+/// the datamodel like any other variable's, one field away on the same struct
+/// the same pass already returns.
+///
+/// This is C-LEARN's shape in miniature -- `Im 6 FF CO2[COP] = ... LOOKUP(RS CO2
+/// FF[COP], Time/One year) * Adjustment to CO2eq ...`, a scalar source into an
+/// arrayed target whose equation reads a per-element GF holder subscripted by
+/// its own dimension name. All 413 of C-LEARN's occurrences are this IDENTITY
+/// shape (the holder's declared axis IS the dimension the index spells, and the
+/// target iterates it), which is what keeps the pin free of the unresolved
+/// element-map question.
+///
+/// The assertion is the EXACT series, not a property of it. An earlier revision
+/// asserted only "not identically zero" and "all finite" while claiming to
+/// constrain the pinned element -- and it did not: mutating `dep_axis_elements`
+/// to pin every axis to the dep's FIRST element left it green. Worse, that
+/// fixture could not have caught the mutant even in principle, because with
+/// `factor` as the sole varying input the score saturates at exactly 1.0 for
+/// BOTH elements -- `out[a]` and `out[b]` differ (2.04 vs 3.06) while their
+/// scores were identical. `drift` exists to break that saturation: with a second
+/// varying contribution the score becomes a real ratio, the table slope enters
+/// the value, and the two elements separate (0.805 vs 0.861). Both facts are
+/// asserted, and the second is what makes the first mean anything.
+#[test]
+fn a_lookup_table_index_is_element_pinned_in_a_per_element_partial() {
+    use crate::datamodel::{
+        Equation, GraphicalFunction, GraphicalFunctionKind, GraphicalFunctionScale, Variable,
+    };
+    use salsa::Setter;
+
+    // Per-element table: `a` doubles its input, `b` triples it. Distinct slopes
+    // are what make a mis-pinned index visible in the value.
+    let gf = |slope: f64| GraphicalFunction {
+        kind: GraphicalFunctionKind::Continuous,
+        x_points: Some(vec![0.0, 10.0]),
+        y_points: vec![0.0, 10.0 * slope],
+        x_scale: GraphicalFunctionScale {
+            min: 0.0,
+            max: 10.0,
+        },
+        y_scale: GraphicalFunctionScale {
+            min: 0.0,
+            max: 10.0 * slope,
+        },
+    };
+    // A lookup-only holder: empty equation text, the table carried per element.
+    let tbl = Variable::Aux(crate::datamodel::Aux {
+        ident: "tbl".to_string(),
+        equation: Equation::Arrayed(
+            vec!["region".to_string()],
+            vec![
+                ("a".to_string(), String::new(), None, Some(gf(2.0))),
+                ("b".to_string(), String::new(), None, Some(gf(3.0))),
+            ],
+            None,
+            false,
+        ),
+        documentation: String::new(),
+        units: None,
+        gf: None,
+        ai_state: None,
+        uid: None,
+        compat: crate::datamodel::Compat::default(),
+    });
+
+    let mut project = TestProject::new("lookup_pin")
+        .with_sim_time(0.0, 3.0, 1.0)
+        .named_dimension("region", &["a", "b"])
+        // The scalar live source, in a feedback loop with the target.
+        .array_stock("level[region]", "1", &["growth"], &[], None)
+        .array_flow("growth[region]", "out[region] * 0.1", None)
+        .aux("factor", "1 + SUM(level[*]) * 0.01", None)
+        .aux("drift", "TIME * 0.5", None)
+        .array_aux("out[region]", "LOOKUP(tbl[region], TIME) * factor + drift")
+        .build_datamodel();
+    project.models[0].variables.push(tbl);
+
+    let mut db = SimlinDb::default();
+    let source_project = sync_from_datamodel(&db, &project).project;
+    source_project.set_ltm_enabled(&mut db).to(true);
+
+    // The model itself must be sound, or the score assertions below are moot.
+    let diags = crate::db::collect_all_diagnostics(&db, source_project);
+    assert!(
+        diags.is_empty(),
+        "the fixture must compile with no diagnostics; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (&d.variable, &d.error))
+            .collect::<Vec<_>>()
+    );
+
+    // The per-element score for the `factor -> out[b]` edge. `b`'s table has
+    // slope 3, so a partial that pinned the index to `a` (slope 2) -- or left it
+    // unpinned -- is a different number, not merely a different spelling.
+    let compiled = crate::db::compile_project_incremental(&db, source_project, "main")
+        .expect("the fixture must compile");
+    let offsets = compiled.offsets.clone();
+    let score_name = offsets
+        .keys()
+        .map(|k| k.as_str().to_string())
+        .find(|k| k.contains("link_score") && k.contains("factor\u{2192}out[b]"))
+        .expect("the factor->out[b] per-element link score must be emitted");
+    let mut vm = crate::vm::Vm::new(compiled).expect("vm");
+    vm.run_to_end().expect("run");
+    let results = vm.into_results();
+    let base = offsets[&crate::common::Ident::new(&score_name)];
+    let series: Vec<f64> = (0..results.step_count)
+        .map(|s| results.data[s * results.step_size + base])
+        .collect();
+
+    // The EXACT series, both elements. `b`'s table has slope 3 and `a`'s has 2,
+    // and `drift` supplies a second varying contribution so the score does not
+    // saturate at 1 -- which is what makes the pinned element observable in the
+    // VALUE. Pinning is the whole subject of this test, so the assertion has to
+    // be the number, not a property the number happens to satisfy.
+    let expected_a = [0.0, 0.0, 0.805_022_617_376_384_4, 0.809_579_376_075_400_5];
+    let expected_b = [0.0, 0.0, 0.860_979_814_269_031_9, 0.864_449_016_428_508_1];
+    assert_eq!(
+        series.len(),
+        expected_b.len(),
+        "step count; got: {series:?}"
+    );
+    for (got, want) in series.iter().zip(expected_b.iter()) {
+        assert!(
+            (got - want).abs() < 1e-12,
+            "the {score_name} series must match the correctly-pinned value; \
+             got: {series:?}, want: {expected_b:?}"
+        );
+    }
+    // ...and `a` must differ, which is the property that makes a WRONG pin
+    // detectable at all: if the two elements scored alike, swapping them would
+    // be invisible and the assertion above would constrain nothing about pinning.
+    let a_off = offsets
+        .keys()
+        .map(|k| k.as_str().to_string())
+        .find(|k| k.contains("link_score") && k.contains("factor\u{2192}out[a]"))
+        .map(|n| offsets[&crate::common::Ident::new(&n)])
+        .expect("the factor->out[a] per-element link score must be emitted");
+    let series_a: Vec<f64> = (0..results.step_count)
+        .map(|s| results.data[s * results.step_size + a_off])
+        .collect();
+    for (got, want) in series_a.iter().zip(expected_a.iter()) {
+        assert!(
+            (got - want).abs() < 1e-12,
+            "the factor->out[a] series must match ITS element's table; \
+             got: {series_a:?}, want: {expected_a:?}"
+        );
+    }
+    assert!(
+        series_a
+            .iter()
+            .zip(series.iter())
+            .any(|(x, y)| (x - y).abs() > 1e-6),
+        "the two elements must score differently, or this fixture cannot \
+         detect a mis-pinned index at all; a={series_a:?} b={series:?}"
+    );
+}
+
+/// The completeness guard must hold on the PER-ELEMENT (`PerElement`-shape)
+/// emitter too, not only on the scalar-to-element one.
+///
+/// The guard originally existed at a single site, which was sufficient for
+/// C-LEARN and wrong in general: three siblings emit the same per-element scalar
+/// partial through a `dep_element_pins`-derived table
+/// (`emit_per_element_link_scores` and both arms of
+/// `emit_agg_to_target_link_scores`), and an unguarded one lets exactly the
+/// defect the guard exists to remove back through -- a score that COMPILES while
+/// the `PREVIOUS`-capture helper under it dies and reads a constant 0.
+///
+/// This fixture reaches `emit_per_element_link_scores`: `out[region]` reads
+/// `src[region, t1]`, a 2-D source at a pinned column, which is the mixed
+/// iterated+literal `PerElement` shape (GH #525) that routes there. It also
+/// reads `other[agg]` across an EXPLICIT element map, which
+/// `mapped_element_correspondence` declines -- so that dep has no projectable
+/// element and its dimension-name subscript would survive into the scalar
+/// partial. Nothing exotic: a 2-D read and a mapped dep.
+#[test]
+fn the_completeness_guard_holds_on_the_per_element_emitter() {
+    use salsa::Setter;
+
+    let project = TestProject::new("perelem_guard")
+        .with_sim_time(0.0, 3.0, 1.0)
+        .named_dimension("region", &["a", "b"])
+        .named_dimension("slot", &["t1", "t2"])
+        .named_dimension_with_element_mapping(
+            "agg",
+            &["x", "y"],
+            "region",
+            &[("x", "b"), ("y", "a")],
+        )
+        .array_aux("other[agg]", "TIME * 2")
+        .array_aux_direct(
+            "src",
+            vec!["region".into(), "slot".into()],
+            "level[region] * 0.3",
+            None,
+        )
+        .array_stock("level[region]", "1", &["growth"], &[], None)
+        .array_flow("growth[region]", "out[region] * 0.1", None)
+        .array_aux("out[region]", "src[region, t1] * 0.5 + other[agg]")
+        .build_datamodel();
+
+    let mut db = SimlinDb::default();
+    let source_project = sync_from_datamodel(&db, &project).project;
+    source_project.set_ltm_enabled(&mut db).to(true);
+    let source_model = sync_from_datamodel(&db, &project).models["main"].source;
+
+    let ltm = crate::db::model_ltm_variables(&db, source_model, source_project);
+    let emitted: Vec<&String> = ltm
+        .vars
+        .iter()
+        .map(|v| &v.name)
+        .filter(|n| n.contains("link_score\u{205A}src[") && n.contains("\u{2192}out["))
+        .collect();
+    assert!(
+        emitted.is_empty(),
+        "the src->out per-element edge cannot be scored (its `other[agg]` dep is \
+         unprojectable), so NO link score may be emitted; got: {emitted:?}"
+    );
+
+    let diags = crate::db::collect_all_diagnostics(&db, source_project);
+    let silently_degraded: Vec<&String> = diags
+        .iter()
+        .filter_map(|d| match &d.error {
+            crate::db::DiagnosticError::Assembly(m) if m.contains("silently degraded") => {
+                d.variable.as_ref()
+            }
+            _ => None,
+        })
+        .collect();
+    assert!(
+        silently_degraded.is_empty(),
+        "no fragment may be left reading a constant 0 under a compiling parent; \
+         got: {silently_degraded:?}"
+    );
+    assert!(
+        diags.iter().any(|d| match &d.error {
+            crate::db::DiagnosticError::Assembly(m) =>
+                m.contains("cannot be projected onto that target element")
+                    && m.contains("other[agg]"),
+            _ => false,
+        }),
+        "the decline must carry the unprojectable-dep warning naming the dep; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (&d.variable, &d.error))
+            .collect::<Vec<_>>()
+    );
+}

--- a/src/simlin-engine/src/db/ltm_tests.rs
+++ b/src/simlin-engine/src/db/ltm_tests.rs
@@ -89,6 +89,7 @@ fn test_ltm_previous_module_var_uses_helper_rewrite() {
         &crate::db::LtmEquation::scalar("PREVIOUS(producer)".to_string()),
         source_model,
         sync.project,
+        None,
     )
     .expect("LTM equation should compile");
 
@@ -140,6 +141,7 @@ fn test_a2a_ltm_equation_fragment_compiles() {
         ),
         source_model,
         sync.project,
+        None,
     )
     .expect("A2A LTM equation should compile");
 
@@ -269,6 +271,7 @@ fn test_a2a_ltm_previous_per_element() {
         ),
         source_model,
         sync.project,
+        None,
     )
     .expect("A2A LTM equation with PREVIOUS should compile");
 
@@ -736,7 +739,7 @@ fn unparseable_generated_arm_degrades_loudly_without_panicking() {
         "scalar must reject loudly"
     );
     assert!(
-        compile_ltm_equation_fragment(&db, "$⁚ltm⁚bad⁚scalar", &scalar, model, sync.project)
+        compile_ltm_equation_fragment(&db, "$⁚ltm⁚bad⁚scalar", &scalar, model, sync.project, None)
             .is_none(),
         "a rejected equation must not produce a fragment (the diagnostic pass \
          reports the missing bytecode)"
@@ -760,8 +763,15 @@ fn unparseable_generated_arm_degrades_loudly_without_panicking() {
          drop the slot and let the surviving sibling keep the fragment alive"
     );
     assert!(
-        compile_ltm_equation_fragment(&db, "$⁚ltm⁚bad⁚arrayed", &arrayed, model, sync.project)
-            .is_none(),
+        compile_ltm_equation_fragment(
+            &db,
+            "$⁚ltm⁚bad⁚arrayed",
+            &arrayed,
+            model,
+            sync.project,
+            None
+        )
+        .is_none(),
         "the arrayed fragment must be rejected -- otherwise the missing slot is \
          zero-filled and no diagnostic fires"
     );

--- a/src/simlin-engine/src/db/ltm_tests.rs
+++ b/src/simlin-engine/src/db/ltm_tests.rs
@@ -1368,6 +1368,128 @@ fn an_index_naming_the_axis_own_element_stays_a_static_selector() {
     );
 }
 
+/// The third `AxisIndexName` arm, and the one GH #986 left unguarded: the axis
+/// IS known, the index is neither an element of that axis nor a dimension the
+/// target iterates -- so the verdict is `Unresolved` -- and yet the name is a
+/// DIMENSION, which is never a causal value.
+///
+/// The wrap's own dimension-name guard (GH #759) says exactly that, but it was
+/// written when the axis was always unknown and stayed gated on `axis_unknown`,
+/// so this arm reached the recursive wrap and froze a dimension name:
+/// `PREVIOUS(aggregated[PREVIOUS(agg, agg)])`. `builtins_visitor` then hoists that
+/// now-dynamic index into a `PREVIOUS`-capture helper aux
+/// (`aggregated[previous(agg·a1, agg·a1)]`) whose inner argument constant-folds to
+/// the element's offset, and codegen rejects `PREVIOUS(<literal>)` -- so the helper
+/// keeps a layout slot with no bytecode, reads a constant 0, and every score
+/// through it is silently degraded. This accounted for 49 of the 1,603 LTM
+/// fragment-compile failures on C-LEARN.
+///
+/// The fixture is C-LEARN's shape in miniature: `Pct interim change in FF
+/// emissions[COP] = IF THEN ELSE(Time < Emissions reference year[COP], ..., Pct
+/// interim in FF emissions Aggregated[Aggregated Regions])` -- a target iterating
+/// one dimension reading a dep declared over ANOTHER, spelled with that other
+/// dimension's own name (legal because the dep's dimension maps onto the
+/// target's).
+///
+/// This test constrains ONE arm of
+/// [`crate::dimensions::resolve_axis_index_name`] as the wrap consumes it:
+/// `Unresolved` where the name is a DIMENSION. The other two arms are covered,
+/// and not here:
+///
+/// * `Element` -- `an_index_naming_the_axis_own_element_stays_a_static_selector`
+///   (directly above).
+/// * `Unresolved` naming a model VARIABLE, which must still FREEZE --
+///   `a_colliding_index_name_is_resolved_against_the_axis_it_indexes`, whose
+///   `PREVIOUS(ctr, ctr)` assertion is this test's counterweight: together they
+///   say the guard distinguishes a dimension from a variable rather than
+///   declining to freeze bare indices generally.
+/// * `IteratedDim` -- twelve tests, all in `db::ltm_char_tests` except the last:
+///   `char_per_element_{ambiguous_pin, dynamic_index, index_nested_occurrence,
+///   mapped_occurrence, mixed_occurrences, other_deps}`,
+///   `bare_arrayed_dep_is_pinned_over_its_own_declared_dims`,
+///   `per_element_{ambiguous_pin, mapped_occurrence}_scores_are_live_not_silent_zero`,
+///   `mapped_bare_live_source_ref_is_pinned_through_the_correspondence`,
+///   `per_element_dynamic_index_scores_preserve_head_lag`, and
+///   `ltm_augment::tests::gh526_transposed_other_dep_with_threaded_dims_is_unfreezable`.
+///   (`char_per_element_link_scores` does NOT reach it, despite the name.)
+///
+/// **This fixture reaches `IteratedDim` not at all**, and the reason is worth
+/// stating because the fixture LOOKS like it should: `level[cop]` and
+/// `ref_year[cop]` are subscripted by the target's own iterated dimension, but
+/// both are collapsed to a bare `Var` in `wrap_non_matching_in_previous` --
+/// the live source by the GH #511 `Bare` normalization, the other-dep by
+/// `OtherDepVerdict::Collapse` -- BEFORE any index is walked. So no `[cop]`
+/// index ever reaches the index pass, and none appears in the emitted text.
+/// An earlier revision of this comment claimed those indices covered the arm.
+/// Measured, not read: replacing `AxisIndexName::IteratedDim => return index`
+/// with `panic!` leaves this test passing when run alone, and panics in exactly
+/// the twelve tests listed above.
+#[test]
+fn a_dimension_name_index_is_not_frozen_when_the_axis_is_known() {
+    use salsa::Setter;
+
+    let project = TestProject::new("dim_name_index")
+        .with_sim_time(0.0, 3.0, 1.0)
+        .named_dimension("cop", &["c1", "c2"])
+        .named_dimension_with_mapping("agg", &["a1", "a2"], "cop")
+        .array_aux("aggregated[agg]", "TIME * 2")
+        .array_aux("ref_year[cop]", "2")
+        .array_stock("level[cop]", "1", &["growth"], &[], None)
+        .array_flow("growth[cop]", "target[cop] * 0.1", None)
+        .array_aux(
+            "target[cop]",
+            "if TIME < ref_year[cop] then level[cop] else aggregated[agg]",
+        )
+        .build_datamodel();
+
+    let mut db = SimlinDb::default();
+    let (source_project, source_model) = {
+        let sync = sync_from_datamodel(&db, &project);
+        (sync.project, sync.models["main"].source)
+    };
+    source_project.set_ltm_enabled(&mut db).to(true);
+
+    let ltm = crate::db::model_ltm_variables(&db, source_model, source_project);
+    let score = ltm
+        .vars
+        .iter()
+        .find(|v| v.name.ends_with("link_score\u{205A}level\u{2192}target"))
+        .map(|v| match &v.equation {
+            crate::db::LtmEquation::ApplyToAll(_, arm) => arm.text.clone(),
+            other => panic!("expected an apply-to-all score, got {other:?}"),
+        })
+        .expect("the level->target link score must be emitted");
+
+    // The co-source freezes WHOLESALE with its dimension-name index verbatim --
+    // the same shape `ltm_augment_tests::partial_equation_dimension_name_index_
+    // not_wrapped` pins on the axis-unknown path.
+    assert!(
+        score.contains("PREVIOUS(aggregated[agg])"),
+        "a dimension-name index must be left verbatim inside the frozen \
+         co-source; got: {score}"
+    );
+    // The pre-fix spelling, pinned by name so a regression cannot pass by
+    // merely differing. (`PREVIOUS(agg,` rather than `PREVIOUS(agg` -- the
+    // latter also matches the legitimate `PREVIOUS(aggregated...)`.)
+    assert!(
+        !score.contains("PREVIOUS(agg,"),
+        "a dimension name is not a causal value and must never be frozen; \
+         got: {score}"
+    );
+    // The runtime consequence, which is what makes this a defect rather than a
+    // spelling preference: the frozen index forced a capture helper whose
+    // argument constant-folded, so the helper compiled to nothing.
+    let diags = crate::db::collect_all_diagnostics(&db, source_project);
+    assert!(
+        diags.is_empty(),
+        "every LTM fragment and helper must compile; got: {:?}",
+        diags
+            .iter()
+            .map(|d| (&d.variable, &d.error))
+            .collect::<Vec<_>>()
+    );
+}
+
 /// `link_score_equation_text_shaped` documents that "a per-shape link score is
 /// recomputed only when the involved variables (and their shape-classifying
 /// dimensions) change". This is that claim, measured.

--- a/src/simlin-engine/src/dimensions.rs
+++ b/src/simlin-engine/src/dimensions.rs
@@ -759,17 +759,85 @@ impl DimensionsContext {
     ///
     /// Semantics:
     /// - **Positional mappings only**: a mapping with a non-empty explicit
-    ///   `element_map` returns `None`. The engine's executed A2A lowering
-    ///   resolves mapped references POSITIONALLY and ignores the element
-    ///   map (different-cardinality maps don't compile at all -- GH #753;
-    ///   the broader positional-vs-element-map execution inconsistency is
-    ///   GH #756), so a map-following diagonal would DROP the
-    ///   true positionally-read edges. Re-enable element-map diagonals
-    ///   here only once the engine honors element maps in execution; the
-    ///   graph-vs-simulation parity test
-    ///   (`element_graph_mapped_element_map_edges_superset_of_simulation_reads`)
-    ///   is written to keep passing across that change.
-    /// - **Direction**: both declaration directions are honored, mirroring
+    ///   `element_map` returns `None`.
+    ///
+    ///   This gate's original justification -- "the engine's executed A2A
+    ///   lowering resolves mapped references POSITIONALLY and ignores the
+    ///   element map" -- is FALSE AS A UNIVERSAL, and the correction matters
+    ///   because it is what made the gate blanket. Execution does both, and
+    ///   which one you get depends on the SPELLING of the reference's
+    ///   subscript, not on the mapping or the direction it was declared in:
+    ///
+    ///   * a subscript naming a dimension the enclosing equation ITERATES
+    ///     (`target[State] = x[State]`, `State` active) is **positional**;
+    ///   * a subscript naming a dimension that is NOT active -- typically the
+    ///     referenced variable's OWN declared dimension (`target[COP] =
+    ///     x[Region]`) -- **follows the element map**;
+    ///   * a BARE reference (`target[COP] = x`) is **positional**, in either
+    ///     declaration direction, and at unequal cardinality fails to compile
+    ///     like the active-dimension spelling. It has no subscript, so the
+    ///     mechanism below never fires for it -- worth stating because
+    ///     `expand_same_element` names `emit_edges_for_reference`'s `Bare` arm
+    ///     as a primary consumer of this correspondence.
+    ///
+    ///   The fork is `ast::expr3`'s `IndexExpr3::Dimension` arm: a name
+    ///   matching an active dimension folds to that dimension's ordinal and
+    ///   indexes the referenced variable's storage raw, never consulting a
+    ///   mapping; a name matching none survives as a dimension reference and
+    ///   reaches `translate_via_mapping`, which honours the map.
+    ///
+    ///   Map-following is the CORRECT behaviour where it happens, checked
+    ///   against real Vensim rather than argued: C-LEARN's
+    ///   `im_6_ff_co2[COP]` reads an `Aggregated Regions`-declared source on
+    ///   the non-active spelling, and its source values and per-element
+    ///   factors are distinct enough that the checked-in `Ref.vdf` uniquely
+    ///   identifies which source region each of the 7 COP elements read --
+    ///   the declared element map every time (positional would put 9.7654
+    ///   where Vensim has 6.7294 for `oecd_eu`). `simulates_clearn` gates it.
+    ///
+    ///   The positional half has NO such ground truth and is recorded here as
+    ///   UNVERIFIED. The argument for doubting it: Vensim's documented trigger
+    ///   for subscript mapping is a right-hand-side subscript absent from the
+    ///   left-hand side, which the active-dimension spelling does not have, so
+    ///   it may not be a mapping use in Vensim at all. Note the structure --
+    ///   that Vensim claim is the PREMISE for the doubt, and it is the weaker
+    ///   of the two: it is PARAPHRASED from a summarising fetch of
+    ///   <https://www.vensim.com/documentation/ref_subscript_mapping.html>,
+    ///   not quoted from the page, and nobody here has read the raw text. So
+    ///   treat neither the positional behaviour nor the reason for doubting it
+    ///   as settled; the `Ref.vdf` evidence above is independent of both and
+    ///   is the load-bearing half of this note.
+    ///
+    ///   **The gate must nevertheless STAY until the spelling is threaded
+    ///   in.** Deleting it is not the fix: with it removed,
+    ///   `element_graph_mapped_element_map_edges_superset_of_simulation_reads`
+    ///   loses a TRUE edge (the forbidden direction for the LTM contract --
+    ///   fewer edges than the simulation reads), and an integration fixture
+    ///   starts reporting loop scores attributed along edges that do not
+    ///   exist (9 lib + 2 integration tests red). A correct fix has to tell
+    ///   the two spellings apart, and this predicate cannot: it is keyed by
+    ///   the dimension PAIR, while the deciding fact -- which dimension name
+    ///   the subscript spells -- belongs to the reference site. Threading it
+    ///   reaches every call site (`db::analysis`, `ltm_agg`,
+    ///   `db::ltm::link_scores`, `ltm_augment_post_transform`), which is why
+    ///   it has not been done.
+    ///
+    ///   The trap, and the most useful thing to know before touching this:
+    ///   **no simulation-level test can catch a mistake here.** The four
+    ///   modules above are the only callers, and all are LTM/analysis --
+    ///   nothing in the compiler, the VM, or the wasm backend consults this,
+    ///   and `DimensionsContext` is not reachable outside the crate at all
+    ///   (`mod dimensions` is private in `lib.rs` and the type is never
+    ///   re-exported), so libsimlin, pysimlin, the CLI and the wasm build
+    ///   cannot reach it even in principle. `simulates_clearn` passes with the
+    ///   gate removed. Only the element-graph parity and LTM tests gate this
+    ///   behaviour.
+    /// - **Direction**: which dimension DECLARED the mapping. Not to be
+    ///   confused with the spelling fork above -- declaration direction has no
+    ///   bearing on whether execution follows the element map, and reading a
+    ///   split in the fixtures as a direction effect is the wrong turn this
+    ///   note exists to prevent. Both declaration directions are honored,
+    ///   mirroring
     ///   [`Self::translate_via_mapping`] (which the compiler's subscript /
     ///   A2A resolution uses): a mapping declared on `iterated_dim` toward
     ///   `source_dim` or one declared on `source_dim` toward
@@ -782,8 +850,16 @@ impl DimensionsContext {
     /// - **Transitivity**: single-hop only, matching `has_mapping_to`. A
     ///   chained `A→B→C` mapping yields `None` for the `(A, C)` pair, just
     ///   as the classifier declines it.
-    /// - **Cardinality**: equal sizes required (positional), per
-    ///   `translate_via_mapping`'s positional path.
+    /// - **Cardinality**: equal sizes required, per
+    ///   `translate_via_mapping`'s positional path -- a property of THIS
+    ///   function, not of the language. GH #753 records that a
+    ///   different-cardinality map "does not compile", and that too holds
+    ///   only for the active-dimension spelling: on the map-following
+    ///   spelling a many-to-one map compiles and runs correctly (C-LEARN's
+    ///   3-element `Aggregated Regions` onto 7-element `COP` is the shipped
+    ///   case, and a 2-onto-4 fixture reproduces it). GH #756 tracks the
+    ///   positional-vs-element-map execution split itself, which the
+    ///   spelling fork above describes.
     /// - **Fallback**: `None` when no direct mapping exists in either
     ///   direction, either dimension is indexed, a non-empty element map
     ///   is declared, or any iterated element fails to translate (a
@@ -801,11 +877,14 @@ impl DimensionsContext {
         {
             return None;
         }
-        // Decline explicit (non-positional) element maps: the executed A2A
-        // lowering resolves mapped references positionally, IGNORING the
-        // element map (see the rustdoc's "Positional mappings only" gate),
-        // so following the map here would emit a diagonal missing the true
-        // positionally-read edges. `None` keeps the broadcast superset.
+        // Decline explicit (non-positional) element maps, keeping the
+        // broadcast superset. Execution follows the element map on one
+        // reference spelling and resolves positionally on the other, and this
+        // predicate is keyed by the dimension PAIR, so it cannot tell which
+        // one it is being asked about; answering either way is wrong for the
+        // other. Read the "Positional mappings only" bullet before changing
+        // this -- deleting it drops a true edge and reds 11 tests, and NO
+        // simulation-level test gates it.
         let has_element_map = |a: &CanonicalDimensionName, b: &CanonicalDimensionName| -> bool {
             self.find_mapping_info(a, b)
                 .is_some_and(|m| !m.element_map.is_empty())

--- a/src/simlin-engine/src/ltm_augment.rs
+++ b/src/simlin-engine/src/ltm_augment.rs
@@ -1032,6 +1032,15 @@ pub(crate) enum PartialEquationErrorKind {
     /// semantics carry a spurious factor (GH #789). Selects a diagnostic
     /// that names the shape and the subscripted-spelling workaround.
     BareReducerFeeder,
+    /// An arrayed dep of the target's equation cannot be projected onto the
+    /// target element this partial is for, so no correct element subscript
+    /// exists for it. `equation_text` carries `dep@element`. Emitting anyway
+    /// leaves the dep's dimension-name subscript in a scalar fragment, which
+    /// becomes a `PREVIOUS`-capture helper that cannot lower WHILE THE PARENT
+    /// STILL COMPILES -- a score that silently reads part of its own equation
+    /// as 0. The reachable cause is an explicit element map, which
+    /// `DimensionsContext::mapped_element_correspondence` declines.
+    UnprojectableDep,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -1063,6 +1072,14 @@ impl PartialEquationError {
         PartialEquationError {
             equation_text: equation_text.to_string(),
             kind: PartialEquationErrorKind::BareReducerFeeder,
+        }
+    }
+
+    /// `dep` cannot be projected onto target element `element`.
+    pub(crate) fn unprojectable_dep(dep: &str, element: &str) -> Self {
+        PartialEquationError {
+            equation_text: format!("{dep}@{element}"),
+            kind: PartialEquationErrorKind::UnprojectableDep,
         }
     }
 }
@@ -2189,6 +2206,81 @@ pub(crate) fn subscript_idents_at_element(
         return Err(PartialEquationError::new(equation_text));
     };
     Ok(print_eqn(&subscript_idents_in_expr0(ast, pins)))
+}
+
+/// The first subscript index in `equation_text` that names a project DIMENSION,
+/// or `None` when every index resolves.
+///
+/// A per-element link-score partial is a SCALAR fragment, so every subscript
+/// index in it must select ONE element. An index left as a bare dimension name
+/// still denotes the whole axis: it cannot lower
+/// (`ErrorCode::DimensionInScalarContext`), and when it sits inside a frozen
+/// subtree `builtins_visitor` hoists it into a `PREVIOUS`-capture helper that
+/// fails on its own WHILE THE PARENT STILL COMPILES -- so the score exists and
+/// reads part of its own equation as a constant 0.
+///
+/// This inspects the FINISHED partial rather than predicting from the pin table,
+/// and that is the point: a dep can be unpinnable and still need no pin (an
+/// index that is a runtime variable read, `source[idx]`, resolves by itself), so
+/// "the pin table does not cover this dep" over-declines. What matters is only
+/// whether an unresolvable index survived into the text about to be compiled.
+///
+/// A returned `Some` is the caller's cue to decline the edge loudly rather than
+/// emit a score computed around a hole.
+pub(crate) fn unresolvable_dimension_index(
+    equation_text: &str,
+    dims_ctx: &crate::dimensions::DimensionsContext,
+) -> Option<String> {
+    fn walk(
+        expr: &Expr0,
+        dims_ctx: &crate::dimensions::DimensionsContext,
+        found: &mut Option<String>,
+    ) {
+        if found.is_some() {
+            return;
+        }
+        match expr {
+            Expr0::Const(..) => {}
+            Expr0::Var(..) => {}
+            Expr0::Subscript(ident, indices, _) => {
+                for idx in indices {
+                    if let IndexExpr0::Expr(Expr0::Var(name, _)) = idx {
+                        let canonical = canonicalize(name.as_str());
+                        if dims_ctx.is_dimension_name(canonical.as_ref()) {
+                            *found = Some(format!("{}[{}]", ident.as_str(), canonical));
+                            return;
+                        }
+                    }
+                    if let IndexExpr0::Expr(e) = idx {
+                        walk(e, dims_ctx, found);
+                    }
+                }
+            }
+            Expr0::App(UntypedBuiltinFn(_, args), _) => {
+                for a in args {
+                    walk(a, dims_ctx, found);
+                }
+            }
+            Expr0::Op1(_, l, _) => walk(l, dims_ctx, found),
+            Expr0::Op2(_, l, r, _) => {
+                walk(l, dims_ctx, found);
+                walk(r, dims_ctx, found);
+            }
+            Expr0::If(c, t, f, _) => {
+                walk(c, dims_ctx, found);
+                walk(t, dims_ctx, found);
+                walk(f, dims_ctx, found);
+            }
+        }
+    }
+    let Ok(Some(ast)) = Expr0::new(equation_text, LexerType::Equation) else {
+        // Unparseable text is a different failure, reported by the caller that
+        // produced it; this predicate says nothing about it.
+        return None;
+    };
+    let mut found = None;
+    walk(&ast, dims_ctx, &mut found);
+    found
 }
 
 /// The `IndexExpr0` a pin entry's element spelling becomes.

--- a/src/simlin-engine/src/ltm_augment_index.rs
+++ b/src/simlin-engine/src/ltm_augment_index.rs
@@ -297,7 +297,25 @@ pub(super) fn wrap_index_non_matching_in_previous(
     // element downstream, exactly as in the target's own equation. The
     // `iter_ctx` leg covers callers without a project dims context (the
     // iterated/source dims are dimension names by construction).
-    if axis_unknown && let IndexExpr0::Expr(Expr0::Var(name, _)) = &index {
+    //
+    // Unlike the two element guards above, this one is NOT gated on
+    // `axis_unknown`, and the asymmetry is the point. Those range over the
+    // project's whole ELEMENT namespace, which can disagree with the axis about
+    // which dimension an element belongs to -- so when the axis is known its
+    // verdict must win. A dimension NAME admits no such disagreement: reaching
+    // here with a known axis means the verdict was `Unresolved`, i.e. the axis
+    // does not declare this name as an element and the target does not iterate
+    // it, and a dimension name cannot also be a variable name (the XMILE spec,
+    // `docs/reference/xmile-v1.0.html` §3.7.1: dimension names "need to be
+    // unique and accessible across a whole-model (including submodels). In
+    // addition, they must be distinct from model variables names within the
+    // whole-model") -- so nothing it could be is a causal value. Gating it left
+    // exactly that case (a dep declared over a dimension the target does not
+    // iterate, spelled with its own dimension name, reachable through a
+    // dimension mapping) freezing a dimension name once GH #986 resolved axes;
+    // `db::ltm_tests::a_dimension_name_index_is_not_frozen_when_the_axis_is_known`
+    // is that shape.
+    if let IndexExpr0::Expr(Expr0::Var(name, _)) = &index {
         let canonical = canonicalize(name.as_str());
         let names_project_dim =
             dims_ctx.is_some_and(|ctx| ctx.is_dimension_name(canonical.as_ref()));

--- a/src/simlin-engine/src/variable.rs
+++ b/src/simlin-engine/src/variable.rs
@@ -1153,6 +1153,35 @@ pub struct DepClassification {
     /// it is kept OUT of `all` so it never creates a runlist-ordering or
     /// causal/LTM edge, and is reunited with the dependency set only when the
     /// fragment compiler builds its metadata + tables map (issue #606).
+    ///
+    /// **A consumer wanting a table reference reads THIS FIELD; it is not, and
+    /// must not be, in `all`.** GH #606 justified the exclusion purely in terms
+    /// of runlist ordering and said nothing about the other questions a caller
+    /// can ask, which is how a later consumer came to read the omission as the
+    /// information being unavailable. It is not: this field rides the same
+    /// struct, from the same single pass, over the same AST. Spelled as the
+    /// three questions a caller might mean:
+    ///
+    /// * **ordering** -- NOT a dependency. Static data imposes no
+    ///   evaluation-order constraint, and a lookup-only holder is excluded from
+    ///   every runlist (`Var::is_table_only`), so an edge to it would order
+    ///   against something that is never evaluated.
+    /// * **attribution** -- NOT a dependency. A table cannot vary, so it has no
+    ///   delta and can carry no causal edge or link score. An edge here is a
+    ///   wrong NUMBER, not a crash.
+    /// * **dimension resolution** -- IT IS needed. A table argument's subscript
+    ///   has to be resolved and element-pinned like any other arrayed
+    ///   reference, and that needs the holder's declared dimensions.
+    ///   `db::ltm::link_scores::pinnable_arrayed_deps` is the worked example: it
+    ///   widens the per-element PIN candidates with this field while leaving the
+    ///   ceteris-paribus wrap's dep set alone.
+    ///
+    /// Moving these into `all` and filtering at the consumers was measured and
+    /// rejected: five consumer families see them, four must filter them out, and
+    /// the first one to break is compilation itself (a lookup-only holder has no
+    /// value slot, so the fragment compiler refuses -- `lookup_only_tests`).
+    /// Absent-by-default fails loudly (a consumer that needs tables sees nothing
+    /// and says so); present-by-default fails silently.
     pub referenced_tables: BTreeSet<String>,
 }
 

--- a/src/simlin-engine/tests/integration/simulate.rs
+++ b/src/simlin-engine/tests/integration/simulate.rs
@@ -6019,7 +6019,7 @@ fn corpus_clearn_macros_import() {
 ///
 /// Nothing under `test/` pins the corrected values either way, so this exact
 /// count is the only tripwire for the recovery. It is a weak one: any emission
-/// change landing on 6,891 satisfies it. The real guard is the sibling
+/// change landing on its pinned total satisfies it. The real guard is the sibling
 /// `clearn_ltm_partials_all_parse`, which asserts the MECHANISM (zero
 /// `PartialEquationErrorKind::Parse` warnings) rather than a total.
 ///
@@ -6031,12 +6031,34 @@ fn corpus_clearn_macros_import() {
 ///
 /// Layout impact (the resource this gate protects -- #654's VM limit of 65,536
 /// u16 result slots, NOT `wasmgen::lower`'s unrelated `MAX_UNROLL_UNITS`): the
-/// per-step result-row width is 30,416 slots, far below the ceiling. It last
-/// moved DOWNWARD, 31,199 -> 30,416 (-783), when the per-element completeness
-/// guard began declining edges whose partial would carry an unresolvable
-/// dimension-name index: those scores are no longer emitted, so they no longer
-/// occupy slots. A decline is the safe direction for this resource; the pin
-/// below exists to catch emission changes in EITHER direction.
+/// per-step result-row width is **30,947 slots**, 47% of the ceiling, with
+/// 34,589 free.
+///
+/// It last moved UPWARD, 30,416 -> 30,947 (+531), when GH #996 stopped the axis
+/// allocator stealing a name-matched slot: 135 link scores that the per-element
+/// completeness guard had been declining now pin their indices and are emitted
+/// again. An earlier note here argued that DOWNWARD was the safe direction, and
+/// that framing is retired -- direction alone is not the test. What matters is
+/// the margin, and +531 against 34,589 free is immaterial. Across this whole
+/// branch the width is still NET DOWN, **31,248 -> 30,947 (-301)**, measured at
+/// the branch base `e913b3f4`. (An earlier revision cited 31,199 as the base;
+/// that is the width at `541c05a8`, seven commits in, and was wrong. Measuring a
+/// past commit needs a fresh worktree: `git archive` restores commit-time
+/// mtimes, so cargo silently reuses a stale binary and reports the CURRENT
+/// number for the old commit.)
+///
+/// Recorded honestly because the trade is currently one-sided: those 135
+/// variables occupy slots and then FAIL in codegen, because each carries a
+/// second, independent defect (an array-valued operand, GH #995) that pinning
+/// the index does not touch. They are loud failures rather than silent zeros --
+/// the guard still holds, and the silent-zero counter stays at 0 -- but a slot
+/// spent on a fragment that cannot compile buys nothing until #995 lands. The
+/// slots are cheap at this margin and the allocator fix is correct on its own
+/// terms, which is why the emission is accepted; if the margin were tight, the
+/// right move would be to sequence #996 behind #995 instead.
+///
+/// The pin below catches emission changes in EITHER direction, and re-deriving
+/// it means re-measuring BOTH numbers, not just the count.
 #[test]
 fn clearn_ltm_var_count_guardrail() {
     use simlin_engine::db::{model_ltm_variables, set_project_ltm_enabled};
@@ -6060,7 +6082,7 @@ fn clearn_ltm_var_count_guardrail() {
         })
         .sum();
     assert_eq!(
-        total, 6665,
+        total, 6800,
         "C-LEARN's emitted LTM var count moved; if this is an intentional \
          emission change, re-derive the layout-slot impact (the #654 \
          ceiling) and update this pin with the new numbers"
@@ -6072,7 +6094,7 @@ fn clearn_ltm_var_count_guardrail() {
 /// `print_eqn` emitted text the engine's own parser rejects.
 ///
 /// The var-count pin above would be satisfied by any emission change that
-/// happened to land on 6,891. This asserts the *mechanism*: zero
+/// happened to land on its pinned total. This asserts the *mechanism*: zero
 /// `PartialEquationErrorKind::Parse` warnings. A regression in the printer
 /// (an operator spelled with a token the lexer lacks, a missing
 /// parenthesization) silently re-drops link scores, and the ceteris-paribus

--- a/src/simlin-engine/tests/integration/simulate.rs
+++ b/src/simlin-engine/tests/integration/simulate.rs
@@ -6031,8 +6031,12 @@ fn corpus_clearn_macros_import() {
 ///
 /// Layout impact (the resource this gate protects -- #654's VM limit of 65,536
 /// u16 result slots, NOT `wasmgen::lower`'s unrelated `MAX_UNROLL_UNITS`): the
-/// per-step result-row width goes 30,800 -> 31,198 slots (+398, +1.29%), still
-/// far below the ceiling.
+/// per-step result-row width is 30,416 slots, far below the ceiling. It last
+/// moved DOWNWARD, 31,199 -> 30,416 (-783), when the per-element completeness
+/// guard began declining edges whose partial would carry an unresolvable
+/// dimension-name index: those scores are no longer emitted, so they no longer
+/// occupy slots. A decline is the safe direction for this resource; the pin
+/// below exists to catch emission changes in EITHER direction.
 #[test]
 fn clearn_ltm_var_count_guardrail() {
     use simlin_engine::db::{model_ltm_variables, set_project_ltm_enabled};
@@ -6056,7 +6060,7 @@ fn clearn_ltm_var_count_guardrail() {
         })
         .sum();
     assert_eq!(
-        total, 6891,
+        total, 6665,
         "C-LEARN's emitted LTM var count moved; if this is an intentional \
          emission change, re-derive the layout-slot impact (the #654 \
          ceiling) and update this pin with the new numbers"


### PR DESCRIPTION
On C-LEARN, 1,603 generated LTM fragments failed to compile. Each kept a layout slot with no bytecode and read a constant 0, so a link or loop score derived from it was silently degraded. The warning said only *that* a fragment failed, never why, so the class had never been diagnosed.

This branch root-causes them and fixes what can be fixed correctly.

**LTM fragment-compile failures 1,603 → 449. Silent zeros (a score present but computed around a hole) → 0.**

## Why it was undiagnosable

Four distinct error paths collapsed into one `Option::None`: two legs of the LTM equation compiler, and `compile_phase_to_per_var_bytecodes` discarding its emit error with `.ok()?`. `d71a4f6a` makes the reason ride the warning and adds `examples/ltm_fragment_failures.rs`, which buckets failures by compiler error and cross-tabulates them against structure. It runs on any model via `LTM_FAIL_MODEL`.

With reasons available, the 1,554 remaining failures resolve into four generators — grouped by generating *root* rather than by fragment, so a defect is counted once rather than once per fragment it poisoned.

## What is fixed

**`485c0170` — stop freezing a dimension-name subscript index.** The ceteris-paribus wrap froze a bare dimension name used as a subscript index. Per-element substitution then turned it into a qualified element, which constant-folds, and codegen rejects `PREVIOUS(<literal>)`. A guard saying exactly that a dimension name must be left verbatim already existed but was gated on a condition that stopped being true once the wrap gained a resolved axis. One token. Beyond the 49 compile failures it clears, three *arrayed* link scores were compiling while their capture helpers were not — silently reading zero. Those are restored.

**`c6b2c76c` — pin a LOOKUP table's index, and decline what cannot be pinned.** A per-element partial is a scalar fragment, so every reference must select one element. The pin pass built its candidates from the dependency set, and a graphical-function holder is deliberately not in it. The dimensions were never unreachable — `referenced_tables` rides the same struct the same AST pass already returns. Widening the *pin candidates* with it is the fix; the wrap's dependency set is deliberately not widened, for an attribution reason.

That alone made 21 parents compile while a helper beneath them stayed dead, so a completeness guard now declines an edge loudly when an unresolvable index survives into the finished partial. It inspects the emitted partial rather than predicting from the pin table — predicting over-declined by 63 edges, caught by an existing test. The guard subsumes a second defect class entirely, and runs at all four sites that emit this object.

**`8a9c17e4` — attribute a codegen rejection to its variable.** A fragment failing in codegen produced *no diagnostic at all*; only lowering errors were reported. Six ordinary hand-written apply-to-all shapes fail this way today **with LTM disabled** and report nothing about why. Severity was measured, not argued: a sweep across the `test/` corpus found added rows land only on projects that already fail to compile.

## Corrections to premises that were wrong

Two claims in the codebase were false and had tests that appeared to pin them.

**`541c05a8`** — `mapped_element_correspondence` declines every explicit element map, justified by the claim that execution resolves mapped references positionally, ignoring the map. That is false as a universal. The discriminator is which dimension name the subscript spells; declaration direction is irrelevant. Map-following is **correct**, settled against real Vensim output: C-LEARN's `im_6_ff_co2[COP]` has seven elements each uniquely identifying their source region in the checked-in `Ref.vdf`, and it is the declared map every time. The gate nonetheless stays — deleting it drops a true causal edge. Recorded because nothing else can catch it: every caller is analysis code, `DimensionsContext` is private with no re-export, and `simulates_clearn` passes with the gate removed.

**`964cc276`** — a module-port reference is spelled as one fully-quoted identifier, and a module-hood lookup misses on it. Real, and **inert**: canonicalization strips the quotes and it resolves anyway. Recorded so nobody re-derives it as a bug, which is exactly what happened here.

## Verification

Every fix is test-first, with the pre-fix failure captured. Each piece was reviewed adversarially by an agent with no stake in it; findings were driven to zero before commit. Reviews caught, by mutation rather than by reading: a coverage claim that was false, a load-bearing justification naming a coincidence rather than the mechanism, a guard reachable on three unguarded sibling sites, and four vacuous assertions — including one whose fixture could not have detected a mis-pin *in principle*, because the score saturated.

Full suite green throughout (5,475 lib + 647 integration + 4 + 3), including `simulates_clearn`, which gates C-LEARN against real Vensim output.

## Scope disclosed rather than implied

Nothing here fixes classes A or B; they are tracked. Every C-LEARN occurrence of the pinned shape is the identity case, which is a measured property of one corpus and not of the language. The implicit-helper phase compiler still swallows its codegen error.

## What is not fixed, and where it is tracked

No closing keywords: this branch fully resolves no existing issue. What it leaves is measured and attributed rather than vague.

| remaining | roots | tracked |
|---|---|---|
| module -> arrayed target: `scalarize()` relabels shape without rewriting the body | 340 | #716 (this is the mechanism behind it; commented with the two code sites) |
| array-valued operand must be a view over storage, so `PREVIOUS()` of an array fails | 109 | #995 |
| the 135 declined edges that may be a pin gap rather than a compiler gap | -- | #996 (**check before #995**; could shrink it substantially) |
| the element-map spelling fix that would let class D be scored rather than declined | 70 | #997 |
| three ranking surfaces dominated by groups of size one | -- | #998 |
| `collect_all_diagnostics` not reproducible run-to-run | -- | #999 |
| the implicit-helper phase compiler still swallowing its codegen error | -- | #1000 |

#984 is **not** closed. It is commented with what moved and with a correction: its surrounding analysis held that a graphical-function holder's dimensions were unreachable, and they were not -- the constraint is absence from the dependency *graph*, which is a different thing. Its runtime-index half is untouched.

Suggested order: #996 first (cheap, and may make #995 much smaller), then #716, then #995.
