### PR TITLE
libsimlin: use wasmalloc as the wasm global allocator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -11,6 +11,9 @@ name: CI
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0
+  # Hosted runners occasionally lose DNS for crates.io mid-build; cargo's default of three
+  # retries with short backoff has not been enough on the Windows smoke job.
+  CARGO_NET_RETRY: 8
 
 jobs:
   build:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4204,9 +4204,9 @@ dependencies = [
 
 [[package]]
 name = "wasmalloc"
-version = "0.1.0"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53513986006df76a8e2894c054703b480dcdd174ef09c733eba086af7d5d9d96"
+checksum = "065f25b3013d594aa09b24789faf58b6ce2db1623c6843eeebd161b5f080736e"
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3284,6 +3284,7 @@ dependencies = [
  "serde_json",
  "simlin-engine",
  "wasm-interpreter",
+ "wasmalloc",
 ]
 
 [[package]]
@@ -4200,6 +4201,12 @@ dependencies = [
  "libm",
  "log_wrapper",
 ]
+
+[[package]]
+name = "wasmalloc"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53513986006df76a8e2894c054703b480dcdd174ef09c733eba086af7d5d9d96"
 
 [[package]]
 name = "winapi-util"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -390,9 +390,9 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chacha20"
-version = "0.10.1"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d524456ba66e72eb8b115ff89e01e497f8e6d11d78b70b1aa13c0fbd97540a81"
+checksum = "65c35e4b699c7e15ccbe7ee35c005e4fc0a278d22238a2857e6ce2dadeda1b06"
 dependencies = [
  "cfg-if",
  "cpufeatures 0.3.0",

--- a/docs/design/engine-performance.md
+++ b/docs/design/engine-performance.md
@@ -17,7 +17,8 @@ set of larger proposals grounded in the measured data.
 - Harness: `src/simlin-engine/examples/clearn_profile.rs` — times each pipeline
   stage (parse → compile-via-salsa → `Vm::new` → `run_to_end`) and, with
   `CLEARN_COUNT_ALLOCS=1`, reports allocation counts / peak live bytes per stage
-  via a gated counting global allocator. With high `CLEARN_COMPILE_ITERS` /
+  via a gated counting global allocator (`CLEARN_ALLOC_HIST=1` adds a size
+  histogram of the allocations and reallocs in each stage). With high `CLEARN_COMPILE_ITERS` /
   `CLEARN_RUN_ITERS` it is a focused `perf record` / `callgrind` target.
 - `CompiledSimulation::bytecode_profile()` — opcode histogram + table sizes.
 - CPU: `perf record -g --call-graph dwarf` and `valgrind --tool=callgrind`

--- a/docs/dev/benchmarks.md
+++ b/docs/dev/benchmarks.md
@@ -72,6 +72,24 @@ The Rust counterpart is `src/simlin-engine/examples/backend_bench.rs`, which use
 
 Results are reported in the PR or chat, not committed: the harness is regenerable, but checked-in numbers go stale and mislead. Do not add a results file.
 
+## Node allocator benchmark for the wasm bundle
+
+`src/engine/bench/clearn-alloc.mjs` compares two or more builds of the libsimlin wasm bundle on the full public-API pipeline for C-LEARN v77 -- `Project.openVensim` (parse + salsa sync), `Model.simulate` (the salsa compile plus `Vm::new`), `Sim.runToEnd`, every series, the LTM link scores, and dispose -- and prints median and min per stage plus the peak `memory.size`. It exists to compare **global allocators**: the compile stage makes tens of millions of small, short-lived allocations on this model, so the allocator the bundle links (`src/libsimlin/src/lib.rs`) is a first-order term in its time, and a synthetic allocation loop would not show how that plays out on the real allocation mix.
+
+```bash
+# Build the bundle to compare against on its branch and copy it out of
+# src/engine/core/ first: build.sh overwrites the staged artifacts.
+node --expose-gc src/engine/bench/clearn-alloc.mjs \
+    dlmalloc=/path/to/main/libsimlin-browser.wasm \
+    wasmalloc=src/engine/core/libsimlin-browser.wasm
+
+# LTM off only, 20 iterations, exact memory.grow counts (needs wasm-tools on PATH)
+node --expose-gc src/engine/bench/clearn-alloc.mjs --ltm off --iters 20 --count-grows \
+    a=/path/to/a.wasm b=/path/to/b.wasm
+```
+
+The bundles are interleaved (A, B, A, B, ...) so machine drift is shared rather than attributed to whichever ran last. Each iteration runs on a fresh instance of a module compiled once per bundle: every iteration starts from a cold heap, the state a page load leaves the allocator in, and no iteration inherits fragmentation from the one before, while V8 keeps its optimized code for the shared module, so the warm-up iterations warm the JIT and only the JIT. Instantiation is not timed. Run it under both node 22 and node 24 (V8 12 and 13), with `--expose-gc` so it can collect between iterations and pinned with `taskset` to reduce drift; like the eval benchmark, its results belong in the PR or chat, never in a committed file.
+
 ## Profiling
 
 ### Build a benchmark binary for profiling

--- a/src/engine/CLAUDE.md
+++ b/src/engine/CLAUDE.md
@@ -67,3 +67,5 @@ For build/test/lint commands, see [docs/dev/commands.md](/docs/dev/commands.md).
 ## Benchmarks
 
 `tests/backend-bench.ts` (runner) + `tests/bench-stats.ts` (pure median/warmup harness, always unit-tested) measure node VM-vs-wasm eval time via `Model.simulate({ engine })`. The runner is gated behind `RUN_BENCH` so it stays out of the default `pnpm test`. See [docs/dev/benchmarks.md](/docs/dev/benchmarks.md#node-vm-vs-wasm-eval-benchmark).
+
+`bench/clearn-alloc.mjs` is a standalone script (not a test) that compares two or more wasm bundles -- builds with different global allocators -- on the whole C-LEARN pipeline through this package's public API, per stage, with peak `memory.size`. See [docs/dev/benchmarks.md](/docs/dev/benchmarks.md#node-allocator-benchmark-for-the-wasm-bundle).

--- a/src/engine/bench/clearn-alloc.mjs
+++ b/src/engine/bench/clearn-alloc.mjs
@@ -1,0 +1,363 @@
+#!/usr/bin/env node
+// Copyright 2026 The Simlin Authors. All rights reserved.
+// Use of this source code is governed by the Apache License,
+// Version 2.0, that can be found in the LICENSE file.
+
+// Allocator A/B benchmark for the libsimlin wasm bundle, on the heaviest model
+// we have (C-LEARN v77, ~53k MDL lines). It drives the public @simlin/engine
+// API exactly as the app does -- Project.openVensim (parse + salsa sync),
+// Model.simulate (salsa compile + Vm::new), Sim.runToEnd, then every series
+// and, with LTM, the link scores -- and times each stage per bundle. The
+// compile stage is the allocator-bound one (tens of millions of small,
+// short-lived allocations on this model), which is why bundles built with
+// different global allocators are compared here rather than on a synthetic
+// allocation loop.
+//
+// Usage:
+//   node src/engine/bench/clearn-alloc.mjs [options] NAME=PATH.wasm [NAME=PATH.wasm ...]
+//     --iters N        measured iterations per bundle and LTM mode (default 10)
+//     --warmup N       discarded iterations before measuring (default 2)
+//     --ltm MODE       on | off | both (default both)
+//     --model PATH     a Vensim .mdl (default: C-LEARN v77)
+//     --count-grows    rewrite each bundle so every `memory.grow` also bumps an
+//                      exported counter (needs `wasm-tools` on PATH); the
+//                      rewritten copy is what gets measured
+//     --json PATH      also write the per-iteration samples as JSON
+//
+// Methodology. The bundles are interleaved (A, B, A, B, ...) so machine drift
+// is shared rather than attributed to whichever ran last; medians and minima
+// are reported, never means. Each iteration instantiates a FRESH instance of a
+// module compiled once per bundle: a fresh linear memory means every iteration
+// starts from a cold heap, the state a page load leaves the allocator in, and
+// no iteration inherits fragmentation from the one before -- while V8 keeps
+// its optimized code for the shared module, so the warm-up iterations warm the
+// JIT and only the JIT. Instantiation itself is not timed.
+//
+// Footprint. `memory.size` never shrinks, so the page count after the last
+// stage is that iteration's peak; it is reported alongside the timings. The
+// number of `memory.grow` calls is exact only with --count-grows; without it
+// the script reports how many times the memory's ArrayBuffer identity changed
+// between stage boundaries, which is a lower bound (one boundary can hide many
+// grows). Results print to the console and are not committed: the harness is
+// regenerable and checked-in numbers go stale.
+
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { parseArgs } from 'node:util';
+import { fileURLToPath } from 'node:url';
+
+import { Project, ready, resetWasm } from '@simlin/engine';
+import { getExports, getMemory } from '@simlin/engine/internal/wasm';
+
+const REPO_ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const DEFAULT_MODEL = path.join(REPO_ROOT, 'test', 'xmutil_test_models', 'C-LEARN v77 for Vensim.mdl');
+const WASM_PAGE = 65536;
+
+const { values: opts, positionals } = parseArgs({
+  options: {
+    iters: { type: 'string', default: '10' },
+    warmup: { type: 'string', default: '2' },
+    ltm: { type: 'string', default: 'both' },
+    model: { type: 'string', default: DEFAULT_MODEL },
+    'count-grows': { type: 'boolean', default: false },
+    json: { type: 'string' },
+    help: { type: 'boolean', default: false },
+  },
+  allowPositionals: true,
+});
+
+if (opts.help || positionals.length === 0) {
+  console.error('usage: clearn-alloc.mjs [--iters N] [--warmup N] [--ltm on|off|both] [--model PATH]');
+  console.error('                        [--count-grows] [--json PATH] NAME=PATH.wasm [NAME=PATH.wasm ...]');
+  process.exit(positionals.length === 0 ? 2 : 0);
+}
+
+const iters = Number.parseInt(opts.iters, 10);
+const warmup = Number.parseInt(opts.warmup, 10);
+if (!Number.isInteger(iters) || iters < 1 || !Number.isInteger(warmup) || warmup < 0) {
+  throw new Error(`--iters must be >= 1 and --warmup >= 0 (got ${opts.iters}, ${opts.warmup})`);
+}
+const ltmModes = { on: [true], off: [false], both: [true, false] }[opts.ltm];
+if (ltmModes === undefined) {
+  throw new Error(`--ltm must be on, off or both (got ${opts.ltm})`);
+}
+
+/**
+ * Rewrite a bundle so each `memory.grow` goes through a counting shim exported
+ * as the mutable i32 global `__grow_count`. Text-level: the shim function and
+ * its global are appended after every existing definition, so no existing
+ * function or global index moves and the rest of the module is untouched. The
+ * regex matches only instruction lines (a data segment's bytes are printed on
+ * `(data ...)` lines), so a string constant containing "memory.grow" is safe.
+ */
+function instrumentGrows(wasmPath, outPath) {
+  const wat = execFileSync('wasm-tools', ['print', wasmPath], { maxBuffer: 1 << 30, encoding: 'utf8' });
+  let sites = 0;
+  let text = wat.replace(/^(\s+)memory\.grow\s*$/gm, (_m, indent) => {
+    sites++;
+    return `${indent}call $__grow_hook`;
+  });
+  const hook = [
+    '  (func $__grow_hook (param i32) (result i32)',
+    '    global.get $__grow_count',
+    '    i32.const 1',
+    '    i32.add',
+    '    global.set $__grow_count',
+    '    local.get 0',
+    '    memory.grow)',
+    '  (global $__grow_count (mut i32) (i32.const 0))',
+    '  (export "__grow_count" (global $__grow_count))',
+    ')',
+  ].join('\n');
+  const end = text.lastIndexOf(')');
+  text = text.slice(0, end) + hook + text.slice(end + 1);
+  const watPath = `${outPath}.wat`;
+  fs.writeFileSync(watPath, text);
+  try {
+    execFileSync('wasm-tools', ['parse', watPath, '-o', outPath]);
+  } finally {
+    fs.unlinkSync(watPath);
+  }
+  return sites;
+}
+
+function parseBundleArg(arg, tmpDir) {
+  const eq = arg.indexOf('=');
+  const name = eq >= 0 ? arg.slice(0, eq) : path.basename(arg, '.wasm');
+  let wasmPath = path.resolve(eq >= 0 ? arg.slice(eq + 1) : arg);
+  let growSites;
+  if (opts['count-grows']) {
+    const instrumented = path.join(tmpDir, `${name}-grow.wasm`);
+    growSites = instrumentGrows(wasmPath, instrumented);
+    wasmPath = instrumented;
+  }
+  return { name, wasmPath, growSites, sizeBytes: fs.statSync(wasmPath).size };
+}
+
+/** Upper-middle element of the sorted samples, matching tests/bench-stats.ts. */
+function median(xs) {
+  const sorted = [...xs].sort((a, b) => a - b);
+  return sorted[sorted.length >> 1];
+}
+
+function pages() {
+  return getMemory().buffer.byteLength / WASM_PAGE;
+}
+
+/**
+ * One measured iteration on a fresh instance: returns per-stage milliseconds,
+ * the memory pages after each stage, the peak (final) page count, and the
+ * grow counts (exact when instrumented; otherwise a lower bound from buffer
+ * identity changes observed between stages).
+ */
+async function runOnce(module, modelBytes, enableLtm) {
+  const ms = {};
+  const pagesAfter = {};
+  let bufferChanges = 0;
+  let lastBuffer = null;
+
+  const stage = async (name, body) => {
+    const t0 = performance.now();
+    const out = await body();
+    ms[name] = performance.now() - t0;
+    const memory = getMemory();
+    if (lastBuffer !== null && memory.buffer !== lastBuffer) {
+      bufferChanges++;
+    }
+    lastBuffer = memory.buffer;
+    pagesAfter[name] = pages();
+    return out;
+  };
+
+  await ready(module);
+  lastBuffer = getMemory().buffer;
+  const initialPages = pages();
+
+  const project = await stage('open', () => Project.openVensim(modelBytes));
+  const model = await project.mainModel();
+  const sim = await stage('compile', () => model.simulate({}, { enableLtm, engine: 'vm' }));
+  await stage('run', () => sim.runToEnd());
+  const stepCount = await sim.getStepCount();
+  const names = await sim.getVarNames();
+  await stage('series', async () => {
+    for (const name of names) {
+      await sim.getSeries(name);
+    }
+  });
+  if (enableLtm) {
+    const links = await stage('links', () => sim.getLinks());
+    if (links.length === 0) {
+      throw new Error('LTM run produced no links');
+    }
+  }
+  await stage('dispose', async () => {
+    await sim.dispose();
+    await project.dispose();
+  });
+
+  const growGlobal = getExports().__grow_count;
+  const grows = growGlobal instanceof WebAssembly.Global ? growGlobal.value : undefined;
+  const peakPages = pages();
+  await resetWasm();
+
+  ms.total = Object.values(ms).reduce((a, b) => a + b, 0);
+  return { ms, pagesAfter, initialPages, peakPages, grows, bufferChanges, stepCount, varCount: names.length };
+}
+
+async function compileBundle(bundle) {
+  const bytes = fs.readFileSync(bundle.wasmPath);
+  return WebAssembly.compile(bytes.buffer.slice(bytes.byteOffset, bytes.byteOffset + bytes.byteLength));
+}
+
+function fmtMs(v) {
+  return v >= 100 ? v.toFixed(0) : v >= 10 ? v.toFixed(1) : v.toFixed(2);
+}
+
+function fmtRatio(v) {
+  return Number.isFinite(v) ? `${v.toFixed(2)}x` : '-';
+}
+
+function fmtMiB(pagesCount) {
+  return ((pagesCount * WASM_PAGE) / (1024 * 1024)).toFixed(1);
+}
+
+function printTable(bundles, enableLtm, samples) {
+  const stages = ['open', 'compile', 'run', 'series', ...(enableLtm ? ['links'] : []), 'dispose', 'total'];
+  const head = ['stage'];
+  const align = ['---'];
+  for (const [i, b] of bundles.entries()) {
+    head.push(`${b.name} median`, `${b.name} min`);
+    align.push('--:', '--:');
+    if (i > 0) {
+      head.push(`${b.name}/${bundles[0].name}`);
+      align.push('--:');
+    }
+  }
+  const rows = [head, align];
+  const base = samples[bundles[0].name];
+  for (const stage of stages) {
+    const row = [`${stage} (ms)`];
+    for (const [i, b] of bundles.entries()) {
+      const xs = samples[b.name].map((s) => s.ms[stage]);
+      row.push(fmtMs(median(xs)), fmtMs(Math.min(...xs)));
+      if (i > 0) {
+        row.push(fmtRatio(median(xs) / median(base.map((s) => s.ms[stage]))));
+      }
+    }
+    rows.push(row);
+  }
+  const memRow = (label, pick, fmt) => {
+    const row = [label];
+    for (const [i, b] of bundles.entries()) {
+      const xs = samples[b.name].map(pick);
+      if (xs.some((x) => x === undefined)) {
+        row.push('-', '-');
+        if (i > 0) {
+          row.push('-');
+        }
+        continue;
+      }
+      row.push(fmt(median(xs)), fmt(Math.min(...xs)));
+      if (i > 0) {
+        row.push(fmtRatio(median(xs) / median(base.map(pick))));
+      }
+    }
+    rows.push(row);
+  };
+  memRow('peak memory.size (pages)', (s) => s.peakPages, String);
+  memRow('peak memory.size (MiB)', (s) => s.peakPages, fmtMiB);
+  memRow(
+    'memory.grow calls' + (opts['count-grows'] ? '' : ' (lower bound)'),
+    (s) => s.grows ?? s.bufferChanges,
+    String,
+  );
+
+  const first = base[0];
+  console.log('');
+  console.log(
+    `### ${path.basename(opts.model)}, LTM ${enableLtm ? 'on' : 'off'}: ${iters} iterations after ${warmup} warm-up, ` +
+      `node ${process.version} (V8 ${process.versions.v8}), ${first.varCount} variables x ${first.stepCount} steps`,
+  );
+  console.log('');
+  for (const row of rows) {
+    console.log(`| ${row.join(' | ')} |`);
+  }
+}
+
+async function main() {
+  const tmpDir = opts['count-grows'] ? fs.mkdtempSync(path.join(os.tmpdir(), 'clearn-alloc-')) : null;
+  try {
+    const bundles = positionals.map((arg) => parseBundleArg(arg, tmpDir));
+    const seen = new Set();
+    for (const b of bundles) {
+      if (seen.has(b.name)) {
+        throw new Error(`duplicate bundle name ${b.name}; use NAME=PATH to disambiguate`);
+      }
+      seen.add(b.name);
+    }
+    const modelBytes = new Uint8Array(fs.readFileSync(opts.model));
+
+    console.log(`model: ${opts.model} (${modelBytes.length} bytes)`);
+    for (const b of bundles) {
+      const sites = b.growSites === undefined ? '' : `, ${b.growSites} memory.grow site(s) instrumented`;
+      console.log(`bundle ${b.name}: ${b.wasmPath} (${b.sizeBytes} bytes${sites})`);
+      b.module = await compileBundle(b);
+    }
+
+    const all = {};
+    for (const enableLtm of ltmModes) {
+      const samples = Object.fromEntries(bundles.map((b) => [b.name, []]));
+      for (let i = 0; i < warmup + iters; i++) {
+        for (const b of bundles) {
+          if (typeof globalThis.gc === 'function') {
+            globalThis.gc();
+          }
+          const sample = await runOnce(b.module, modelBytes, enableLtm);
+          if (i >= warmup) {
+            samples[b.name].push(sample);
+          }
+          process.stderr.write(
+            `${enableLtm ? 'ltm ' : 'nol '}${i < warmup ? 'warm' : 'iter'} ${String(i + 1).padStart(2)} ${b.name.padEnd(12)} ` +
+              `open ${fmtMs(sample.ms.open).padStart(5)}  compile ${fmtMs(sample.ms.compile).padStart(5)}  ` +
+              `run ${fmtMs(sample.ms.run).padStart(5)}  total ${fmtMs(sample.ms.total).padStart(5)} ms  ` +
+              `pages ${String(sample.peakPages).padStart(5)}\n`,
+          );
+        }
+      }
+      printTable(bundles, enableLtm, samples);
+      all[enableLtm ? 'ltm' : 'noltm'] = samples;
+    }
+
+    if (opts.json) {
+      fs.writeFileSync(
+        opts.json,
+        JSON.stringify(
+          {
+            node: process.version,
+            v8: process.versions.v8,
+            model: opts.model,
+            iters,
+            warmup,
+            bundles: bundles.map(({ name, wasmPath, sizeBytes, growSites }) => ({
+              name,
+              wasmPath,
+              sizeBytes,
+              growSites,
+            })),
+            samples: all,
+          },
+          null,
+          2,
+        ),
+      );
+    }
+  } finally {
+    if (tmpDir !== null) {
+      fs.rmSync(tmpDir, { recursive: true, force: true });
+    }
+  }
+}
+
+await main();

--- a/src/libsimlin/Cargo.toml
+++ b/src/libsimlin/Cargo.toml
@@ -24,9 +24,10 @@ ext_data = ["simlin-engine/ext_data"]
 png_render = ["simlin-engine/png_render"]
 # Use mimalloc as the global allocator. Off by default; enabled by native
 # consumers of the cdylib/staticlib (pysimlin via cffi, C/C++ FFI) where the
-# allocation-heavy engine compile path benefits. Never enabled for the wasm32
-# bundle (the wasm build uses --no-default-features), and the global_allocator
-# is additionally cfg'd off for wasm32 in lib.rs as belt-and-suspenders.
+# allocation-heavy engine compile path benefits. Irrelevant to the wasm32
+# bundle, which always uses wasmalloc (the target-specific dependency below):
+# lib.rs cfg's the mimalloc global_allocator off for wasm32, so enabling this
+# feature there cannot declare a second global allocator.
 mimalloc = ["dep:mimalloc"]
 
 [dependencies]
@@ -36,6 +37,12 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 anyhow = "1.0"
 mimalloc = { version = "0.1", optional = true }
+
+# The wasm32 bundle's global allocator (see the `#[global_allocator]` in
+# lib.rs). Pure Rust and no_std, so it adds no build tooling; single-threaded,
+# which every artifact src/engine/build.sh produces is.
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasmalloc = "0.1"
 
 [dev-dependencies]
 # Second edge onto the engine, adding EXACTLY `test-support` (the `TestProject`

--- a/src/libsimlin/Cargo.toml
+++ b/src/libsimlin/Cargo.toml
@@ -42,7 +42,7 @@ mimalloc = { version = "0.1", optional = true }
 # lib.rs). Pure Rust and no_std, so it adds no build tooling; single-threaded,
 # which every artifact src/engine/build.sh produces is.
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-wasmalloc = "0.1"
+wasmalloc = "0.1.1"
 
 [dev-dependencies]
 # Second edge onto the engine, adding EXACTLY `test-support` (the `TestProject`

--- a/src/libsimlin/src/lib.rs
+++ b/src/libsimlin/src/lib.rs
@@ -23,16 +23,39 @@
 //! Shared types (enums, structs, helpers) live here in `lib.rs` and are
 //! imported by the modules via `crate::`.
 
+// The Rust global allocator, chosen per target. The engine compile path is
+// allocation-heavy (tens of millions of small, short-lived allocations on a
+// large model; see docs/design/engine-performance.md), so allocator speed is a
+// first-order term in compile time. This is independent of the
+// `simlin_malloc`/`simlin_free` cross-boundary helpers in `memory`.
+//
 // Native consumers of this cdylib/staticlib (pysimlin via cffi, C/C++ FFI) opt
-// into mimalloc with the `mimalloc` feature: the engine compile path is
-// allocation-heavy (millions of small, short-lived allocations) and mimalloc
-// roughly halves allocator time vs the system malloc. Never enabled for the
-// wasm32 bundle. See docs/design/engine-performance.md. This is the Rust global
-// allocator and is independent of the `simlin_malloc`/`simlin_free`
-// cross-boundary helpers in `memory`.
+// into mimalloc with the `mimalloc` feature: it roughly halves allocator time
+// vs the system malloc. mimalloc is C and is cfg'd off for wasm32 so that the
+// feature can never declare a second global allocator alongside the wasm one.
 #[cfg(all(feature = "mimalloc", not(target_arch = "wasm32")))]
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
+
+// The wasm32 bundle uses wasmalloc, a pure-Rust single-threaded implementation
+// of mimalloc's design (https://github.com/bpowers/wasmalloc), in place of the
+// dlmalloc port std installs on wasm32-unknown-unknown. It is unconditional
+// rather than a feature because both artifacts src/engine/build.sh produces
+// (the full Node bundle and the --no-default-features browser bundle) are the
+// same single-threaded target, which is the one thing wasmalloc requires (it
+// refuses to build with the `atomics` target feature). The release profile's
+// `lto = true` matters here: wasmalloc's fast paths are `#[inline]` and only
+// specialise per call site when they can be inlined across the crate boundary.
+//
+// Measured with src/engine/bench/clearn-alloc.mjs on C-LEARN v77 with LTM
+// (node 22 and 24): the salsa compile, ~34M mostly sub-128-byte allocations,
+// takes 0.72-0.75x the time it takes on dlmalloc, dispose 0.52x, the
+// allocation-free run is unchanged, and the whole open-compile-run pipeline
+// 0.83-0.85x. The costs are +5% peak `memory.size` (wasmalloc keeps at least
+// one 64 KiB page per size class in use) and about 9 KiB of optimized bundle.
+#[cfg(target_arch = "wasm32")]
+#[global_allocator]
+static GLOBAL: wasmalloc::WasmAlloc = wasmalloc::WasmAlloc::new();
 
 use anyhow::{Error as AnyError, Result};
 use simlin_engine::{self as engine};

--- a/src/simlin-engine/examples/clearn_profile.rs
+++ b/src/simlin-engine/examples/clearn_profile.rs
@@ -24,6 +24,9 @@
 //!   CLEARN_RUN_ITERS      extra run-only iterations (default 0)
 //!   CLEARN_PROFILE        "compile" | "run" | "both" (default both) -- which
 //!                         extra-iteration loop(s) to execute
+//!   CLEARN_COUNT_ALLOCS   "1" to count allocations per phase (distorts timing)
+//!   CLEARN_ALLOC_HIST     "1" to also print, per phase, a histogram of
+//!                         allocation and realloc sizes (implies counting)
 
 use std::alloc::{GlobalAlloc, Layout};
 
@@ -48,17 +51,80 @@ use simlin_engine::{CompiledSimulation, Vm, open_vensim};
 // so the counters are atomic and the peak is maintained with a CAS loop. That
 // is a requirement of the allocator position, not of the workload:
 // compile_project_incremental runs on one thread today (measured at 0.9996 CPUs
-// utilized). The default
-// GlobalAlloc::realloc routes through our alloc/dealloc, so realloc is counted
-// without an explicit override.
+// utilized). `realloc` is overridden so reallocs can be histogrammed
+// separately (an allocator serves a grow-in-place very differently from a
+// fresh block), but each one is still counted as one allocation of the new
+// size, exactly as the default `GlobalAlloc::realloc` (alloc + copy + dealloc)
+// would count it, so the `allocs` column does not depend on the override.
 
 struct Counting;
 
 static COUNTING_ON: AtomicBool = AtomicBool::new(false);
+static HIST_ON: AtomicBool = AtomicBool::new(false);
 static ALLOC_CALLS: AtomicUsize = AtomicUsize::new(0);
 static ALLOC_BYTES: AtomicUsize = AtomicUsize::new(0);
+static REALLOC_CALLS: AtomicUsize = AtomicUsize::new(0);
 static LIVE_BYTES: AtomicUsize = AtomicUsize::new(0);
 static PEAK_BYTES: AtomicUsize = AtomicUsize::new(0);
+
+// Size-class histogram (CLEARN_ALLOC_HIST=1). Bins are 8 bytes wide up to
+// 1 KiB, the range a size-class allocator serves from per-class pages, and one
+// bin per power of two above that. Reallocs are binned by their NEW size.
+const HIST_SMALL_BINS: usize = 128;
+const HIST_LARGE_BINS: usize = 22;
+const HIST_BINS: usize = HIST_SMALL_BINS + HIST_LARGE_BINS;
+static HIST_ALLOCS: [AtomicUsize; HIST_BINS] = [const { AtomicUsize::new(0) }; HIST_BINS];
+static HIST_BYTES: [AtomicUsize; HIST_BINS] = [const { AtomicUsize::new(0) }; HIST_BINS];
+static HIST_REALLOCS: [AtomicUsize; HIST_BINS] = [const { AtomicUsize::new(0) }; HIST_BINS];
+
+fn hist_bin(size: usize) -> usize {
+    if size <= 8 * HIST_SMALL_BINS {
+        // 1..=8 -> 0, 9..=16 -> 1, ...; a zero-size request never reaches
+        // GlobalAlloc, but clamp anyway.
+        (size.max(1) - 1) / 8
+    } else {
+        // ceil(log2(size)): 1025..=2048 -> 11, 2049..=4096 -> 12, ...
+        let log2 = (usize::BITS - (size - 1).leading_zeros()) as usize;
+        HIST_SMALL_BINS + (log2 - 11).min(HIST_LARGE_BINS - 1)
+    }
+}
+
+/// The inclusive upper size bound of a histogram bin, for printing.
+fn hist_bin_upper(bin: usize) -> usize {
+    if bin < HIST_SMALL_BINS {
+        8 * (bin + 1)
+    } else {
+        1usize << (11 + bin - HIST_SMALL_BINS)
+    }
+}
+
+fn record_live(delta: isize) {
+    let live = if delta >= 0 {
+        LIVE_BYTES.fetch_add(delta as usize, Ordering::Relaxed) + delta as usize
+    } else {
+        LIVE_BYTES.fetch_sub(delta.unsigned_abs(), Ordering::Relaxed) - delta.unsigned_abs()
+    };
+    let mut peak = PEAK_BYTES.load(Ordering::Relaxed);
+    while live > peak {
+        match PEAK_BYTES.compare_exchange_weak(peak, live, Ordering::Relaxed, Ordering::Relaxed) {
+            Ok(_) => break,
+            Err(observed) => peak = observed,
+        }
+    }
+}
+
+fn record_alloc(size: usize, realloc: bool) {
+    ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+    ALLOC_BYTES.fetch_add(size, Ordering::Relaxed);
+    if HIST_ON.load(Ordering::Relaxed) {
+        let bin = hist_bin(size);
+        HIST_ALLOCS[bin].fetch_add(1, Ordering::Relaxed);
+        HIST_BYTES[bin].fetch_add(size, Ordering::Relaxed);
+        if realloc {
+            HIST_REALLOCS[bin].fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
 
 unsafe impl GlobalAlloc for Counting {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -67,21 +133,8 @@ unsafe impl GlobalAlloc for Counting {
         // per-allocation atomic overhead. Enable with CLEARN_COUNT_ALLOCS=1 to
         // get allocation counts (at the cost of distorted timing).
         if !p.is_null() && COUNTING_ON.load(Ordering::Relaxed) {
-            ALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
-            ALLOC_BYTES.fetch_add(layout.size(), Ordering::Relaxed);
-            let live = LIVE_BYTES.fetch_add(layout.size(), Ordering::Relaxed) + layout.size();
-            let mut peak = PEAK_BYTES.load(Ordering::Relaxed);
-            while live > peak {
-                match PEAK_BYTES.compare_exchange_weak(
-                    peak,
-                    live,
-                    Ordering::Relaxed,
-                    Ordering::Relaxed,
-                ) {
-                    Ok(_) => break,
-                    Err(observed) => peak = observed,
-                }
-            }
+            record_alloc(layout.size(), false);
+            record_live(layout.size() as isize);
         }
         p
     }
@@ -92,6 +145,16 @@ unsafe impl GlobalAlloc for Counting {
             LIVE_BYTES.fetch_sub(layout.size(), Ordering::Relaxed);
         }
     }
+
+    unsafe fn realloc(&self, ptr: *mut u8, layout: Layout, new_size: usize) -> *mut u8 {
+        let p = unsafe { Backing.realloc(ptr, layout, new_size) };
+        if !p.is_null() && COUNTING_ON.load(Ordering::Relaxed) {
+            REALLOC_CALLS.fetch_add(1, Ordering::Relaxed);
+            record_alloc(new_size, true);
+            record_live(new_size as isize - layout.size() as isize);
+        }
+        p
+    }
 }
 
 #[global_allocator]
@@ -101,6 +164,7 @@ static GLOBAL: Counting = Counting;
 struct Snap {
     calls: usize,
     bytes: usize,
+    reallocs: usize,
     live: usize,
 }
 
@@ -108,7 +172,65 @@ fn snap() -> Snap {
     Snap {
         calls: ALLOC_CALLS.load(Ordering::Relaxed),
         bytes: ALLOC_BYTES.load(Ordering::Relaxed),
+        reallocs: REALLOC_CALLS.load(Ordering::Relaxed),
         live: LIVE_BYTES.load(Ordering::Relaxed),
+    }
+}
+
+/// The histogram counters at one instant.
+struct HistSnap {
+    allocs: [usize; HIST_BINS],
+    bytes: [usize; HIST_BINS],
+    reallocs: [usize; HIST_BINS],
+}
+
+fn hist_snap() -> HistSnap {
+    let load = |counters: &[AtomicUsize; HIST_BINS]| {
+        let mut out = [0usize; HIST_BINS];
+        for (slot, counter) in out.iter_mut().zip(counters) {
+            *slot = counter.load(Ordering::Relaxed);
+        }
+        out
+    };
+    HistSnap {
+        allocs: load(&HIST_ALLOCS),
+        bytes: load(&HIST_BYTES),
+        reallocs: load(&HIST_REALLOCS),
+    }
+}
+
+/// Print the non-empty bins of the histogram delta between two snapshots:
+/// allocation count (with its share of the phase's allocations and the running
+/// cumulative share), bytes requested, and how many of the bin's allocations
+/// arrived as reallocs.
+fn print_hist_delta(before: &HistSnap, after: &HistSnap) {
+    let total: usize = (0..HIST_BINS)
+        .map(|bin| after.allocs[bin] - before.allocs[bin])
+        .sum();
+    if total == 0 {
+        return;
+    }
+    println!("  size histogram (bin upper bound, inclusive):");
+    println!(
+        "    {:>12} {:>10} {:>6} {:>6} {:>10} {:>9}",
+        "size <=", "allocs", "%", "cum%", "MiB", "reallocs"
+    );
+    let mut cum = 0usize;
+    for bin in 0..HIST_BINS {
+        let allocs = after.allocs[bin] - before.allocs[bin];
+        if allocs == 0 {
+            continue;
+        }
+        cum += allocs;
+        println!(
+            "    {:>12} {:>10} {:>6.2} {:>6.2} {:>10.2} {:>9}",
+            hist_bin_upper(bin),
+            allocs,
+            100.0 * allocs as f64 / total as f64,
+            100.0 * cum as f64 / total as f64,
+            mib(after.bytes[bin] - before.bytes[bin]),
+            after.reallocs[bin] - before.reallocs[bin],
+        );
     }
 }
 
@@ -126,6 +248,7 @@ fn mib(bytes: usize) -> f64 {
 /// the phase, net retained (live) bytes, and peak live bytes reached.
 fn phase<T>(name: &str, f: impl FnOnce() -> T) -> T {
     reset_peak();
+    let hist_before = HIST_ON.load(Ordering::Relaxed).then(hist_snap);
     let before = snap();
     let t0 = Instant::now();
     let out = f();
@@ -135,16 +258,21 @@ fn phase<T>(name: &str, f: impl FnOnce() -> T) -> T {
 
     let calls = after.calls - before.calls;
     let bytes = after.bytes - before.bytes;
+    let reallocs = after.reallocs - before.reallocs;
     let retained = after.live as i64 - before.live as i64;
 
     println!(
-        "{name:<22} {:>9.2} ms | allocs {:>10} | alloc'd {:>9.1} MiB | retained {:>+8.1} MiB | peak {:>8.1} MiB",
+        "{name:<22} {:>9.2} ms | allocs {:>10} | alloc'd {:>9.1} MiB | retained {:>+8.1} MiB | peak {:>8.1} MiB | reallocs {:>8}",
         elapsed.as_secs_f64() * 1000.0,
         calls,
         mib(bytes),
         retained as f64 / (1024.0 * 1024.0),
         mib(peak),
+        reallocs,
     );
+    if let Some(hist_before) = hist_before {
+        print_hist_delta(&hist_before, &hist_snap());
+    }
     out
 }
 
@@ -182,6 +310,10 @@ fn main() {
     let ltm = std::env::var("CLEARN_LTM").is_ok_and(|v| v != "0");
     if std::env::var("CLEARN_COUNT_ALLOCS").is_ok_and(|v| v != "0") {
         COUNTING_ON.store(true, Ordering::Relaxed);
+    }
+    if std::env::var("CLEARN_ALLOC_HIST").is_ok_and(|v| v != "0") {
+        COUNTING_ON.store(true, Ordering::Relaxed);
+        HIST_ON.store(true, Ordering::Relaxed);
     }
 
     println!("model: {path}");


### PR DESCRIPTION
## What

The wasm32 build of `libsimlin` now installs [wasmalloc](https://github.com/bpowers/wasmalloc) ([crates.io](https://crates.io/crates/wasmalloc), `MIT OR Apache-2.0`, pure Rust, `no_std`, no build step) as its `#[global_allocator]`, in place of the dlmalloc port std uses on `wasm32-unknown-unknown`. It is a target-specific dependency and an unconditional `#[cfg(target_arch = "wasm32")]` declaration rather than a feature, because both artifacts `src/engine/build.sh` produces (the full Node bundle and the `--no-default-features` browser bundle) are the same single-threaded target, which is the one thing wasmalloc requires. The existing mimalloc comment is rewritten around that split; native consumers are untouched.

## Why

The engine compile is allocation-bound. On C-LEARN v77 with LTM the salsa compile makes ~34M allocations (3.5 GiB churned for 15 MiB retained), 90% of them 128 bytes or smaller, and the wasm bundle was serving them from dlmalloc. mimalloc already halves native compile time; wasmalloc is the same design for wasm.

## Measurements

All numbers are from the new `src/engine/bench/clearn-alloc.mjs` on the browser bundle (`libsimlin-browser.wasm`, wasm-opt -O3), C-LEARN v77, bundles interleaved, 10 iterations after 2 warm-up, medians, fresh instance per iteration, pinned with `taskset -c 4-7` on an idle Ryzen 9 9950X. `compile` is `Model.simulate` (salsa compile + `Vm::new`); `series` reads every variable's series; `links` is `Sim.getLinks`.

### node 22.22.2 (V8 12.4), LTM on

| stage | dlmalloc | wasmalloc | wasmalloc/dlmalloc |
|---|--:|--:|--:|
| open (ms) | 63.8 | 59.0 | 0.92x |
| compile (ms) | 2950 | 2226 | 0.75x |
| run (ms) | 1871 | 1900 | 1.02x |
| series (ms) | 19.7 | 19.3 | 0.98x |
| links (ms) | 19.2 | 18.6 | 0.97x |
| dispose (ms) | 77.6 | 40.2 | 0.52x |
| total (ms) | 5016 | 4282 | 0.85x |
| peak memory.size | 4456 pages (278.5 MiB) | 4671 pages (291.9 MiB) | 1.05x |
| memory.grow calls | 2844 | 37 | 0.01x |

### node 22.22.2 (V8 12.4), LTM off

| stage | dlmalloc | wasmalloc | wasmalloc/dlmalloc |
|---|--:|--:|--:|
| open (ms) | 56.1 | 50.8 | 0.91x |
| compile (ms) | 245 | 219 | 0.89x |
| run (ms) | 173 | 175 | 1.01x |
| series (ms) | 17.4 | 17.0 | 0.98x |
| dispose (ms) | 10.6 | 6.72 | 0.63x |
| total (ms) | 503 | 469 | 0.93x |
| peak memory.size | 554 pages (34.6 MiB) | 613 pages (38.3 MiB) | 1.11x |
| memory.grow calls | 289 | 19 | 0.07x |

### node 24.20.0 (V8 13.6), LTM on

| stage | dlmalloc | wasmalloc | wasmalloc/dlmalloc |
|---|--:|--:|--:|
| open (ms) | 53.7 | 48.6 | 0.90x |
| compile (ms) | 2597 | 1877 | 0.72x |
| run (ms) | 1776 | 1759 | 0.99x |
| series (ms) | 17.7 | 18.0 | 1.02x |
| links (ms) | 18.1 | 16.7 | 0.92x |
| dispose (ms) | 71.2 | 37.1 | 0.52x |
| total (ms) | 4534 | 3755 | 0.83x |
| peak memory.size | 4456 pages (278.5 MiB) | 4671 pages (291.9 MiB) | 1.05x |

### node 24.20.0 (V8 13.6), LTM off

| stage | dlmalloc | wasmalloc | wasmalloc/dlmalloc |
|---|--:|--:|--:|
| open (ms) | 45.6 | 40.2 | 0.88x |
| compile (ms) | 199 | 172 | 0.86x |
| run (ms) | 161 | 162 | 1.01x |
| series (ms) | 16.4 | 16.5 | 1.01x |
| dispose (ms) | 9.39 | 5.87 | 0.63x |
| total (ms) | 432 | 396 | 0.92x |
| peak memory.size | 554 pages (34.6 MiB) | 613 pages (38.3 MiB) | 1.11x |

Min and median agree to within 1-2% in every cell (the full tables with both are in the script's output). The full Node bundle (`libsimlin.wasm`, node 22, 5 iterations) shows the same picture: LTM compile 2969 -> 2233 ms (0.75x), whole pipeline 0.87x, peak 279 -> 304 MiB. The memory.grow counts come from a `--count-grows` run (the script rewrites each bundle with `wasm-tools` so every `memory.grow` bumps an exported counter); they are exact and deterministic, so they were taken from a 2-iteration run rather than the timed one. All of the memory.size growth happens in `open` and `compile`; `run`, `series`, `links` and `dispose` never grow memory on either allocator.

`[profile.release.package.wasmalloc] opt-level = 3` was also measured (LTM compile 2208 vs 2226 ms on node 22, 1879 vs 1877 on node 24, bundle +2 bytes): under the workspace's fat LTO it makes no difference, so it is not in this PR.

### Bundle size

| artifact | main (dlmalloc) | this branch (wasmalloc) | delta |
|---|--:|--:|--:|
| libsimlin.wasm, cargo output | 8,437,842 | 8,464,859 | +27,017 |
| libsimlin.wasm, after wasm-opt -O3 | 6,891,491 | 6,900,809 | +9,318 (+0.14%) |
| libsimlin-browser.wasm, cargo output | 6,666,186 | 6,692,927 | +26,741 |
| libsimlin-browser.wasm, after wasm-opt -O3 | 5,367,390 | 5,376,435 | +9,045 (+0.17%) |

## Also in this PR

- `src/engine/bench/clearn-alloc.mjs` (+ a section in `docs/dev/benchmarks.md`): the allocator A/B harness the tables above came from. A standalone script rather than a gated rstest because its inputs are bundle files from different builds and it has to run under several node binaries.
- `CLEARN_ALLOC_HIST=1` for `examples/clearn_profile.rs`: a per-phase size histogram of allocations and reallocs (8-byte bins to 1 KiB, then powers of two), which is where the "90% at or below 128 bytes" figure comes from. Own commit; easy to drop.
- `cargo deny check` was failing on main on the yanked `chacha20 0.10.1` (via `rmcp -> rand`). The last commit is the lockfile-only bump to 0.10.2 that makes it green; it is unrelated to the allocator and separable.

## Evidence

- `bash src/engine/build.sh` builds both artifacts with wasm-opt; `pnpm test` in `src/engine` passes (408 tests) against the wasm-opt'd wasmalloc bundles under node 22.22.2 and node 24.20.0, and passed identically on main before the change.
- Every commit went through the pre-commit hook: rustfmt, cbindgen freshness, `clippy --all-targets --all-features`, the Rust workspace tests, TypeScript lint/build/tsc and the test suites of every package, and the pysimlin suite.
- `cargo deny check`: licenses, bans and sources pass with wasmalloc added; advisories pass after the chacha20 bump.
- There are no wasm32 Rust tests in CI to run (the workflows only build for wasm32); the wasm-side coverage is the `@simlin/engine` suite above.

What this does not establish: the timings are from one Linux machine under node/V8 only (no JavaScriptCore or SpiderMonkey, no Web Worker path, no mobile), and the allocator's per-size-class pages cost more, proportionally, on small models than on C-LEARN (opening fishbanks leaves memory.size at 78 pages vs 34 with dlmalloc). The tests establish that the engine behaves identically on the new allocator for everything the suite covers, not that every code path has been exercised under it.
